### PR TITLE
fixes for paypal - don't reset or fire events if a select contains the target value

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8262,15 +8262,14 @@ const setValueForInput = (el, val) => {
 
 
 const fireEventsOnSelect = el => {
+  /** @type {Event[]} */
   const events = [new Event('mousedown', {
-    bubbles: true
-  }), new Event('focus', {
-    bubbles: true
-  }), new Event('change', {
     bubbles: true
   }), new Event('mouseup', {
     bubbles: true
   }), new Event('click', {
+    bubbles: true
+  }), new Event('change', {
     bubbles: true
   })]; // Events fire on the select el, not option
 
@@ -8302,6 +8301,7 @@ const setValueForSelect = (el, val) => {
 
 
     if (value.includes(String(val))) {
+      if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);
       return true;
@@ -8310,6 +8310,7 @@ const setValueForSelect = (el, val) => {
 
   for (const option of el.options) {
     if (option.innerText.includes(String(val))) {
+      if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);
       return true;

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -115,13 +115,14 @@ const setValueForInput = (el, val) => {
  * @param {HTMLSelectElement} el
  */
 const fireEventsOnSelect = (el) => {
+    /** @type {Event[]} */
     const events = [
         new Event('mousedown', {bubbles: true}),
-        new Event('focus', {bubbles: true}),
-        new Event('change', {bubbles: true}),
         new Event('mouseup', {bubbles: true}),
-        new Event('click', {bubbles: true})
+        new Event('click', {bubbles: true}),
+        new Event('change', {bubbles: true})
     ]
+
     // Events fire on the select el, not option
     events.forEach((ev) => el.dispatchEvent(ev))
     events.forEach((ev) => el.dispatchEvent(ev))
@@ -150,6 +151,7 @@ const setValueForSelect = (el, val) => {
         }
         // TODO: try to match localised month names
         if (value.includes(String(val))) {
+            if (option.selected) return false
             option.selected = true
             fireEventsOnSelect(el)
             return true
@@ -158,6 +160,7 @@ const setValueForSelect = (el, val) => {
 
     for (const option of el.options) {
         if (option.innerText.includes(String(val))) {
+            if (option.selected) return false
             option.selected = true
             fireEventsOnSelect(el)
             return true

--- a/src/autofill-utils.test.js
+++ b/src/autofill-utils.test.js
@@ -21,7 +21,7 @@ afterEach(() => {
     document.body.innerHTML = ''
 })
 
-describe('value setting', function () {
+describe('value setting on inputs', function () {
     it('should set value & dispatch events in the correct order', () => {
         const {input, events} = renderInputWithEvents()
         setValue(input, '123456')
@@ -38,6 +38,48 @@ describe('value setting', function () {
             'keyup',
             'change'
         ])
+    })
+})
+
+const renderInputWithSelect = () => {
+    document.body.innerHTML = `
+    <select name="country">
+        <option value="GB">Great Britain</option>
+        <option value="US">USA</option>
+    </select>
+    `
+
+    const events = []
+    const select = document.querySelector('select')
+    if (!select) throw new Error('unreachable')
+
+    select.addEventListener('mousedown', () => events.push('mousedown'))
+    select.addEventListener('mouseup', () => events.push('mouseup'))
+    select.addEventListener('click', () => events.push('click'))
+    select.addEventListener('change', () => events.push('change'))
+
+    return {select, events}
+}
+
+describe('value setting on selects', function () {
+    it('should set value & dispatch events when value has changed', () => {
+        const {select, events} = renderInputWithSelect()
+        setValue(select, 'US')
+        expect(events).toStrictEqual([
+            'mousedown',
+            'mouseup',
+            'click',
+            'change',
+            'mousedown',
+            'mouseup',
+            'click',
+            'change'
+        ])
+    })
+    it('should not fire any events when the value has not changed', () => {
+        const {select, events} = renderInputWithSelect()
+        setValue(select, 'GB')
+        expect(events).toStrictEqual([])
     })
 })
 


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1177771139624306/1201923546020812/f

## Description

This removes the `focus` event when changing a select field and also prevents duplicate values being set, which was causing PayPal's checkout to break.