### PR TITLE
Mark generated files as binary + linguist-generated (github)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** binary linguist-generated


### PR DESCRIPTION
**Reviewer:** @jonathanKingston 
**Asana:** 

## Description

We really need this in place to stop git + Github from considering these files in stats

## Steps to test

Note: This changes nothing functionally - it just helps prevent PRs/diff from looking as bad :)
