### PR TITLE
fix: changed the order that events are dispatched on inputs

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -2726,9 +2726,9 @@ const setValueForInput = (el, val) => {
   originalSet.call(el, val);
   const events = [new Event('keydown', {
     bubbles: true
-  }), new Event('keyup', {
-    bubbles: true
   }), new Event('input', {
+    bubbles: true
+  }), new Event('keyup', {
     bubbles: true
   }), new Event('change', {
     bubbles: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "scripts": {
     "start": "grunt dev",
     "build": "grunt",
-    "test": "jest"
+    "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -63,8 +63,8 @@ const setValueForInput = (el, val) => {
 
     const events = [
         new Event('keydown', {bubbles: true}),
-        new Event('keyup', {bubbles: true}),
         new Event('input', {bubbles: true}),
+        new Event('keyup', {bubbles: true}),
         new Event('change', {bubbles: true})
     ]
     events.forEach((ev) => el.dispatchEvent(ev))

--- a/src/autofill-utils.test.js
+++ b/src/autofill-utils.test.js
@@ -1,0 +1,43 @@
+const {setValue} = require('./autofill-utils')
+
+const renderInputWithEvents = () => {
+    const input = document.createElement('input')
+    input.id = 'inputId'
+
+    const form = document.createElement('form')
+    form.append(input)
+    document.body.append(form)
+
+    const events = []
+    input.addEventListener('keyup', () => events.push('keyup'))
+    input.addEventListener('keydown', () => events.push('keydown'))
+    input.addEventListener('input', () => events.push('input'))
+    input.addEventListener('change', () => events.push('change'))
+
+    return {input, events}
+}
+
+afterEach(() => {
+    document.body.innerHTML = null
+})
+
+describe('value setting', function () {
+    it('should set value & dispatch events in the correct order', () => {
+        const {input, events} = renderInputWithEvents()
+        setValue(input, '123456')
+        expect(input.value).toBe('123456')
+
+        // the order of events here is *extremely* important to ensure interoperability with
+        // page scripts that register their own keyup/keydown event listeners.
+        expect(events).toStrictEqual([
+            'keydown',
+            'input',
+            'keyup',
+            'change',
+            'keydown',
+            'input',
+            'keyup',
+            'change'
+        ])
+    })
+})


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1177771139624306/1201650539303894/f

## Description

Changed the order of events that are fired when an input's value is set.

## Steps to test

I tested the sites mentioned in the task above, along with approximately 20 other sites - everything seems to work correctly
