### PR TITLE
Improve test stats with absolute values

### DIFF
--- a/src/Form/input-classifiers.test.js
+++ b/src/Form/input-classifiers.test.js
@@ -246,6 +246,8 @@ afterAll(() => {
         '\n' + Object.keys(totalFieldsByType).sort().map((type) => {
             return '\n' + (type + ':').padEnd(24) +
                     (Math.round((totalFailuresByFieldType[type] / totalFieldsByType[type]) * 100) + '%').padEnd(4) +
+                    ' | ' + String(totalFailuresByFieldType[type]).padStart(4) +
+                    ' out of ' + String(totalFieldsByType[type]).padStart(4) + ' fields | ' +
                     ' (' + Math.round((totalFailuresByFieldType[type] / totalFailedFields) * 100) + '% of all failures)'
         }).join('') + '\n'
     )


### PR DESCRIPTION
**Reviewer:** @shakyShane @bstandaert-ddg @jonathanKingston 
**Asana:** NA

## Description
Adds absolute values to the test stat report. The output now looks like this and makes it easier to understand how much test cases we have for the single field type.

```
username:               3%   |    2 out of   58 fields |  (2% of all failures)
```