### PR TITLE
Fix gmail false positive and improve UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # DuckDuckGo Autofill
 
-This code is imported as a subrepo by our [extension](https://github.com/duckduckgo/duckduckgo-privacy-extension) and native apps ([iOS](https://github.com/duckduckgo/iOS) and [Android](https://github.com/duckduckgo/Android)).
+This code is imported as an `npm` module by our [extension](https://github.com/duckduckgo/duckduckgo-privacy-extension) and as a subrepo by native apps ([iOS](https://github.com/duckduckgo/iOS) and [Android](https://github.com/duckduckgo/Android)).
 
 DuckDuckGo Autofill is distributed under the Apache 2.0 [License](LICENSE.md).
 
-## How to add this repo to another project
+## How to develop and test within the context of the extensions
+
+To simplify development workflows, you can use [`npm-link`](https://docs.npmjs.com/cli/v6/commands/npm-link). `npm-link` creates a symlink to the source repo and links it to local package usages. It's a two-step process.
+
+1. In the source repo (this folder), run `npm link`. This must be done only once.
+1. In the client repo (the extension folder), run `npm link @duckduckgo/autofill`. Do this every time you start working on the extension repo.
+
+Now you can run `npm start` in this repo and the changes will be picked up automatically in the client 🎉.
+
+## How to add this as a subrepo to another project
 ###### [See the docs](https://git-scm.com/book/en/v2/Git-Tools-Submodules#_starting_submodules)
 
 To add this repo as a submodule, run:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DuckDuckGo Autofill
 
-This code is imported as an `npm` module by our [extension](https://github.com/duckduckgo/duckduckgo-privacy-extension) and as a subrepo by native apps ([iOS](https://github.com/duckduckgo/iOS) and [Android](https://github.com/duckduckgo/Android)).
+This code is installed using `npm` in our [extension](https://github.com/duckduckgo/duckduckgo-privacy-extension) and as a git submodule by native apps ([iOS](https://github.com/duckduckgo/iOS) and [Android](https://github.com/duckduckgo/Android)).
 
 DuckDuckGo Autofill is distributed under the Apache 2.0 [License](LICENSE.md).
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -264,6 +264,9 @@ var createAttachTooltip = function createAttachTooltip(getAutofillData, refreshA
       window.addEventListener('mousedown', form.removeTooltip, {
         capture: true
       });
+      window.addEventListener('input', form.removeTooltip, {
+        once: true
+      });
     }
   };
 };
@@ -790,8 +793,10 @@ var Form = /*#__PURE__*/function () {
         if (e.button !== 0) return;
 
         if (_this2.shouldOpenTooltip(e, e.target)) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
+          if (isEventWithinDax(e, e.target)) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+          }
 
           _this2.touched.add(e.target);
 
@@ -882,7 +887,7 @@ var FormAnalyzer = /*#__PURE__*/function () {
           _ref$shouldBeConserva = _ref.shouldBeConservative,
           shouldBeConservative = _ref$shouldBeConserva === void 0 ? false : _ref$shouldBeConserva;
       var negativeRegex = new RegExp(/sign(ing)?.?in(?!g)|log.?in/i);
-      var positiveRegex = new RegExp(/sign(ing)?.?up|join|regist(er|ration)|newsletter|subscri(be|ption)|contact|create|start|settings|preferences|profile|update|checkout|guest|purchase|buy|order/i);
+      var positiveRegex = new RegExp(/sign(ing)?.?up|join|regist(er|ration)|newsletter|subscri(be|ption)|contact|create|start|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate/i);
       var conservativePositiveRegex = new RegExp(/sign.?up|join|register|newsletter|subscri(be|ption)|settings|preferences|profile|update/i);
       var strictPositiveRegex = new RegExp(/sign.?up|join|register|settings|preferences|profile|update/i);
       var matchesNegative = string.match(negativeRegex); // Check explicitly for unified login/signup forms. They should always be negative, so we increase signal
@@ -912,6 +917,7 @@ var FormAnalyzer = /*#__PURE__*/function () {
       var signalStrength = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 3;
       var isInput = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
       Array.from(el.attributes).forEach(function (attr) {
+        if (attr.nodeName === 'style') return;
         var attributeString = "".concat(attr.nodeName, "=").concat(attr.nodeValue);
 
         _this.updateSignal({

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -917,13 +917,13 @@ var FormAnalyzer = /*#__PURE__*/function () {
       var signalStrength = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 3;
       var isInput = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
       Array.from(el.attributes).forEach(function (attr) {
-        if (attr.nodeName === 'style') return;
-        var attributeString = "".concat(attr.nodeName, "=").concat(attr.nodeValue);
+        if (attr.name === 'style') return;
+        var attributeString = "".concat(attr.name, "=").concat(attr.value);
 
         _this.updateSignal({
           string: attributeString,
           strength: signalStrength,
-          signalType: "".concat(el.nodeName, " attr: ").concat(attributeString),
+          signalType: "".concat(el.name, " attr: ").concat(attributeString),
           shouldCheckUnifiedForm: isInput
         });
       });

--- a/src/DeviceInterface.js
+++ b/src/DeviceInterface.js
@@ -27,6 +27,7 @@ const createAttachTooltip = (getAutofillData, refreshAlias, addresses) => (form,
         form.tooltip = new DDGAutofill(input, form, getAutofillData, refreshAlias, addresses)
         form.intObs.observe(input)
         window.addEventListener('mousedown', form.removeTooltip, {capture: true})
+        window.addEventListener('input', form.removeTooltip, {once: true})
     }
 }
 

--- a/src/Form.js
+++ b/src/Form.js
@@ -117,8 +117,10 @@ class Form {
             if (e.button !== 0) return
 
             if (this.shouldOpenTooltip(e, e.target)) {
-                e.preventDefault()
-                e.stopImmediatePropagation()
+                if (isEventWithinDax(e, e.target)) {
+                    e.preventDefault()
+                    e.stopImmediatePropagation()
+                }
 
                 this.touched.add(e.target)
                 this.attachTooltip(this, e.target)

--- a/src/FormAnalyzer.js
+++ b/src/FormAnalyzer.js
@@ -61,14 +61,13 @@ class FormAnalyzer {
 
     evaluateElAttributes (el, signalStrength = 3, isInput = false) {
         Array.from(el.attributes).forEach(attr => {
+            if (attr.name === 'style') return
 
-            if (attr.nodeName === 'style') return
-
-            const attributeString = `${attr.nodeName}=${attr.nodeValue}`
+            const attributeString = `${attr.name}=${attr.value}`
             this.updateSignal({
                 string: attributeString,
                 strength: signalStrength,
-                signalType: `${el.nodeName} attr: ${attributeString}`,
+                signalType: `${el.name} attr: ${attributeString}`,
                 shouldCheckUnifiedForm: isInput
             })
         })

--- a/src/FormAnalyzer.js
+++ b/src/FormAnalyzer.js
@@ -61,6 +61,9 @@ class FormAnalyzer {
 
     evaluateElAttributes (el, signalStrength = 3, isInput = false) {
         Array.from(el.attributes).forEach(attr => {
+
+            if (attr.nodeName === 'style') return
+
             const attributeString = `${attr.nodeName}=${attr.nodeValue}`
             this.updateSignal({
                 string: attributeString,

--- a/src/FormAnalyzer.js
+++ b/src/FormAnalyzer.js
@@ -34,7 +34,7 @@ class FormAnalyzer {
     }) {
         const negativeRegex = new RegExp(/sign(ing)?.?in(?!g)|log.?in/i)
         const positiveRegex = new RegExp(
-            /sign(ing)?.?up|join|regist(er|ration)|newsletter|subscri(be|ption)|contact|create|start|settings|preferences|profile|update|checkout|guest|purchase|buy|order/i
+            /sign(ing)?.?up|join|regist(er|ration)|newsletter|subscri(be|ption)|contact|create|start|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate/i
         )
         const conservativePositiveRegex = new RegExp(/sign.?up|join|register|newsletter|subscri(be|ption)|settings|preferences|profile|update/i)
         const strictPositiveRegex = new RegExp(/sign.?up|join|register|settings|preferences|profile|update/i)


### PR DESCRIPTION
**Asana:** https://app.asana.com/0/0/1200338731982527/f
**Reviewer:** @alistairjcbrown 

## Description
- Fix a gmail false-positive (we were matching `order` in `border` in a `style` attribute). This change avoid checking style attributes, which are not relevant anyway. See https://app.asana.com/0/0/1200288622137918/f.
- Add `schedule` and `estimate` to autofill detection. See https://app.asana.com/0/1199348606025791/1200337309679147/f.
- Improve autofill UX as explained here: https://app.asana.com/0/1198964220583541/1200338731982506/f.

## How to test
1. If you have a gmail account, visit it in Firefox with autofill enabled. You should not see Dax in the email search bar.
2. [This](http://www.jandjconcretepaving.com/quotes.html) and [this page](https://www.atozfamilybusiness.com/scheduleservice) (click on the hour) should show Dax.
3. The click on field UX should be changed as explained [in Asana](https://app.asana.com/0/1198964220583541/1200338731982506/f).