### PR TITLE
Fix twitter regression

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -382,10 +382,10 @@ class AppleDeviceInterface extends InterfacePrototype {
 
     /**
      * @typedef {{
-     *      id: Number
-     *      username: String
-     *      password?: String
-     *      lastUpdated: String
+     *      id: Number,
+     *      username: String,
+     *      password?: String,
+     *      lastUpdated: String,
      * }} CredentialsObject
      */
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -1665,7 +1665,11 @@ module.exports = {
 
         if (!isApp) return; // Check for clicks on submit buttons
 
-        const matchingForm = [...forms.values()].find(form => [...form.submitButtons].includes(e.target));
+        const matchingForm = [...forms.values()].find(form => {
+          const btns = [...form.submitButtons];
+          if (btns.includes(e.target)) return true;
+          if (btns.find(btn => btn.contains(e.target))) return true;
+        });
         matchingForm === null || matchingForm === void 0 ? void 0 : matchingForm.submitHandler();
       }, true);
 

--- a/src/DeviceInterface.js
+++ b/src/DeviceInterface.js
@@ -275,10 +275,10 @@ class AppleDeviceInterface extends InterfacePrototype {
 
         /**
          * @typedef {{
-         *      id: Number
-         *      username: String
-         *      password?: String
-         *      lastUpdated: String
+         *      id: Number,
+         *      username: String,
+         *      password?: String,
+         *      lastUpdated: String,
          * }} CredentialsObject
          */
 

--- a/src/autofill.js
+++ b/src/autofill.js
@@ -29,7 +29,12 @@
 
                 // Check for clicks on submit buttons
                 const matchingForm = [...forms.values()].find(
-                    (form) => [...form.submitButtons].includes(e.target)
+                    (form) => {
+                        const btns = [...form.submitButtons]
+                        if (btns.includes(e.target)) return true
+
+                        if (btns.find((btn) => btn.contains(e.target))) return true
+                    }
                 )
                 matchingForm?.submitHandler()
             }, true)


### PR DESCRIPTION
**Reviewer:** @jonathanKingston
**Asana:** https://app.asana.com/0/1144596633445612/1200085115126414

## Description
With the new global listener, we introduced a regression on Twitter where the login button fires the event on a child element so our detection failed to match it. This update checks if the `target` is a child of our known buttons. See also https://github.com/duckduckgo/privacy-test-pages/pull/45.