### PR TITLE
Catalina fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: npm install
-        run: "npm install"
+      - name: npm ci
+        run: "npm ci"
       - name: "Clean tree"
         run: "npm run test:clean-tree"
       - name: "ESLint"

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -13023,7 +13023,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  * @property {boolean} testMode
  * @property {string | null} [wrapperClass]
  * @property {(top: number, left: number) => string} [tooltipPositionClass]
- * @property {(details: {height: number, width: number}) => void} [setSize]
+ * @property {(details: {height: number, width: number}) => void} [setSize] - if this is set, it will be called initially once + every times the size changes
  * @property {() => void} remove
  * @property {string} css
  */
@@ -13033,9 +13033,7 @@ const defaultOptions = {
   wrapperClass: '',
   tooltipPositionClass: (top, left) => ".wrapper {transform: translate(".concat(left, "px, ").concat(top, "px);}"),
   css: "<style>".concat(_styles.CSS_STYLES, "</style>"),
-  setSize: () => {
-    /** noop */
-  },
+  setSize: undefined,
   remove: () => {
     /** noop */
   },
@@ -13229,8 +13227,7 @@ class HTMLTooltip {
   }
 
   setupSizeListener() {
-    if (typeof this.options.setSize !== 'function') return; // Listen to layout and paint changes to register the size
-
+    // Listen to layout and paint changes to register the size
     const observer = new PerformanceObserver(() => {
       this.setSize();
     });
@@ -13273,7 +13270,10 @@ class HTMLTooltip {
       capture: true
     });
     this.setSize();
-    this.setupSizeListener();
+
+    if (typeof this.options.setSize === 'function') {
+      this.setupSizeListener();
+    }
   }
 
 }

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -14086,10 +14086,16 @@ const wkSendAndWait = async function (handler) {
     const decrypted = await decrypt(cipher, key, iv);
     return _captureDdgGlobals.default.JSONparse(decrypted || '{}');
   } catch (e) {
-    console.error('decryption failed', e);
-    return {
-      error: e
-    };
+    // re-throw when the error is a 'MissingWebkitHandler'
+    if (e instanceof MissingWebkitHandler) {
+      throw e;
+    } else {
+      console.error('decryption failed', e);
+      console.error(e);
+      return {
+        error: e
+      };
+    }
   }
 };
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -10410,10 +10410,16 @@ const wkSendAndWait = async function (handler) {
     const decrypted = await decrypt(cipher, key, iv);
     return _captureDdgGlobals.default.JSONparse(decrypted || '{}');
   } catch (e) {
-    console.error('decryption failed', e);
-    return {
-      error: e
-    };
+    // re-throw when the error is a 'MissingWebkitHandler'
+    if (e instanceof MissingWebkitHandler) {
+      throw e;
+    } else {
+      console.error('decryption failed', e);
+      console.error(e);
+      return {
+        error: e
+      };
+    }
   }
 };
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -9347,7 +9347,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  * @property {boolean} testMode
  * @property {string | null} [wrapperClass]
  * @property {(top: number, left: number) => string} [tooltipPositionClass]
- * @property {(details: {height: number, width: number}) => void} [setSize]
+ * @property {(details: {height: number, width: number}) => void} [setSize] - if this is set, it will be called initially once + every times the size changes
  * @property {() => void} remove
  * @property {string} css
  */
@@ -9357,9 +9357,7 @@ const defaultOptions = {
   wrapperClass: '',
   tooltipPositionClass: (top, left) => ".wrapper {transform: translate(".concat(left, "px, ").concat(top, "px);}"),
   css: "<style>".concat(_styles.CSS_STYLES, "</style>"),
-  setSize: () => {
-    /** noop */
-  },
+  setSize: undefined,
   remove: () => {
     /** noop */
   },
@@ -9553,8 +9551,7 @@ class HTMLTooltip {
   }
 
   setupSizeListener() {
-    if (typeof this.options.setSize !== 'function') return; // Listen to layout and paint changes to register the size
-
+    // Listen to layout and paint changes to register the size
     const observer = new PerformanceObserver(() => {
       this.setSize();
     });
@@ -9597,7 +9594,10 @@ class HTMLTooltip {
       capture: true
     });
     this.setSize();
-    this.setupSizeListener();
+
+    if (typeof this.options.setSize === 'function') {
+      this.setupSizeListener();
+    }
   }
 
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -68,13 +68,5 @@ function setupIntersectionObserverMock ({
         configurable: true,
         value: MockIntersectionObserver
     })
-
-    Object.defineProperty(global, 'ResizeObserver', {
-        writable: true,
-        configurable: true,
-        value: class MockResizeObserver {
-            observe () {}
-        }
-    })
 }
 setupIntersectionObserverMock()

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -68,5 +68,13 @@ function setupIntersectionObserverMock ({
         configurable: true,
         value: MockIntersectionObserver
     })
+
+    Object.defineProperty(global, 'ResizeObserver', {
+        writable: true,
+        configurable: true,
+        value: class MockResizeObserver {
+            observe () {}
+        }
+    })
 }
 setupIntersectionObserverMock()

--- a/src/UI/HTMLTooltip.js
+++ b/src/UI/HTMLTooltip.js
@@ -7,7 +7,7 @@ import {CSS_STYLES} from './styles/styles'
  * @property {boolean} testMode
  * @property {string | null} [wrapperClass]
  * @property {(top: number, left: number) => string} [tooltipPositionClass]
- * @property {(details: {height: number, width: number}) => void} [setSize]
+ * @property {(details: {height: number, width: number}) => void} [setSize] - if this is set, it will be called initially once + every times the size changes
  * @property {() => void} remove
  * @property {string} css
  */
@@ -17,7 +17,7 @@ export const defaultOptions = {
     wrapperClass: '',
     tooltipPositionClass: (top, left) => `.wrapper {transform: translate(${left}px, ${top}px);}`,
     css: `<style>${CSS_STYLES}</style>`,
-    setSize: () => { /** noop */ },
+    setSize: undefined,
     remove: () => { /** noop */ },
     testMode: false
 }
@@ -172,7 +172,6 @@ export class HTMLTooltip {
         }
     }
     setupSizeListener () {
-        if (typeof this.options.setSize !== 'function') return
         // Listen to layout and paint changes to register the size
         const observer = new PerformanceObserver(() => {
             this.setSize()
@@ -203,7 +202,9 @@ export class HTMLTooltip {
         window.addEventListener('scroll', this, {capture: true})
         this.setSize()
 
-        this.setupSizeListener()
+        if (typeof this.options.setSize === 'function') {
+            this.setupSizeListener()
+        }
     }
 }
 

--- a/src/UI/HTMLTooltip.test.js
+++ b/src/UI/HTMLTooltip.test.js
@@ -2,6 +2,22 @@ import HTMLTooltip, {defaultOptions} from './HTMLTooltip'
 import {getInputConfigFromType} from '../Form/inputTypeConfig'
 
 describe('HTMLTooltip', () => {
+    let o1 = global.ResizeObserver
+    let o2 = global.MutationObserver
+    beforeEach(() => {
+        // @ts-ignore
+        global.ResizeObserver = class ResizeObserver {
+            observe () {}
+        }
+        // @ts-ignore
+        global.MutationObserver = class MutationObserver {
+            observe () {}
+        }
+    })
+    afterEach(() => {
+        global.ResizeObserver = o1
+        global.MutationObserver = o2
+    })
     /**
      * This test ensures that `setupSizeListener` is not called if the platform
      * in question cannot use PerformanceObserver with {entryTypes: ['layout-shift', 'paint']}

--- a/src/UI/HTMLTooltip.test.js
+++ b/src/UI/HTMLTooltip.test.js
@@ -1,0 +1,24 @@
+import HTMLTooltip, {defaultOptions} from './HTMLTooltip'
+import {getInputConfigFromType} from '../Form/inputTypeConfig'
+
+describe('HTMLTooltip', () => {
+    /**
+     * This test ensures that `setupSizeListener` is not called if the platform
+     * in question cannot use PerformanceObserver with {entryTypes: ['layout-shift', 'paint']}
+     *
+     * A bug occurred because those parameters are not valid for PerformanceObserver on macOS Catalina
+     *  - so this test ensures that `setupSizeListener` is NOT called when default options are used.
+     *
+     * on macOS/Windows when operating in a top-frame scenario, those both **can** support the arguments
+     * above so they will each provide their own callback for setSize.
+     *
+     * @link {https://app.asana.com/0/1177771139624306/1202412384393015/f}
+     */
+    it('works with default values', () => {
+        const config = getInputConfigFromType('credentials')
+        const tooltip = new HTMLTooltip(config, 'credentials.username', () => {}, defaultOptions)
+        const spy = jest.spyOn(tooltip, 'setupSizeListener')
+        tooltip.init()
+        expect(spy).not.toHaveBeenCalled()
+    })
+})

--- a/src/appleDeviceUtils/appleDeviceUtils.js
+++ b/src/appleDeviceUtils/appleDeviceUtils.js
@@ -65,8 +65,14 @@ const wkSendAndWait = async (handler, data = {}, opts = {}) => {
         const decrypted = await decrypt(cipher, key, iv)
         return ddgGlobals.JSONparse(decrypted || '{}')
     } catch (e) {
-        console.error('decryption failed', e)
-        return {error: e}
+        // re-throw when the error is a 'MissingWebkitHandler'
+        if (e instanceof MissingWebkitHandler) {
+            throw e
+        } else {
+            console.error('decryption failed', e)
+            console.error(e)
+            return { error: e }
+        }
     }
 }
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -13023,7 +13023,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  * @property {boolean} testMode
  * @property {string | null} [wrapperClass]
  * @property {(top: number, left: number) => string} [tooltipPositionClass]
- * @property {(details: {height: number, width: number}) => void} [setSize]
+ * @property {(details: {height: number, width: number}) => void} [setSize] - if this is set, it will be called initially once + every times the size changes
  * @property {() => void} remove
  * @property {string} css
  */
@@ -13033,9 +13033,7 @@ const defaultOptions = {
   wrapperClass: '',
   tooltipPositionClass: (top, left) => ".wrapper {transform: translate(".concat(left, "px, ").concat(top, "px);}"),
   css: "<style>".concat(_styles.CSS_STYLES, "</style>"),
-  setSize: () => {
-    /** noop */
-  },
+  setSize: undefined,
   remove: () => {
     /** noop */
   },
@@ -13229,8 +13227,7 @@ class HTMLTooltip {
   }
 
   setupSizeListener() {
-    if (typeof this.options.setSize !== 'function') return; // Listen to layout and paint changes to register the size
-
+    // Listen to layout and paint changes to register the size
     const observer = new PerformanceObserver(() => {
       this.setSize();
     });
@@ -13273,7 +13270,10 @@ class HTMLTooltip {
       capture: true
     });
     this.setSize();
-    this.setupSizeListener();
+
+    if (typeof this.options.setSize === 'function') {
+      this.setupSizeListener();
+    }
   }
 
 }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -14086,10 +14086,16 @@ const wkSendAndWait = async function (handler) {
     const decrypted = await decrypt(cipher, key, iv);
     return _captureDdgGlobals.default.JSONparse(decrypted || '{}');
   } catch (e) {
-    console.error('decryption failed', e);
-    return {
-      error: e
-    };
+    // re-throw when the error is a 'MissingWebkitHandler'
+    if (e instanceof MissingWebkitHandler) {
+      throw e;
+    } else {
+      console.error('decryption failed', e);
+      console.error(e);
+      return {
+        error: e
+      };
+    }
   }
 };
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -10410,10 +10410,16 @@ const wkSendAndWait = async function (handler) {
     const decrypted = await decrypt(cipher, key, iv);
     return _captureDdgGlobals.default.JSONparse(decrypted || '{}');
   } catch (e) {
-    console.error('decryption failed', e);
-    return {
-      error: e
-    };
+    // re-throw when the error is a 'MissingWebkitHandler'
+    if (e instanceof MissingWebkitHandler) {
+      throw e;
+    } else {
+      console.error('decryption failed', e);
+      console.error(e);
+      return {
+        error: e
+      };
+    }
   }
 };
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -9347,7 +9347,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  * @property {boolean} testMode
  * @property {string | null} [wrapperClass]
  * @property {(top: number, left: number) => string} [tooltipPositionClass]
- * @property {(details: {height: number, width: number}) => void} [setSize]
+ * @property {(details: {height: number, width: number}) => void} [setSize] - if this is set, it will be called initially once + every times the size changes
  * @property {() => void} remove
  * @property {string} css
  */
@@ -9357,9 +9357,7 @@ const defaultOptions = {
   wrapperClass: '',
   tooltipPositionClass: (top, left) => ".wrapper {transform: translate(".concat(left, "px, ").concat(top, "px);}"),
   css: "<style>".concat(_styles.CSS_STYLES, "</style>"),
-  setSize: () => {
-    /** noop */
-  },
+  setSize: undefined,
   remove: () => {
     /** noop */
   },
@@ -9553,8 +9551,7 @@ class HTMLTooltip {
   }
 
   setupSizeListener() {
-    if (typeof this.options.setSize !== 'function') return; // Listen to layout and paint changes to register the size
-
+    // Listen to layout and paint changes to register the size
     const observer = new PerformanceObserver(() => {
       this.setSize();
     });
@@ -9597,7 +9594,10 @@ class HTMLTooltip {
       capture: true
     });
     this.setSize();
-    this.setupSizeListener();
+
+    if (typeof this.options.setSize === 'function') {
+      this.setupSizeListener();
+    }
   }
 
 }


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1177771139624306/1202412384393015/f

## Description

2 fixes

1) ensure `setSize` defaults to undefined 469cac03

This bug was introduced with recent changes - on Catalina we attempt to execute the following code when the HTMLTooltip starts 

```js
const observer = new PerformanceObserver(() => {
    this.setSize()
})
observer.observe({entryTypes: ['layout-shift', 'paint']})
```

The problem is that the params `{entryTypes: ['layout-shift', 'paint']}` are not valid on Catalina - it was throwing an exception preventing autofill from working. 

On Catalina, this should of never been executed in the first place, so now we ensure `setSize` is defaulted to `undefined` and only top-frame scenarios will opt-in to that size listener

---

2) fix: re-throw WebkitHandlerNotFound f965f949

Also found when testing the upcoming release: something that only affects Catalina. Our error handling logic now makes a distinction between missing webkit handlers (to aid in platforms upgrading) - so this change ensures that we propagate those errors correctly when we're in a Catalina environment

## Steps to test

Any Autofill scenario on Catalina is enough to test this