### PR TITLE
Move isSecureContext check back into the autofill.js

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -7552,7 +7552,6 @@ const sendAndWaitForAnswer = (msgOrFn, expectedResponse) => {
 };
 
 const autofillEnabled = processConfig => {
-  if (!window.isSecureContext) return false;
   let contentScope = null;
   let userUnprotectedDomains = null;
   let userPreferences = null; // INJECT contentScope HERE
@@ -7841,6 +7840,8 @@ module.exports = {
 require('./requestIdleCallback');
 
 (() => {
+  if (!window.isSecureContext) return false;
+
   try {
     const deviceInterface = require('./DeviceInterface');
 

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -50,8 +50,6 @@ const sendAndWaitForAnswer = (msgOrFn, expectedResponse) => {
 }
 
 const autofillEnabled = (processConfig) => {
-    if (!window.isSecureContext) return false
-
     let contentScope = null
     let userUnprotectedDomains = null
     let userPreferences = null

--- a/src/autofill.js
+++ b/src/autofill.js
@@ -2,6 +2,7 @@
 require('./requestIdleCallback');
 
 (() => {
+    if (!window.isSecureContext) return false
     try {
         const deviceInterface = require('./DeviceInterface')
         deviceInterface.init()


### PR DESCRIPTION
**Reviewer:** @shakyShane or @GioSensation 
**Asana:** 

## Description

Moves the _isSecureContext_ check back into the parent due to the require chain happening before the check happens.

## Steps to test

1. Go to http://example.com/ (http not https)
2. Open console, ensure there isn't a crypto warning in the console.