### PR TITLE
Fix domain check regression

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -1459,7 +1459,7 @@ const isDDGApp = /(iPhone|iPad|Android|Mac).*DuckDuckGo\/[0-9]/i.test(window.nav
 const isAndroid = isDDGApp && /Android/i.test(window.navigator.userAgent);
 const DDG_DOMAIN_REGEX = new RegExp(/^https:\/\/(([a-z0-9-_]+?)\.)?duckduckgo\.com\/email/);
 
-const isDDGDomain = () => window.origin.match(DDG_DOMAIN_REGEX); // Send a message to the web app (only on DDG domains)
+const isDDGDomain = () => window.location.href.match(DDG_DOMAIN_REGEX); // Send a message to the web app (only on DDG domains)
 
 
 const notifyWebApp = message => {

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -8,7 +8,7 @@ const isAndroid = isDDGApp && /Android/i.test(window.navigator.userAgent)
 
 const DDG_DOMAIN_REGEX = new RegExp(/^https:\/\/(([a-z0-9-_]+?)\.)?duckduckgo\.com\/email/)
 
-const isDDGDomain = () => window.origin.match(DDG_DOMAIN_REGEX)
+const isDDGDomain = () => window.location.href.match(DDG_DOMAIN_REGEX)
 
 // Send a message to the web app (only on DDG domains)
 const notifyWebApp = (message) => {


### PR DESCRIPTION
We were using `window.origin`, instead of the full url.