### PR TITLE
Fixes release mode refreshing of aliases

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -238,12 +238,7 @@ class AppleDeviceInterface extends InterfacePrototype {
         return;
 
       case 'ok':
-        return this.inboundCredential({
-          detail: {
-            data: response.data,
-            configType: response.configType
-          }
-        });
+        return this.activeFormSelectedDetail(response.data, response.configType);
 
       case 'stop':
         // Parent wants us to stop polling
@@ -270,12 +265,6 @@ class AppleDeviceInterface extends InterfacePrototype {
     var _this$currentTooltip;
 
     (_this$currentTooltip = this.currentTooltip) === null || _this$currentTooltip === void 0 ? void 0 : _this$currentTooltip.focus(event.detail.x, event.detail.y);
-  }
-
-  inboundCredential(e) {
-    const activeForm = this.currentAttached;
-    if (activeForm === null) return;
-    activeForm.autofillData(e.detail.data, e.detail.configType);
   }
 
   async setupAutofill({
@@ -905,6 +894,10 @@ class InterfacePrototype {
 
     if (!form) {
       return;
+    }
+
+    if (data.id === 'privateAddress') {
+      this.refreshAlias();
     }
 
     if (type === 'email') {
@@ -4138,10 +4131,6 @@ class DataAutofill extends Tooltip {
   }
 
   async fillForm(data) {
-    if (data.id === 'privateAddress') {
-      await this.interface.refreshAlias();
-    }
-
     this.interface.selectedDetail(data, this.config.type);
   }
 
@@ -4180,22 +4169,26 @@ class EmailAutofill extends Tooltip {
     };
 
     this.registerClickableButton(this.usePersonalButton, () => {
-      this.fillForm(this.addresses.personalAddress);
+      this.fillForm('personalAddress');
     });
     this.registerClickableButton(this.usePrivateButton, () => {
-      const email = this.addresses.privateAddress;
-      this.fillForm(email);
+      this.fillForm('privateAddress');
     }); // Get the alias from the extension
 
     this.interface.getAddresses().then(this.updateAddresses);
     this.init();
   }
+  /**
+   * @param {'personalAddress' | 'privateAddress'} id
+   */
 
-  async fillForm(address) {
+
+  async fillForm(id) {
+    const address = this.addresses[id];
     const formattedAddress = formatDuckAddress(address);
-    await this.interface.refreshAlias();
     this.interface.selectedDetail({
-      email: formattedAddress
+      email: formattedAddress,
+      id
     }, 'email');
   }
 

--- a/src/DeviceInterface/AppleDeviceInterface.js
+++ b/src/DeviceInterface/AppleDeviceInterface.js
@@ -73,12 +73,7 @@ class AppleDeviceInterface extends InterfacePrototype {
             }, 100)
             return
         case 'ok':
-            return this.inboundCredential({
-                detail: {
-                    data: response.data,
-                    configType: response.configType
-                }
-            })
+            return this.activeFormSelectedDetail(response.data, response.configType)
         case 'stop':
             // Parent wants us to stop polling
 
@@ -101,12 +96,6 @@ class AppleDeviceInterface extends InterfacePrototype {
 
     processMouseMove (event) {
         this.currentTooltip?.focus(event.detail.x, event.detail.y)
-    }
-
-    inboundCredential (e) {
-        const activeForm = this.currentAttached
-        if (activeForm === null) return
-        activeForm.autofillData(e.detail.data, e.detail.configType)
     }
 
     async setupAutofill ({shouldLog} = {shouldLog: false}) {

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -203,6 +203,9 @@ class InterfacePrototype {
         if (!form) {
             return
         }
+        if (data.id === 'privateAddress') {
+            this.refreshAlias()
+        }
         if (type === 'email') {
             form.autofillEmail(data.email)
         } else {

--- a/src/UI/DataAutofill.js
+++ b/src/UI/DataAutofill.js
@@ -70,9 +70,6 @@ ${escapeXML(singleData[config.displaySubtitlePropName] || config.displaySubtitle
         this.init()
     }
     async fillForm (data) {
-        if (data.id === 'privateAddress') {
-            await this.interface.refreshAlias()
-        }
         this.interface.selectedDetail(data, this.config.type)
     }
 }

--- a/src/UI/EmailAutofill.js
+++ b/src/UI/EmailAutofill.js
@@ -44,11 +44,10 @@ ${includeStyles}
             }
         }
         this.registerClickableButton(this.usePersonalButton, () => {
-            this.fillForm(this.addresses.personalAddress)
+            this.fillForm('personalAddress')
         })
         this.registerClickableButton(this.usePrivateButton, () => {
-            const email = this.addresses.privateAddress
-            this.fillForm(email)
+            this.fillForm('privateAddress')
         })
 
         // Get the alias from the extension
@@ -56,10 +55,13 @@ ${includeStyles}
 
         this.init()
     }
-    async fillForm (address) {
+    /**
+     * @param {'personalAddress' | 'privateAddress'} id
+     */
+    async fillForm (id) {
+        const address = this.addresses[id]
         const formattedAddress = formatDuckAddress(address)
-        await this.interface.refreshAlias()
-        this.interface.selectedDetail({email: formattedAddress}, 'email')
+        this.interface.selectedDetail({email: formattedAddress, id}, 'email')
     }
 }
 


### PR DESCRIPTION
**Reviewer:** 
**Asana:** 

## Description

- Removes _inboundCredential_ function that is duplicated (used to handle events but we no longer do this)
- Calls _activeFormSelectedDetail_ instead which does the checks we need.
- Clean up and fix emailAutofill alias over rotation when personal email is selected
- Moves _refreshAlias_ into _activeFormSelectedDetail_ which happens after the detail is thrown back into the page rather than the top autofill.

This opts us into a little more coupling to _activeFormSelectedDetail_ having a weird and undefined _data_ type; I think we should resolve this as a follow up or create a task for it.

## Steps to test
