### PR TITLE
fix: don't allow overlay to close itself

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -2996,7 +2996,9 @@ class AppleOverlayDeviceInterface extends _AppleDeviceInterface.AppleDeviceInter
       css: "<style>".concat(_styles.CSS_STYLES, "</style>"),
       setSize: details => this._setSize(details),
       testMode: this.isTestMode(),
-      remove: () => this._closeAutofillParent()
+      remove: () => {
+        /** noop - the overlay does not close itself */
+      }
     };
     return new _HTMLTooltipUIController.HTMLTooltipUIController(controllerOptions, tooltipOptions);
   }

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -3,6 +3,7 @@
  */
 export const constants = {
     pages: {
+        'overlay': 'overlay.html',
         'email-autofill': 'email-autofill.html',
         'signup': 'signup.html',
         'login': 'login.html'

--- a/integration-test/helpers/mocks.webkit.js
+++ b/integration-test/helpers/mocks.webkit.js
@@ -75,11 +75,12 @@ export function createWebkitMocks (platform = 'macos') {
      */
     const webkitBase = {
         pmHandlerGetAutofillInitData: {
-            /** @type {PMData} */
+            /** @type {InboundPMData} */
             success: {
                 identities: [],
                 credentials: [],
-                creditCards: []
+                creditCards: [],
+                serializedInputContext: '{}'
             }
         },
         emailHandlerCheckAppSignedInStatus: {
@@ -104,7 +105,8 @@ export function createWebkitMocks (platform = 'macos') {
             /** @type {CredentialsObject|null} */
             success: null
         },
-        showAutofillParent: {}
+        showAutofillParent: {},
+        setSize: {}
     }
 
     /** @type {MockBuilder} */
@@ -133,6 +135,9 @@ export function createWebkitMocks (platform = 'macos') {
         },
         withCredentials: function (credentials) {
             webkitBase.pmHandlerGetAutofillInitData.success.credentials.push(credentials)
+            /** @type {TopContextData} */
+            const topContextData = {inputType: 'credentials.username'}
+            webkitBase.pmHandlerGetAutofillInitData.success.serializedInputContext = JSON.stringify(topContextData)
             webkitBase.pmHandlerGetAutofillCredentials.success = credentials
             webkitBase.getSelectedCredentials = [
                 {type: 'none'},

--- a/integration-test/pages/overlay.html
+++ b/integration-test/pages/overlay.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+    <style>
+        html, body {
+            margin: 0;
+            background-color: rgba(242, 240, 240, 0.9);
+        }
+    </style>
+</head>
+<body id="topAutofill">
+<main></main>
+</body>
+</html>

--- a/src/DeviceInterface/AppleOverlayDeviceInterface.js
+++ b/src/DeviceInterface/AppleOverlayDeviceInterface.js
@@ -36,7 +36,9 @@ class AppleOverlayDeviceInterface extends AppleDeviceInterface {
             css: `<style>${CSS_STYLES}</style>`,
             setSize: (details) => this._setSize(details),
             testMode: this.isTestMode(),
-            remove: () => this._closeAutofillParent()
+            remove: () => {
+                /** noop - the overlay does not close itself */
+            }
         }
         return new HTMLTooltipUIController(controllerOptions, tooltipOptions)
     }

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -2996,7 +2996,9 @@ class AppleOverlayDeviceInterface extends _AppleDeviceInterface.AppleDeviceInter
       css: "<style>".concat(_styles.CSS_STYLES, "</style>"),
       setSize: details => this._setSize(details),
       testMode: this.isTestMode(),
-      remove: () => this._closeAutofillParent()
+      remove: () => {
+        /** noop - the overlay does not close itself */
+      }
     };
     return new _HTMLTooltipUIController.HTMLTooltipUIController(controllerOptions, tooltipOptions);
   }


### PR DESCRIPTION
https://app.asana.com/0/1198964220583541/1202307926453345/f

**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1198964220583541/1202307926453345/f

## Description

This prevents `closeAutofillParent` being called from the overlay.

This was happening because event/error handling in the swift part of Autofill has scenarios where messages are not responded to, causing errors to be thrown in our JavaScript.

Regardless of that though, we shouldn't ever call `closeAutofillParent` from the overlay, and now that overlay + none-overlay code paths are separate we can easily fix this.

https://github.com/duckduckgo/duckduckgo-autofill/compare/shane/fix-macos-overlay?expand=1#diff-8b924aa96e6f8f0f8a78c5113b3b763b7f28907f6073e469c5b4bcb5b2025659R39-R41

## Steps to test

I've added a regression test that loads the overlay code and ensures the message is not being sent - which is a pretty good way of preventing this from happening again, but doesn't prevent the need for manual testing on ios+macos

- [x] iOS
- [x] macOS (with top frame support)
- [x] macOS (in-page)

I'll update this description as I test each of the above. Code review can commence though.
