### PR TITLE
Shane/inline icon flags

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10043,13 +10043,33 @@ const inputTypeConfig = {
   /** @type {CredentialsInputTypeConfig} */
   credentials: {
     type: 'credentials',
-    getIconBase: () => ddgPasswordIcons.ddgPasswordIconBase,
-    getIconFilled: () => ddgPasswordIcons.ddgPasswordIconFilled,
-    shouldDecorate: (input, _ref2) => {
+    getIconBase: (_input, _ref2) => {
+      let {
+        device
+      } = _ref2;
+
+      if (device.settings.featureToggles.inlineIcon_credentials) {
+        return ddgPasswordIcons.ddgPasswordIconBase;
+      }
+
+      return '';
+    },
+    getIconFilled: (_input, _ref3) => {
+      let {
+        device
+      } = _ref3;
+
+      if (device.settings.featureToggles.inlineIcon_credentials) {
+        return ddgPasswordIcons.ddgPasswordIconFilled;
+      }
+
+      return '';
+    },
+    shouldDecorate: (input, _ref4) => {
       let {
         isLogin,
         device
-      } = _ref2;
+      } = _ref4;
 
       // if we are on a 'login' page, continue to use old logic, eg: just checking if there's a
       // saved password
@@ -10077,10 +10097,10 @@ const inputTypeConfig = {
     type: 'creditCards',
     getIconBase: () => '',
     getIconFilled: () => '',
-    shouldDecorate: (_input, _ref3) => {
+    shouldDecorate: (_input, _ref5) => {
       let {
         device
-      } = _ref3;
+      } = _ref5;
       return canBeDecorated(_input) && Boolean(device.settings.availableInputTypes.creditCards);
     },
     dataType: 'CreditCards',
@@ -10092,10 +10112,10 @@ const inputTypeConfig = {
     type: 'identities',
     getIconBase: getIdentitiesIcon,
     getIconFilled: getIdentitiesIcon,
-    shouldDecorate: (input, _ref4) => {
+    shouldDecorate: (input, _ref6) => {
       let {
         device
-      } = _ref4;
+      } = _ref6;
       if (!canBeDecorated(input)) return false;
       const subtype = (0, _matching.getInputSubtype)(input);
 
@@ -12847,7 +12867,8 @@ _defineProperty(Settings, "defaults", {
     emailProtection: false,
     inputType_identities: false,
     inputType_credentials: false,
-    inputType_creditCards: false
+    inputType_creditCards: false,
+    inlineIcon_credentials: false
   },
 
   /** @type {AvailableInputTypes} */
@@ -14722,7 +14743,8 @@ const autofillFeatureTogglesSchema = _zod.z.object({
   inputType_creditCards: _zod.z.boolean().optional(),
   emailProtection: _zod.z.boolean().optional(),
   password_generation: _zod.z.boolean().optional(),
-  credentials_saving: _zod.z.boolean().optional()
+  credentials_saving: _zod.z.boolean().optional(),
+  inlineIcon_credentials: _zod.z.boolean().optional()
 });
 
 exports.autofillFeatureTogglesSchema = autofillFeatureTogglesSchema;

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6367,13 +6367,33 @@ const inputTypeConfig = {
   /** @type {CredentialsInputTypeConfig} */
   credentials: {
     type: 'credentials',
-    getIconBase: () => ddgPasswordIcons.ddgPasswordIconBase,
-    getIconFilled: () => ddgPasswordIcons.ddgPasswordIconFilled,
-    shouldDecorate: (input, _ref2) => {
+    getIconBase: (_input, _ref2) => {
+      let {
+        device
+      } = _ref2;
+
+      if (device.settings.featureToggles.inlineIcon_credentials) {
+        return ddgPasswordIcons.ddgPasswordIconBase;
+      }
+
+      return '';
+    },
+    getIconFilled: (_input, _ref3) => {
+      let {
+        device
+      } = _ref3;
+
+      if (device.settings.featureToggles.inlineIcon_credentials) {
+        return ddgPasswordIcons.ddgPasswordIconFilled;
+      }
+
+      return '';
+    },
+    shouldDecorate: (input, _ref4) => {
       let {
         isLogin,
         device
-      } = _ref2;
+      } = _ref4;
 
       // if we are on a 'login' page, continue to use old logic, eg: just checking if there's a
       // saved password
@@ -6401,10 +6421,10 @@ const inputTypeConfig = {
     type: 'creditCards',
     getIconBase: () => '',
     getIconFilled: () => '',
-    shouldDecorate: (_input, _ref3) => {
+    shouldDecorate: (_input, _ref5) => {
       let {
         device
-      } = _ref3;
+      } = _ref5;
       return canBeDecorated(_input) && Boolean(device.settings.availableInputTypes.creditCards);
     },
     dataType: 'CreditCards',
@@ -6416,10 +6436,10 @@ const inputTypeConfig = {
     type: 'identities',
     getIconBase: getIdentitiesIcon,
     getIconFilled: getIdentitiesIcon,
-    shouldDecorate: (input, _ref4) => {
+    shouldDecorate: (input, _ref6) => {
       let {
         device
-      } = _ref4;
+      } = _ref6;
       if (!canBeDecorated(input)) return false;
       const subtype = (0, _matching.getInputSubtype)(input);
 
@@ -9171,7 +9191,8 @@ _defineProperty(Settings, "defaults", {
     emailProtection: false,
     inputType_identities: false,
     inputType_credentials: false,
-    inputType_creditCards: false
+    inputType_creditCards: false,
+    inlineIcon_credentials: false
   },
 
   /** @type {AvailableInputTypes} */

--- a/integration-test/helpers/mocks.android.js
+++ b/integration-test/helpers/mocks.android.js
@@ -40,6 +40,7 @@ export function androidStringReplacements (overrides = {}) {
                             emailProtection: true,
                             password_generation: false,
                             credentials_saving: true,
+                            inlineIcon_credentials: false,
                             ...overrides.featureToggles
                         }
                     }

--- a/integration-test/helpers/mocks.webkit.js
+++ b/integration-test/helpers/mocks.webkit.js
@@ -26,6 +26,7 @@ export const iosContentScopeReplacements = (overrides = {}) => {
                 autofill: {
                     settings: {
                         featureToggles: {
+                            inlineIcon_credentials: false,
                             ...overrides.featureToggles
                         }
                     }
@@ -68,6 +69,7 @@ export const macosContentScopeReplacements = (opts = {}) => {
                             emailProtection: true,
                             password_generation: true,
                             credentials_saving: true,
+                            inlineIcon_credentials: true,
                             ...featureToggles
                         }
                     }

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -145,8 +145,14 @@ export function loginPage (page, server, opts = {}) {
         async fieldsDoNotContainIcons () {
             const styles1 = await page.locator('#email').getAttribute('style')
             const styles2 = await page.locator('#password').getAttribute('style')
-            expect(styles1).toBeNull()
-            expect(styles2).toBeNull()
+            expect(styles1 || '').not.toContain('data:image/svg+xml;base64,')
+            expect(styles2 || '').not.toContain('data:image/svg+xml;base64,')
+        },
+        async fieldsContainIcons () {
+            const styles1 = await page.locator('#email').getAttribute('style')
+            const styles2 = await page.locator('#password').getAttribute('style')
+            expect(styles1).toContain('data:image/svg+xml;base64,')
+            expect(styles2).toContain('data:image/svg+xml;base64,')
         },
         /**
          * @param {string} username

--- a/integration-test/tests/login-form.ios.spec.js
+++ b/integration-test/tests/login-form.ios.spec.js
@@ -72,6 +72,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                 })
                 await login.promptWasShown('ios')
                 await login.assertFirstCredential(personalAddress, password)
+                await login.fieldsDoNotContainIcons()
             })
         })
         test.describe('but I dont have saved credentials', () => {

--- a/integration-test/tests/login-form.macos.spec.js
+++ b/integration-test/tests/login-form.macos.spec.js
@@ -116,6 +116,7 @@ test.describe('Auto-fill a login form on macOS', () => {
 
                 const login = loginPage(page, server)
                 await login.navigate()
+                await login.fieldsContainIcons()
                 await login.selectFirstCredential(personalAddress)
                 await login.assertFirstCredential(personalAddress, password)
             })

--- a/src/Form/inputTypeConfig.js
+++ b/src/Form/inputTypeConfig.js
@@ -36,8 +36,18 @@ const inputTypeConfig = {
     /** @type {CredentialsInputTypeConfig} */
     credentials: {
         type: 'credentials',
-        getIconBase: () => ddgPasswordIcons.ddgPasswordIconBase,
-        getIconFilled: () => ddgPasswordIcons.ddgPasswordIconFilled,
+        getIconBase: (_input, {device}) => {
+            if (device.settings.featureToggles.inlineIcon_credentials) {
+                return ddgPasswordIcons.ddgPasswordIconBase
+            }
+            return ''
+        },
+        getIconFilled: (_input, {device}) => {
+            if (device.settings.featureToggles.inlineIcon_credentials) {
+                return ddgPasswordIcons.ddgPasswordIconFilled
+            }
+            return ''
+        },
         shouldDecorate: (input, {isLogin, device}) => {
             // if we are on a 'login' page, continue to use old logic, eg: just checking if there's a
             // saved password

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -152,7 +152,8 @@ export class Settings {
             emailProtection: false,
             inputType_identities: false,
             inputType_credentials: false,
-            inputType_creditCards: false
+            inputType_creditCards: false,
+            inlineIcon_credentials: false
         },
         /** @type {AvailableInputTypes} */
         availableInputTypes: {

--- a/src/Settings.test.js
+++ b/src/Settings.test.js
@@ -57,6 +57,7 @@ describe('Settings', () => {
       {
         "credentials_saving": false,
         "emailProtection": false,
+        "inlineIcon_credentials": false,
         "inputType_credentials": false,
         "inputType_creditCards": false,
         "inputType_identities": false,

--- a/src/deviceApiCalls/__generated__/validators-ts.d.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.d.ts
@@ -17,6 +17,7 @@ export interface AutofillFeatureToggles {
   emailProtection?: boolean;
   password_generation?: boolean;
   credentials_saving?: boolean;
+  inlineIcon_credentials?: boolean;
 }
 
 // credentials.json

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -8,7 +8,8 @@ export const autofillFeatureTogglesSchema = z.object({
     inputType_creditCards: z.boolean().optional(),
     emailProtection: z.boolean().optional(),
     password_generation: z.boolean().optional(),
-    credentials_saving: z.boolean().optional()
+    credentials_saving: z.boolean().optional(),
+    inlineIcon_credentials: z.boolean().optional()
 });
 
 export const credentialsSchema = z.object({

--- a/src/deviceApiCalls/schemas/autofill-settings.json
+++ b/src/deviceApiCalls/schemas/autofill-settings.json
@@ -28,6 +28,9 @@
         },
         "credentials_saving": {
           "type": "boolean"
+        },
+        "inlineIcon_credentials": {
+          "type": "boolean"
         }
       },
       "required": []

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10043,13 +10043,33 @@ const inputTypeConfig = {
   /** @type {CredentialsInputTypeConfig} */
   credentials: {
     type: 'credentials',
-    getIconBase: () => ddgPasswordIcons.ddgPasswordIconBase,
-    getIconFilled: () => ddgPasswordIcons.ddgPasswordIconFilled,
-    shouldDecorate: (input, _ref2) => {
+    getIconBase: (_input, _ref2) => {
+      let {
+        device
+      } = _ref2;
+
+      if (device.settings.featureToggles.inlineIcon_credentials) {
+        return ddgPasswordIcons.ddgPasswordIconBase;
+      }
+
+      return '';
+    },
+    getIconFilled: (_input, _ref3) => {
+      let {
+        device
+      } = _ref3;
+
+      if (device.settings.featureToggles.inlineIcon_credentials) {
+        return ddgPasswordIcons.ddgPasswordIconFilled;
+      }
+
+      return '';
+    },
+    shouldDecorate: (input, _ref4) => {
       let {
         isLogin,
         device
-      } = _ref2;
+      } = _ref4;
 
       // if we are on a 'login' page, continue to use old logic, eg: just checking if there's a
       // saved password
@@ -10077,10 +10097,10 @@ const inputTypeConfig = {
     type: 'creditCards',
     getIconBase: () => '',
     getIconFilled: () => '',
-    shouldDecorate: (_input, _ref3) => {
+    shouldDecorate: (_input, _ref5) => {
       let {
         device
-      } = _ref3;
+      } = _ref5;
       return canBeDecorated(_input) && Boolean(device.settings.availableInputTypes.creditCards);
     },
     dataType: 'CreditCards',
@@ -10092,10 +10112,10 @@ const inputTypeConfig = {
     type: 'identities',
     getIconBase: getIdentitiesIcon,
     getIconFilled: getIdentitiesIcon,
-    shouldDecorate: (input, _ref4) => {
+    shouldDecorate: (input, _ref6) => {
       let {
         device
-      } = _ref4;
+      } = _ref6;
       if (!canBeDecorated(input)) return false;
       const subtype = (0, _matching.getInputSubtype)(input);
 
@@ -12847,7 +12867,8 @@ _defineProperty(Settings, "defaults", {
     emailProtection: false,
     inputType_identities: false,
     inputType_credentials: false,
-    inputType_creditCards: false
+    inputType_creditCards: false,
+    inlineIcon_credentials: false
   },
 
   /** @type {AvailableInputTypes} */
@@ -14722,7 +14743,8 @@ const autofillFeatureTogglesSchema = _zod.z.object({
   inputType_creditCards: _zod.z.boolean().optional(),
   emailProtection: _zod.z.boolean().optional(),
   password_generation: _zod.z.boolean().optional(),
-  credentials_saving: _zod.z.boolean().optional()
+  credentials_saving: _zod.z.boolean().optional(),
+  inlineIcon_credentials: _zod.z.boolean().optional()
 });
 
 exports.autofillFeatureTogglesSchema = autofillFeatureTogglesSchema;

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6367,13 +6367,33 @@ const inputTypeConfig = {
   /** @type {CredentialsInputTypeConfig} */
   credentials: {
     type: 'credentials',
-    getIconBase: () => ddgPasswordIcons.ddgPasswordIconBase,
-    getIconFilled: () => ddgPasswordIcons.ddgPasswordIconFilled,
-    shouldDecorate: (input, _ref2) => {
+    getIconBase: (_input, _ref2) => {
+      let {
+        device
+      } = _ref2;
+
+      if (device.settings.featureToggles.inlineIcon_credentials) {
+        return ddgPasswordIcons.ddgPasswordIconBase;
+      }
+
+      return '';
+    },
+    getIconFilled: (_input, _ref3) => {
+      let {
+        device
+      } = _ref3;
+
+      if (device.settings.featureToggles.inlineIcon_credentials) {
+        return ddgPasswordIcons.ddgPasswordIconFilled;
+      }
+
+      return '';
+    },
+    shouldDecorate: (input, _ref4) => {
       let {
         isLogin,
         device
-      } = _ref2;
+      } = _ref4;
 
       // if we are on a 'login' page, continue to use old logic, eg: just checking if there's a
       // saved password
@@ -6401,10 +6421,10 @@ const inputTypeConfig = {
     type: 'creditCards',
     getIconBase: () => '',
     getIconFilled: () => '',
-    shouldDecorate: (_input, _ref3) => {
+    shouldDecorate: (_input, _ref5) => {
       let {
         device
-      } = _ref3;
+      } = _ref5;
       return canBeDecorated(_input) && Boolean(device.settings.availableInputTypes.creditCards);
     },
     dataType: 'CreditCards',
@@ -6416,10 +6436,10 @@ const inputTypeConfig = {
     type: 'identities',
     getIconBase: getIdentitiesIcon,
     getIconFilled: getIdentitiesIcon,
-    shouldDecorate: (input, _ref4) => {
+    shouldDecorate: (input, _ref6) => {
       let {
         device
-      } = _ref4;
+      } = _ref6;
       if (!canBeDecorated(input)) return false;
       const subtype = (0, _matching.getInputSubtype)(input);
 
@@ -9171,7 +9191,8 @@ _defineProperty(Settings, "defaults", {
     emailProtection: false,
     inputType_identities: false,
     inputType_credentials: false,
-    inputType_creditCards: false
+    inputType_creditCards: false,
+    inlineIcon_credentials: false
   },
 
   /** @type {AvailableInputTypes} */


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/0/1202330323073689/f

## Description

This will only add the 'key' icon on platforms that explicitly opt-in.

To enable this, I already had my PRs merged to macOS, iOS + BSK.

This PR can only be merged following https://github.com/duckduckgo/duckduckgo-autofill/pull/170

## Steps to test

Ensure the icon **does** show on 

- macOS (develop)

Ensure the icon **does not** show on:

- iOS feature/autofillLogins+Keyboard

Other platforms do not support credentials yet anyway, so there's no need to test existing android, extension etc
