### PR TITLE
Look for closest label on click

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -3909,7 +3909,8 @@ class Form {
     let timeout = null;
 
     const handlerLabel = e => {
-      const control = e.target.control;
+      // Look for e.target OR it's closest parent to be a HTMLLabelElement
+      const control = e.target.closest('label').control;
       if (!control) return;
       storedClick.set(control, getMainClickCoords(e));
       clearTimeout(timeout); // Remove the stored click if the timer expires

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -259,7 +259,8 @@ class Form {
         let storedClick = new WeakMap()
         let timeout = null
         const handlerLabel = (e) => {
-            const control = e.target.control
+            // Look for e.target OR it's closest parent to be a HTMLLabelElement
+            const control = e.target.closest('label').control
             if (!control) return
             storedClick.set(control, getMainClickCoords(e))
             clearTimeout(timeout)


### PR DESCRIPTION
**Reviewer:** 
**Asana:** 

## Description

Fixes closest label selector clicking in to the input field and loading top autofill.

## Steps to test
1. Go to https://example.com
2. Enter the following into the debugger:
```
 document.body.innerHTML = `<form><label for="namething"><span>Name</span></label><input id="namething" name="name" /></form>`
```
Clicking the 'Name' label should now work