### PR TITLE
Fix moving of pointerdown temporary event by removing the need for it

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -843,6 +843,8 @@ class InterfacePrototype {
       e.stopImmediatePropagation();
       const activeTooltip = this.getActiveTooltip();
       activeTooltip === null || activeTooltip === void 0 ? void 0 : activeTooltip.dispatchClick();
+    } else {
+      this.removeTooltip();
     }
 
     if (!isApp) return; // Check for clicks on submit buttons
@@ -873,15 +875,13 @@ class InterfacePrototype {
     } else {
       form.autofillData(data, type);
     }
+
+    this.removeTooltip();
   }
 
   createTooltip(inputType, getPosition) {
     const config = getInputConfigFromType(inputType); // Attach close listeners
 
-    window.addEventListener('pointerdown', () => this.removeTooltip(), {
-      capture: true,
-      once: true
-    });
     window.addEventListener('input', () => this.removeTooltip(), {
       once: true
     });

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -167,6 +167,8 @@ class InterfacePrototype {
 
             const activeTooltip = this.getActiveTooltip()
             activeTooltip?.dispatchClick()
+        } else {
+            this.removeTooltip()
         }
 
         if (!isApp) return
@@ -199,13 +201,13 @@ class InterfacePrototype {
         } else {
             form.autofillData(data, type)
         }
+        this.removeTooltip()
     }
 
     createTooltip (inputType, getPosition) {
         const config = getInputConfigFromType(inputType)
 
         // Attach close listeners
-        window.addEventListener('pointerdown', () => this.removeTooltip(), {capture: true, once: true})
         window.addEventListener('input', () => this.removeTooltip(), {once: true})
 
         if (isApp) {


### PR DESCRIPTION
**Reviewer:** 
**Asana:** 

## Description

- Out of time close events was causing the form to not be filled in
- We don't need the transient pointerdown as we have a global one
   - We just needed to swallow clicks that are inside the autofill.

## Steps to test
