### PR TITLE
Close top autofill and add escape+tab keydown closure

### DIFF
--- a/src/DeviceInterface/AppleDeviceInterface.js
+++ b/src/DeviceInterface/AppleDeviceInterface.js
@@ -29,7 +29,7 @@ class AppleDeviceInterface extends InterfacePrototype {
         if (isTopFrame) {
             this.stripCredentials = false
             window.addEventListener('mouseMove', this)
-        } else {
+        } else if (supportsTopFrame) {
             // This is always added as a child frame needs to be informed of a parent frame scroll
             window.addEventListener('scroll', this)
         }
@@ -193,6 +193,7 @@ class AppleDeviceInterface extends InterfacePrototype {
 
     async removeTooltip () {
         if (!supportsTopFrame) return super.removeTooltip()
+        this.removeCloseListeners()
         await wkSend('closeAutofillParent', {})
     }
 

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -262,9 +262,6 @@ class InterfacePrototype {
     createTooltip (getPosition, topContextData) {
         const config = getInputConfigFromType(topContextData.inputType)
 
-        // Attach close listeners
-        window.addEventListener('input', () => this.removeTooltip(), {once: true})
-
         if (isApp) {
             // collect the data for each item to display
             const data = this.dataForAutofill(config, topContextData.inputType, topContextData)
@@ -351,7 +348,19 @@ class InterfacePrototype {
             topContextData.credentials = [fromPassword(password)]
         }
 
+        this.attachCloseListeners()
+
         this.attachTooltipInner(form, input, getPosition, click, topContextData)
+    }
+
+    attachCloseListeners () {
+        window.addEventListener('input', this)
+        window.addEventListener('keydown', this)
+    }
+
+    removeCloseListeners () {
+        window.removeEventListener('input', this)
+        window.removeEventListener('keydown', this)
     }
 
     /**
@@ -428,6 +437,7 @@ class InterfacePrototype {
 
     async removeTooltip () {
         if (this.currentTooltip) {
+            this.removeCloseListeners()
             this.currentTooltip.remove()
             this.currentTooltip = null
             this.currentAttached = null
@@ -443,6 +453,14 @@ class InterfacePrototype {
     }
     handleEvent (event) {
         switch (event.type) {
+        case 'keydown':
+            if (event.code === 'Escape' || event.code === 'Tab') {
+                this.removeTooltip()
+            }
+            break
+        case 'input':
+            this.removeTooltip()
+            break
         case 'pointerdown':
             this.pointerDownListener(event)
             break


### PR DESCRIPTION
**Reviewer:** @shakyShane or @GioSensation 
**Asana:** https://app.asana.com/0/1177771139624306/1201894953278298/f

## Description

- Fixes for top autofill the event handlers not registered
- Removes scroll listening for iOS
- Removes both listeners when we close the autofill
- Adds tab/esc listeners to close

## Steps to test

- Open autofill up
- Type a letter/tab/esc
- Should close
