### PR TITLE
vendoring rules

### DIFF
--- a/.github/workflows/password-rules.yml
+++ b/.github/workflows/password-rules.yml
@@ -1,0 +1,38 @@
+name: Password Rules
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - uses: actions/github-script@v6
+        with:
+          #language=javascript
+          script: |
+            const current = require('./packages/password/rules.json')
+            const {summary, intoMarkdown, REMOTE_URL} = require('./packages/password/scripts/rules.js')
+            const result = await github.request(REMOTE_URL);            
+            const lines = summary(current, JSON.parse(result.data)); 
+            
+            if (lines.length === 0) return;
+            
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: intoMarkdown(lines),   
+            })

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -98,15 +98,17 @@ function generate() {
     }
 
     if (typeof (options === null || options === void 0 ? void 0 : options.domain) === 'string') {
-      const rules = _selectPasswordRules(options.domain, options.rules);
+      if (options !== null && options !== void 0 && options.rules) {
+        const rules = _selectPasswordRules(options.domain, options.rules);
 
-      if (rules) {
-        return Password.generateOrThrow(rules);
+        if (rules) {
+          return Password.generateOrThrow(rules);
+        }
       }
     }
   } catch (e) {
     // if an 'onError' callback was provided, forward all errors
-    if (options.onError && typeof options.onError === 'function') {
+    if (options !== null && options !== void 0 && options.onError && typeof (options === null || options === void 0 ? void 0 : options.onError) === 'function') {
       options.onError(e);
     } else {
       // otherwise, only console.error unknown errors (which could be implementation bugs)
@@ -132,15 +134,13 @@ class HostnameInputError extends Error {}
 /**
  * @private
  * @param {string} inputHostname
- * @param {RulesFormat | null | undefined} [rules]
+ * @param {RulesFormat} rules
  * @returns {string | undefined}
  * @throws {HostnameInputError}
  */
 
 
 function _selectPasswordRules(inputHostname, rules) {
-  rules = rules || require('./rules.json');
-
   const hostname = _safeHostname(inputHostname); // direct match
 
 
@@ -193,7 +193,7 @@ module.exports.HostnameInputError = HostnameInputError;
 module.exports.ParserError = ParserError;
 module.exports.constants = constants;
 
-},{"./lib/apple.password":3,"./lib/constants":4,"./lib/rules-parser":5,"./rules.json":6}],3:[function(require,module,exports){
+},{"./lib/apple.password":3,"./lib/constants":4,"./lib/rules-parser":5}],3:[function(require,module,exports){
 "use strict";
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
@@ -6951,6 +6951,8 @@ function _classApplyDescriptorGet(receiver, descriptor) { if (descriptor.get) { 
 const {
   generate
 } = require('../packages/password');
+
+const rules = require('../packages/password/rules.json');
 /**
  * Create a password once and reuse it.
  */
@@ -6980,7 +6982,9 @@ class PasswordGenerator {
       return _classPrivateFieldGet(this, _previous);
     }
 
-    _classPrivateFieldSet(this, _previous, generate(params));
+    _classPrivateFieldSet(this, _previous, generate({ ...params,
+      rules
+    }));
 
     return _classPrivateFieldGet(this, _previous);
   }
@@ -6989,7 +6993,7 @@ class PasswordGenerator {
 
 module.exports.PasswordGenerator = PasswordGenerator;
 
-},{"../packages/password":2}],29:[function(require,module,exports){
+},{"../packages/password":2,"../packages/password/rules.json":6}],29:[function(require,module,exports){
 "use strict";
 
 const {

--- a/packages/password/docs/updating-rules.md
+++ b/packages/password/docs/updating-rules.md
@@ -1,0 +1,26 @@
+## Rules
+
+We include the following [file](https://raw.githubusercontent.com/apple/password-manager-resources/main/quirks/password-rules.json) within this
+package, which allows password generation to respect known rules for the websites listed.
+
+## Update the rules
+
+Inside this packages folder, `packages/password`, run the following
+
+```shell
+npm run rules:update
+```
+
+## Github Action
+
+We use a Github action to notify new PR's with a comment when our ruleset has
+become out of sync with Apple's.
+
+It's in the following file: 
+- `.github/workflows/password-rules.yml`
+ 
+It uses scripts from 
+- `packages/password/scripts/rules.js`
+
+The script itself does not update anything, it's just there as a notice to prompt
+anyone watching the repo that an update may be required.

--- a/packages/password/index.js
+++ b/packages/password/index.js
@@ -29,14 +29,16 @@ function generate (options = {}) {
             return Password.generateOrThrow(options.input)
         }
         if (typeof options?.domain === 'string') {
-            const rules = _selectPasswordRules(options.domain, options.rules)
-            if (rules) {
-                return Password.generateOrThrow(rules)
+            if (options?.rules) {
+                const rules = _selectPasswordRules(options.domain, options.rules)
+                if (rules) {
+                    return Password.generateOrThrow(rules)
+                }
             }
         }
     } catch (e) {
         // if an 'onError' callback was provided, forward all errors
-        if (options.onError && typeof options.onError === 'function') {
+        if (options?.onError && typeof options?.onError === 'function') {
             options.onError(e)
         } else {
             // otherwise, only console.error unknown errors (which could be implementation bugs)
@@ -62,12 +64,11 @@ class HostnameInputError extends Error {}
 /**
  * @private
  * @param {string} inputHostname
- * @param {RulesFormat | null | undefined} [rules]
+ * @param {RulesFormat} rules
  * @returns {string | undefined}
  * @throws {HostnameInputError}
  */
 function _selectPasswordRules (inputHostname, rules) {
-    rules = rules || require('./rules.json')
     const hostname = _safeHostname(inputHostname)
     // direct match
     if (rules[hostname]) {

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run test",
-    "generate:html": "node html-testing/generate.js"
+    "generate:html": "node html-testing/generate.js",
+    "rules:update": "node scripts/rules.js --write-rules-json"
   },
   "repository": {
     "type": "git",

--- a/packages/password/readme.md
+++ b/packages/password/readme.md
@@ -1,0 +1,6 @@
+# Password generation utilities
+
+## Docs
+
+- [Password generation](./docs/password.md)
+- [Updating rules](./docs/updating-rules.md)

--- a/packages/password/scripts/rules.js
+++ b/packages/password/scripts/rules.js
@@ -1,0 +1,99 @@
+const {join} = require('path')
+const {writeFileSync} = require('fs')
+const outputPath = join(__dirname, '..', 'rules.json')
+const REMOTE_URL = 'https://raw.githubusercontent.com/apple/password-manager-resources/main/quirks/password-rules.json'
+
+/**
+ * This file contains utilities for keeping our password rules in sync.
+ */
+
+/**
+ * @param {typeof import("../rules.json")} prev
+ * @param {typeof import("../rules.json")} next
+ * @returns {string[]}
+ */
+function summary (prev, next) {
+    const lines = []
+
+    for (let [domain, value] of Object.entries(prev)) {
+        if (domain in next) {
+            if (value['password-rules'] !== next[domain]['password-rules']) {
+                lines.push(`${domain} rules differ`)
+                lines.push(`\tcurrent: ${value['password-rules']}`)
+                lines.push(`\tremote:  ${next[domain]['password-rules']}`)
+            }
+        } else {
+            lines.push(`${domain} no longer in remote`)
+        }
+    }
+
+    for (let [domain, value] of Object.entries(next)) {
+        if (!(domain in prev)) {
+            lines.push(`${domain} not present in current`)
+            lines.push(`\trules: ${value['password-rules']}`)
+        }
+    }
+
+    return lines
+}
+
+/**
+ * @param {typeof import("../rules.json")} rules
+ */
+function update (rules) {
+    writeFileSync(outputPath, JSON.stringify(rules, null, 2))
+}
+
+/**
+ * @returns {Promise<typeof import("../rules.json")>}
+ */
+function download () {
+    const https = require('https')
+    return new Promise((resolve, reject) => {
+        const chunks = []
+        https.get(REMOTE_URL, (res) => {
+            res.on('data', (d) => {
+                chunks.push(d.toString())
+            })
+        }).on('error', (e) => {
+            reject(e)
+        }).on('close', () => {
+            resolve(JSON.parse(chunks.join('')))
+        })
+    })
+}
+
+/**
+ * @param {string[]} lines
+ */
+function intoMarkdown (lines) {
+    const header = '## Note: Password rules outdated'
+    const mainBody = '```\n' + lines.join('\n') + '\n```'
+    const updateTitle = '**You can update the rules with the following command**'
+    const updateCommand = '```sh\ncd packages/password && npm run rules:update\n```'
+    const footer = `Once you've updated the rules, commit the changes.`
+    return [header, mainBody, updateTitle, updateCommand, footer].join('\n')
+}
+
+if (process.argv.includes('--write-rules-json')) {
+    download()
+        .then((remoteRules) => {
+            const current = require('../rules.json')
+            const lines = summary(current, remoteRules)
+            if (lines.length) {
+                update(remoteRules)
+                console.log('rules updated')
+            } else {
+                console.log('nothing to update')
+            }
+        }).catch(e => {
+            console.error(e)
+            process.exit(1)
+        })
+}
+
+module.exports.update = update
+module.exports.summary = summary
+module.exports.download = download
+module.exports.intoMarkdown = intoMarkdown
+module.exports.REMOTE_URL = REMOTE_URL

--- a/packages/password/tests/generate.test.js
+++ b/packages/password/tests/generate.test.js
@@ -84,6 +84,7 @@ describe('password generation', () => {
             expect.assertions(1)
             generate({
                 ...args,
+                rules: vendorRules,
                 onError (e) {
                     expect(e).toBeInstanceOf(expectedErrorClass)
                 }
@@ -114,7 +115,7 @@ describe('password generation', () => {
         it('_selectPasswordRules throws when a full URL is given', () => {
             expect.assertions(1)
             try {
-                _selectPasswordRules('http://example.com')
+                _selectPasswordRules('http://example.com', vendorRules)
             } catch (e) {
                 expect(e).toBeInstanceOf(HostnameInputError)
             }
@@ -122,7 +123,7 @@ describe('password generation', () => {
         it('_selectPasswordRules throws when a host is given (with port)', () => {
             expect.assertions(1)
             try {
-                _selectPasswordRules('localhost:8080')
+                _selectPasswordRules('localhost:8080', vendorRules)
             } catch (e) {
                 expect(e).toBeInstanceOf(HostnameInputError)
             }
@@ -130,13 +131,13 @@ describe('password generation', () => {
         it('_selectPasswordRules throws when a URL cannot be constructed from input', () => {
             expect.assertions(1)
             try {
-                _selectPasswordRules('')
+                _selectPasswordRules('', vendorRules)
             } catch (e) {
                 expect(e).toBeInstanceOf(HostnameInputError)
             }
         })
         it('_selectPasswordRules returns undefined for a valid host with no match', () => {
-            expect(_selectPasswordRules('example.com')).toBeUndefined()
+            expect(_selectPasswordRules('example.com', {})).toBeUndefined()
         })
         it('_selectPasswordRules returns rules when its a direct match', () => {
             const actual = _selectPasswordRules('example.com', {

--- a/src/PasswordGenerator.js
+++ b/src/PasswordGenerator.js
@@ -1,4 +1,5 @@
 const {generate} = require('../packages/password')
+const rules = require('../packages/password/rules.json')
 
 /**
  * Create a password once and reuse it.
@@ -18,7 +19,7 @@ class PasswordGenerator {
             return this.#previous
         }
 
-        this.#previous = generate(params)
+        this.#previous = generate({ ...params, rules })
 
         return this.#previous
     }


### PR DESCRIPTION
**Reviewer:** @GioSensation @jonathanKingston 
**Asana:** https://app.asana.com/0/0/1201884374201342/f

## Description

This PR adds 2 things.

1) added a script that can be manually ran in our repo to update our rules to match the remote file that we use
2) added a Github Actions script that will comment on new PR's if our rules become outdated. The comment can be ignored, but it's just there to notify people on the project that the remote resource is different to our own. Each update should be verified by a human anyway, so this works out well.

You can see the comment format below in this PR, which shows the process is working :)
