### PR TITLE
Fix release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -50,6 +50,7 @@ const run = async () => {
             .replace('[[commit]]', commit)
             .replace('[[release_url]]', `<a href="${releaseUrl}">${releaseUrl}</a>`)
             .replace('[[notes]]', releaseNotes)
+            .replace(/<\/?p>/ig, '\n')
 
     console.info('Updating task and moving to Release section...')
 
@@ -84,6 +85,6 @@ const run = async () => {
 }
 
 run().catch((e) => {
-    console.error(e)
+    console.error(e.value?.errors)
     process.exit(1)
 })


### PR DESCRIPTION
**Reviewer:** @shakyShane 

## Description
Asana API doesn't accept `p` tags so I'm stripping them with a `replace`. The library we use for markdown seems to have options but I couldn't get the result I wanted and this fixes the issue. ~~This is holding up the release train so I'd like to get it out ASAP.~~ In fact, it's not so urgent. I can create the tasks manually. If you have time to investigate that library, please follow up.

- https://github.com/markdown-it/markdown-it
- Info on Asana markup support https://forum.asana.com/t/changes-are-coming-to-rich-text-html-notes-and-html-text-in-asana/113434
