### PR TITLE
Fix for BestBuy.com

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -2723,10 +2723,11 @@ const setValueForInput = (el, val) => {
     el.focus();
   }
 
-  originalSet.call(el, val);
-  const events = [new Event('keydown', {
+  el.dispatchEvent(new Event('keydown', {
     bubbles: true
-  }), new Event('input', {
+  }));
+  originalSet.call(el, val);
+  const events = [new Event('input', {
     bubbles: true
   }), new Event('keyup', {
     bubbles: true

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -59,10 +59,12 @@ const setValueForInput = (el, val) => {
     if (!isAndroid) {
         el.focus()
     }
+
+    el.dispatchEvent(new Event('keydown', {bubbles: true}))
+
     originalSet.call(el, val)
 
     const events = [
-        new Event('keydown', {bubbles: true}),
         new Event('input', {bubbles: true}),
         new Event('keyup', {bubbles: true}),
         new Event('change', {bubbles: true})

--- a/src/autofill-utils.test.js
+++ b/src/autofill-utils.test.js
@@ -34,7 +34,6 @@ describe('value setting', function () {
             'input',
             'keyup',
             'change',
-            'keydown',
             'input',
             'keyup',
             'change'


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1177771139624306/1201650539303894/f

## Description

I spent some time deep-diving into the BestBuy checkout to discover why the address field was not populating with our Autofill

It turns out that because we **set** the value *before* we fire the initial `keydown` event, it confuses the custom event handlers that are part the BestBuy codebase.

This PR even more closely mimics what Safari autofill fill does, which is the following:

- `keydown` event
- set value on the input
- `input` event
- `keyup` event
- `change` event

The big difference here is that we do NOT set the value on the input until *after* that initial `keydown` event. This seems to fix BestBuy's address field and doesn't appear to have any adverse effects.

Note: I am leaving this as a 'draft' whilst I test this further.