### PR TITLE
Fix regex to skip autofill on signup page

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -1719,7 +1719,7 @@ const forms = new Map(); // Accepts the DeviceInterface as an explicit dependenc
 
 const scanForInputs = DeviceInterface => {
   // Avoid autofill on our signup page
-  if (window.location.href.match(/^https:\/\/.+\.duckduckgo\.com\/email\/choose-address/i)) return;
+  if (window.location.href.match(/^https:\/\/(.+\.)?duckduckgo\.com\/email\/choose-address/i)) return;
 
   const getParentForm = input => {
     if (input.form) return input.form;

--- a/src/scanForInputs.js
+++ b/src/scanForInputs.js
@@ -7,7 +7,7 @@ const forms = new Map()
 // Accepts the DeviceInterface as an explicit dependency
 const scanForInputs = (DeviceInterface) => {
     // Avoid autofill on our signup page
-    if (window.location.href.match(/^https:\/\/.+\.duckduckgo\.com\/email\/choose-address/i)) return
+    if (window.location.href.match(/^https:\/\/(.+\.)?duckduckgo\.com\/email\/choose-address/i)) return
 
     const getParentForm = (input) => {
         if (input.form) return input.form


### PR DESCRIPTION
**Asana:** https://app.asana.com/0/1162895505193104/1200625153189770/f
**Reviewer:** @alistairjcbrown 


## Description
This regressed when we moved to the public domain. Regex fail 🤦‍♂️.

## Steps to test
- With autofill enabled, visit the signup page.
- It should not show Dax in the email field.
- It should show up here instead: https://duckduckgo.com/newsletter.