### PR TITLE
Fix Dax showing up on signup for good

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -770,14 +770,19 @@ class FormAnalyzer {
   constructor(form, input) {
     this.form = form;
     this.autofillSignal = 0;
-    this.signals = [];
+    this.signals = []; // Avoid autofill on our signup page
+
+    if (window.location.href.match(/^https:\/\/(.+\.)?duckduckgo\.com\/email\/choose-address/i)) {
+      return this;
+    }
+
     this.evaluateElAttributes(input, 3, true);
     form ? this.evaluateForm() : this.evaluatePage();
     return this;
   }
 
   get isLogin() {
-    return this.autofillSignal < 0;
+    return this.autofillSignal <= 0;
   }
 
   get isSignup() {
@@ -1718,9 +1723,6 @@ const {
 const forms = new Map(); // Accepts the DeviceInterface as an explicit dependency
 
 const scanForInputs = DeviceInterface => {
-  // Avoid autofill on our signup page
-  if (window.location.href.match(/^https:\/\/(.+\.)?duckduckgo\.com\/email\/choose-address/i)) return;
-
   const getParentForm = input => {
     if (input.form) return input.form;
     let element = input; // traverse the DOM to search for related inputs

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -6,13 +6,18 @@ class FormAnalyzer {
         this.autofillSignal = 0
         this.signals = []
 
+        // Avoid autofill on our signup page
+        if (window.location.href.match(/^https:\/\/(.+\.)?duckduckgo\.com\/email\/choose-address/i)) {
+            return this
+        }
+
         this.evaluateElAttributes(input, 3, true)
         form ? this.evaluateForm() : this.evaluatePage()
         return this
     }
 
     get isLogin () {
-        return this.autofillSignal < 0
+        return this.autofillSignal <= 0
     }
 
     get isSignup () {

--- a/src/scanForInputs.js
+++ b/src/scanForInputs.js
@@ -6,9 +6,6 @@ const forms = new Map()
 
 // Accepts the DeviceInterface as an explicit dependency
 const scanForInputs = (DeviceInterface) => {
-    // Avoid autofill on our signup page
-    if (window.location.href.match(/^https:\/\/(.+\.)?duckduckgo\.com\/email\/choose-address/i)) return
-
     const getParentForm = (input) => {
         if (input.form) return input.form
 


### PR DESCRIPTION
**Asana:** https://app.asana.com/0/1162895505193104/1200625153189770/f
**Reviewer:** @alistairjcbrown 

## Description
While testing on other devices I found that this was not entirely fixing the problem. The previous check was running once on page load, so when navigating our frontend that check had already run. This version runs when analyzing the form itself, which works even when we navigate to other pages.

## Steps to test
- Go to https://duckduckgo.com/email/privacy-guarantees-step
- Click next
- You should not see the Dax
- Refresh the page
- Dax should still not be there