### PR TITLE
fix(dom): prevent calls to document.getElementId with empty strings

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -7182,11 +7182,14 @@ const getExplicitLabelsText = el => {
   } // Try to access another element if it was marked as the label for this input/select
 
 
-  const ariaLabelAttr = el.getAttribute('aria-labelled') || el.getAttribute('aria-labelledby') || '';
-  const labelledByElement = document.getElementById(ariaLabelAttr);
+  const ariaLabelAttr = el.getAttribute('aria-labelled') || el.getAttribute('aria-labelledby');
 
-  if (labelledByElement) {
-    labelTextCandidates.push(...extractElementStrings(labelledByElement));
+  if (ariaLabelAttr) {
+    const labelledByElement = document.getElementById(ariaLabelAttr);
+
+    if (labelledByElement) {
+      labelTextCandidates.push(...extractElementStrings(labelledByElement));
+    }
   }
 
   if (labelTextCandidates.length > 0) {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -2133,6 +2133,9 @@ module.exports={
   "premier.ticketek.com.au": {
     "password-rules": "minlength: 6; maxlength: 16;"
   },
+  "premierinn.com": {
+    "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower;"
+  },
   "prepaid.bankofamerica.com": {
     "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
   },
@@ -2337,11 +2340,11 @@ module.exports={
   "yatra.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
   },
-  "zdf.de": {
-    "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
-  },
   "zara.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
+  },
+  "zdf.de": {
+    "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
   },
   "zoom.us": {
     "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"

--- a/packages/password/rules.json
+++ b/packages/password/rules.json
@@ -551,6 +551,9 @@
   "premier.ticketek.com.au": {
     "password-rules": "minlength: 6; maxlength: 16;"
   },
+  "premierinn.com": {
+    "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower;"
+  },
   "prepaid.bankofamerica.com": {
     "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
   },
@@ -755,11 +758,11 @@
   "yatra.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
   },
-  "zdf.de": {
-    "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
-  },
   "zara.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
+  },
+  "zdf.de": {
+    "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
   },
   "zoom.us": {
     "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"

--- a/packages/password/scripts/rules.js
+++ b/packages/password/scripts/rules.js
@@ -71,7 +71,7 @@ function intoMarkdown (lines) {
     const mainBody = '```\n' + lines.join('\n') + '\n```'
     const updateTitle = '**You can update the rules with the following command**'
     const updateCommand = '```sh\ncd packages/password && npm run rules:update\n```'
-    const footer = `Once you've updated the rules, commit the changes.`
+    const footer = 'Once you\'ve updated the rules, re-run the build from the root with `npm run build` and then commit all changes.'
     return [header, mainBody, updateTitle, updateCommand, footer].join('\n')
 }
 

--- a/src/Form/matching-utils.test.js
+++ b/src/Form/matching-utils.test.js
@@ -1,0 +1,48 @@
+const { getExplicitLabelsText } = require('./matching')
+
+const setFormHtml = (html) => {
+    document.body.innerHTML = `<form>${html}</form>`
+    const inputs = Array.from(document?.querySelectorAll('input') || [])
+    return { inputs }
+}
+
+beforeEach(() => {
+    document.body.innerHTML = ''
+})
+
+/**
+ * Calling `getElementById()` with an empty string in FF produces console warnings
+ * https://app.asana.com/0/892838074342800/1202094878508964/f
+ */
+describe('getExplicitLabelsText()', () => {
+    let spy
+    beforeEach(() => {
+        spy = jest.spyOn(document, 'getElementById')
+    })
+    afterEach(() => {
+        spy.mockClear()
+    })
+    it.each([
+        `<input type="text">`,
+        `<input type="text" aria-labelledby="">`,
+        `<input type="text" aria-labelled="">`
+    ])('does not call getElementById() with empty string', (html) => {
+        const {inputs} = setFormHtml(html)
+        getExplicitLabelsText(inputs[0])
+        expect(spy).not.toHaveBeenCalled()
+    })
+    it.each([
+        `
+        <div id="label-div">First Name</div>
+        <input type="text" aria-labelledby="label-div">
+        `,
+        `
+        <div id="label-div">First Name</div>
+        <input type="text" aria-labelled="label-div">
+        `
+    ])('calls getElementById() using string from `aria-labelledby` or `aria-labelled`', (html) => {
+        const {inputs} = setFormHtml(html)
+        getExplicitLabelsText(inputs[0])
+        expect(spy).toHaveBeenCalledWith('label-div')
+    })
+})

--- a/src/Form/matching.js
+++ b/src/Form/matching.js
@@ -687,11 +687,13 @@ const getExplicitLabelsText = (el) => {
     }
 
     // Try to access another element if it was marked as the label for this input/select
-    const ariaLabelAttr = el.getAttribute('aria-labelled') || el.getAttribute('aria-labelledby') || ''
-    const labelledByElement = document.getElementById(ariaLabelAttr)
+    const ariaLabelAttr = el.getAttribute('aria-labelled') || el.getAttribute('aria-labelledby')
 
-    if (labelledByElement) {
-        labelTextCandidates.push(...extractElementStrings(labelledByElement))
+    if (ariaLabelAttr) {
+        const labelledByElement = document.getElementById(ariaLabelAttr)
+        if (labelledByElement) {
+            labelTextCandidates.push(...extractElementStrings(labelledByElement))
+        }
     }
 
     if (labelTextCandidates.length > 0) {


### PR DESCRIPTION
https://app.asana.com/0/892838074342800/1202094878508964/f

**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/892838074342800/1202094878508964/f

## Description

prevent calls to document.getElementId with empty strings

## Steps to test

Unit tests were added, no functionality is changed here so I'm confident this is enough.
