### PR TITLE
Fix Android not supporting string.replaceAll

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -5060,7 +5060,7 @@ const getCountryName = function (el) {
   if (el.nodeName === 'SELECT') {
     const englishCountryName = getCountryDisplayName('en', addressCountryCode); // This regex matches both the localised and English country names
 
-    const countryNameRegex = new RegExp(String.raw(_templateObject || (_templateObject = _taggedTemplateLiteral(["", "|", ""])), localisedCountryName.replaceAll(' ', '.?'), englishCountryName.replaceAll(' ', '.?')), 'i');
+    const countryNameRegex = new RegExp(String.raw(_templateObject || (_templateObject = _taggedTemplateLiteral(["", "|", ""])), localisedCountryName.replace(/ /g, '.?'), englishCountryName.replace(/ /g, '.?')), 'i');
     const countryCodeRegex = new RegExp(String.raw(_templateObject2 || (_templateObject2 = _taggedTemplateLiteral(["\b", "\b"], ["\\b", "\\b"])), addressCountryCode), 'i'); // We check the country code first because it's more accurate
 
     if (el instanceof HTMLSelectElement) {
@@ -5230,7 +5230,7 @@ const prepareFormValuesForStorage = formValues => {
     }
 
     if (creditCards.cardNumber) {
-      creditCards.cardNumber = creditCards.cardNumber.replaceAll(/\D/g, '');
+      creditCards.cardNumber = creditCards.cardNumber.replace(/\D/g, '');
     }
   } else {
     creditCards = undefined;

--- a/src/Form/formatters.js
+++ b/src/Form/formatters.js
@@ -84,9 +84,9 @@ const getCountryName = (el, options = {}) => {
         const englishCountryName = getCountryDisplayName('en', addressCountryCode)
         // This regex matches both the localised and English country names
         const countryNameRegex = new RegExp(String.raw`${
-            localisedCountryName.replaceAll(' ', '.?')
+            localisedCountryName.replace(/ /g, '.?')
         }|${
-            englishCountryName.replaceAll(' ', '.?')
+            englishCountryName.replace(/ /g, '.?')
         }`, 'i')
         const countryCodeRegex = new RegExp(String.raw`\b${addressCountryCode}\b`, 'i')
 
@@ -237,7 +237,7 @@ const prepareFormValuesForStorage = (formValues) => {
             creditCards.expirationYear = `${Number(creditCards.expirationYear) + 2000}`
         }
         if (creditCards.cardNumber) {
-            creditCards.cardNumber = creditCards.cardNumber.replaceAll(/\D/g, '')
+            creditCards.cardNumber = creditCards.cardNumber.replace(/\D/g, '')
         }
     } else {
         creditCards = undefined


### PR DESCRIPTION
**Reviewer:** @shakyShane @jonathanKingston 
**Asana:** https://app.asana.com/0/0/1201749050559820/f

## Description
While cross-testing on Android I noticed it doesn't support `string.replaceAll`, so I substitute it with a simple `replace` with the `//g` flag.

## Steps to test
Tested on all platforms + unit testing going strong 🙂.