### PR TITLE
Fix submitHandler over triggering

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -2340,6 +2340,9 @@ module.exports={
   "zdf.de": {
     "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
   },
+  "zara.com": {
+    "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
+  },
   "zoom.us": {
     "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
   }

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -5673,7 +5673,7 @@ const listenForGlobalFormSubmission = () => {
     });
     const observer = new PerformanceObserver(list => {
       const entries = list.getEntries().filter(entry => // @ts-ignore why does TS not know about `entry.initiatorType`?
-      ['fetch', 'xmlhttprequest'].includes(entry.initiatorType) && entry.name.match(/login|sign-in|signin|session/));
+      ['fetch', 'xmlhttprequest'].includes(entry.initiatorType) && entry.name.match(/login|sign-in|signin/));
       if (!entries.length) return;
       const filledForm = [...forms.values()].find(form => form.hasValues());
       filledForm === null || filledForm === void 0 ? void 0 : filledForm.submitHandler();

--- a/packages/password/rules.json
+++ b/packages/password/rules.json
@@ -758,6 +758,9 @@
   "zdf.de": {
     "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
   },
+  "zara.com": {
+    "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
+  },
   "zoom.us": {
     "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
   }

--- a/src/Form/listenForFormSubmission.js
+++ b/src/Form/listenForFormSubmission.js
@@ -21,7 +21,7 @@ const listenForGlobalFormSubmission = () => {
             const entries = list.getEntries().filter((entry) =>
                 // @ts-ignore why does TS not know about `entry.initiatorType`?
                 ['fetch', 'xmlhttprequest'].includes(entry.initiatorType) &&
-                entry.name.match(/login|sign-in|signin|session/)
+                entry.name.match(/login|sign-in|signin/)
             )
 
             if (!entries.length) return


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/0/1202017197604661/f

## Description
I noticed we were overtriggering the submitHandler on Amazon because of this regex (literally all their network call had `session` in the url). With the submit detection now being much better I am confident we can remove this `session` keyword from that regex and still maintain good coverage.