### PR TITLE
Update content scope scripts and setting it to a fixed dependency whi…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    labels:
+      - "dependencies"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts"
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.1.2"
       },
       "devDependencies": {
         "@babel/core": "^7.17.5",
@@ -1691,8 +1691,8 @@
       "dev": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#943d9ca3d3f32e57eaa918b46fb6b1954b7c3319",
+      "version": "1.1.2",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#57e3d2876eaa17fed7632d6e5d8d2fc3ddeafea7",
       "hasInstallScript": true,
       "dependencies": {
         "seedrandom": "^3.0.5",
@@ -14092,8 +14092,8 @@
       "dev": true
     },
     "@duckduckgo/content-scope-scripts": {
-      "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#943d9ca3d3f32e57eaa918b46fb6b1954b7c3319",
-      "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts",
+      "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#57e3d2876eaa17fed7632d6e5d8d2fc3ddeafea7",
+      "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#1.1.2",
       "requires": {
         "seedrandom": "^3.0.5",
         "sjcl": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts"
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.1.2"
   }
 }


### PR DESCRIPTION
…ch helps package locking. Enable dependabot to do this for us.

**Reviewer:** @shakyShane or @GioSensation 
**Asana:** 

## Description

This is causing issues with releasing the extension as dependabot doesn't have a concrete reference to content scope and so we're getting integrity issues whilst installing.

## Steps to test
