### PR TITLE
fix(email): on Android + DDG domains, always use the EmailInterface t…

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -6589,13 +6589,16 @@ class AndroidInterface extends _InterfacePrototype.default {
   isDeviceSignedIn() {
     var _this$globalConfig$av;
 
-    // if availableInputTypes are available, use .email first, whether true or false
+    // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
+    if (this.globalConfig.isDDGDomain) {
+      return window.EmailInterface.isSignedIn() === 'true';
+    } // on none-DDG domains, where `availableInputTypes.email` is present, use it
+
+
     if (typeof ((_this$globalConfig$av = this.globalConfig.availableInputTypes) === null || _this$globalConfig$av === void 0 ? void 0 : _this$globalConfig$av.email) === 'boolean') {
       return this.globalConfig.availableInputTypes.email;
-    } // isDeviceSignedIn is only available on DDG domains...
+    } // ...on other domains we assume true because the script wouldn't exist otherwise
 
-
-    if (this.globalConfig.isDDGDomain) return window.EmailInterface.isSignedIn() === 'true'; // ...on other domains we assume true because the script wouldn't exist otherwise
 
     return true;
   }
@@ -14971,6 +14974,18 @@ class AndroidTransport extends _deviceApi.DeviceApiTransport {
     _defineProperty(this, "config", void 0);
 
     this.config = globalConfig;
+
+    if (this.config.isDDGTestMode) {
+      var _window$BrowserAutofi, _window$BrowserAutofi2;
+
+      if (typeof ((_window$BrowserAutofi = window.BrowserAutofill) === null || _window$BrowserAutofi === void 0 ? void 0 : _window$BrowserAutofi.getAutofillData) !== 'function') {
+        throw new Error('window.BrowserAutofill.getAutofillData missing');
+      }
+
+      if (typeof ((_window$BrowserAutofi2 = window.BrowserAutofill) === null || _window$BrowserAutofi2 === void 0 ? void 0 : _window$BrowserAutofi2.storeFormData) !== 'function') {
+        throw new Error('window.BrowserAutofill.storeFormData missing');
+      }
+    }
   }
   /**
    * @param {import("../../../packages/device-api").DeviceApiCall} deviceApiCall

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -6592,7 +6592,7 @@ class AndroidInterface extends _InterfacePrototype.default {
     // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
     if (this.globalConfig.isDDGDomain) {
       return window.EmailInterface.isSignedIn() === 'true';
-    } // on none-DDG domains, where `availableInputTypes.email` is present, use it
+    } // on non-DDG domains, where `availableInputTypes.email` is present, use it
 
 
     if (typeof ((_this$globalConfig$av = this.globalConfig.availableInputTypes) === null || _this$globalConfig$av === void 0 ? void 0 : _this$globalConfig$av.email) === 'boolean') {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -2913,13 +2913,16 @@ class AndroidInterface extends _InterfacePrototype.default {
   isDeviceSignedIn() {
     var _this$globalConfig$av;
 
-    // if availableInputTypes are available, use .email first, whether true or false
+    // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
+    if (this.globalConfig.isDDGDomain) {
+      return window.EmailInterface.isSignedIn() === 'true';
+    } // on none-DDG domains, where `availableInputTypes.email` is present, use it
+
+
     if (typeof ((_this$globalConfig$av = this.globalConfig.availableInputTypes) === null || _this$globalConfig$av === void 0 ? void 0 : _this$globalConfig$av.email) === 'boolean') {
       return this.globalConfig.availableInputTypes.email;
-    } // isDeviceSignedIn is only available on DDG domains...
+    } // ...on other domains we assume true because the script wouldn't exist otherwise
 
-
-    if (this.globalConfig.isDDGDomain) return window.EmailInterface.isSignedIn() === 'true'; // ...on other domains we assume true because the script wouldn't exist otherwise
 
     return true;
   }
@@ -11180,6 +11183,18 @@ class AndroidTransport extends _deviceApi.DeviceApiTransport {
     _defineProperty(this, "config", void 0);
 
     this.config = globalConfig;
+
+    if (this.config.isDDGTestMode) {
+      var _window$BrowserAutofi, _window$BrowserAutofi2;
+
+      if (typeof ((_window$BrowserAutofi = window.BrowserAutofill) === null || _window$BrowserAutofi === void 0 ? void 0 : _window$BrowserAutofi.getAutofillData) !== 'function') {
+        throw new Error('window.BrowserAutofill.getAutofillData missing');
+      }
+
+      if (typeof ((_window$BrowserAutofi2 = window.BrowserAutofill) === null || _window$BrowserAutofi2 === void 0 ? void 0 : _window$BrowserAutofi2.storeFormData) !== 'function') {
+        throw new Error('window.BrowserAutofill.storeFormData missing');
+      }
+    }
   }
   /**
    * @param {import("../../../packages/device-api").DeviceApiCall} deviceApiCall

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -2916,7 +2916,7 @@ class AndroidInterface extends _InterfacePrototype.default {
     // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
     if (this.globalConfig.isDDGDomain) {
       return window.EmailInterface.isSignedIn() === 'true';
-    } // on none-DDG domains, where `availableInputTypes.email` is present, use it
+    } // on non-DDG domains, where `availableInputTypes.email` is present, use it
 
 
     if (typeof ((_this$globalConfig$av = this.globalConfig.availableInputTypes) === null || _this$globalConfig$av === void 0 ? void 0 : _this$globalConfig$av.email) === 'boolean') {

--- a/src/DeviceInterface/AndroidInterface.js
+++ b/src/DeviceInterface/AndroidInterface.js
@@ -27,12 +27,15 @@ class AndroidInterface extends InterfacePrototype {
      * @returns {boolean}
      */
     isDeviceSignedIn () {
-        // if availableInputTypes are available, use .email first, whether true or false
+        // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
+        if (this.globalConfig.isDDGDomain) {
+            return window.EmailInterface.isSignedIn() === 'true'
+        }
+
+        // on none-DDG domains, where `availableInputTypes.email` is present, use it
         if (typeof this.globalConfig.availableInputTypes?.email === 'boolean') {
             return this.globalConfig.availableInputTypes.email
         }
-        // isDeviceSignedIn is only available on DDG domains...
-        if (this.globalConfig.isDDGDomain) return window.EmailInterface.isSignedIn() === 'true'
 
         // ...on other domains we assume true because the script wouldn't exist otherwise
         return true
@@ -46,7 +49,6 @@ class AndroidInterface extends InterfacePrototype {
         const cleanup = this.scanner.init()
         this.addLogoutListener(cleanup)
     }
-
     /**
      * Used by the email web app
      * Settings page displays data of the logged in user data

--- a/src/DeviceInterface/AndroidInterface.js
+++ b/src/DeviceInterface/AndroidInterface.js
@@ -32,7 +32,7 @@ class AndroidInterface extends InterfacePrototype {
             return window.EmailInterface.isSignedIn() === 'true'
         }
 
-        // on none-DDG domains, where `availableInputTypes.email` is present, use it
+        // on non-DDG domains, where `availableInputTypes.email` is present, use it
         if (typeof this.globalConfig.availableInputTypes?.email === 'boolean') {
             return this.globalConfig.availableInputTypes.email
         }

--- a/src/deviceApiCalls/transports/android.transport.js
+++ b/src/deviceApiCalls/transports/android.transport.js
@@ -14,6 +14,15 @@ export class AndroidTransport extends DeviceApiTransport {
     constructor (globalConfig) {
         super()
         this.config = globalConfig
+
+        if (this.config.isDDGTestMode) {
+            if (typeof window.BrowserAutofill?.getAutofillData !== 'function') {
+                throw new Error('window.BrowserAutofill.getAutofillData missing')
+            }
+            if (typeof window.BrowserAutofill?.storeFormData !== 'function') {
+                throw new Error('window.BrowserAutofill.storeFormData missing')
+            }
+        }
     }
     /**
      * @param {import("../../../packages/device-api").DeviceApiCall} deviceApiCall

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -6589,13 +6589,16 @@ class AndroidInterface extends _InterfacePrototype.default {
   isDeviceSignedIn() {
     var _this$globalConfig$av;
 
-    // if availableInputTypes are available, use .email first, whether true or false
+    // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
+    if (this.globalConfig.isDDGDomain) {
+      return window.EmailInterface.isSignedIn() === 'true';
+    } // on none-DDG domains, where `availableInputTypes.email` is present, use it
+
+
     if (typeof ((_this$globalConfig$av = this.globalConfig.availableInputTypes) === null || _this$globalConfig$av === void 0 ? void 0 : _this$globalConfig$av.email) === 'boolean') {
       return this.globalConfig.availableInputTypes.email;
-    } // isDeviceSignedIn is only available on DDG domains...
+    } // ...on other domains we assume true because the script wouldn't exist otherwise
 
-
-    if (this.globalConfig.isDDGDomain) return window.EmailInterface.isSignedIn() === 'true'; // ...on other domains we assume true because the script wouldn't exist otherwise
 
     return true;
   }
@@ -14971,6 +14974,18 @@ class AndroidTransport extends _deviceApi.DeviceApiTransport {
     _defineProperty(this, "config", void 0);
 
     this.config = globalConfig;
+
+    if (this.config.isDDGTestMode) {
+      var _window$BrowserAutofi, _window$BrowserAutofi2;
+
+      if (typeof ((_window$BrowserAutofi = window.BrowserAutofill) === null || _window$BrowserAutofi === void 0 ? void 0 : _window$BrowserAutofi.getAutofillData) !== 'function') {
+        throw new Error('window.BrowserAutofill.getAutofillData missing');
+      }
+
+      if (typeof ((_window$BrowserAutofi2 = window.BrowserAutofill) === null || _window$BrowserAutofi2 === void 0 ? void 0 : _window$BrowserAutofi2.storeFormData) !== 'function') {
+        throw new Error('window.BrowserAutofill.storeFormData missing');
+      }
+    }
   }
   /**
    * @param {import("../../../packages/device-api").DeviceApiCall} deviceApiCall

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -6592,7 +6592,7 @@ class AndroidInterface extends _InterfacePrototype.default {
     // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
     if (this.globalConfig.isDDGDomain) {
       return window.EmailInterface.isSignedIn() === 'true';
-    } // on none-DDG domains, where `availableInputTypes.email` is present, use it
+    } // on non-DDG domains, where `availableInputTypes.email` is present, use it
 
 
     if (typeof ((_this$globalConfig$av = this.globalConfig.availableInputTypes) === null || _this$globalConfig$av === void 0 ? void 0 : _this$globalConfig$av.email) === 'boolean') {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -2913,13 +2913,16 @@ class AndroidInterface extends _InterfacePrototype.default {
   isDeviceSignedIn() {
     var _this$globalConfig$av;
 
-    // if availableInputTypes are available, use .email first, whether true or false
+    // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
+    if (this.globalConfig.isDDGDomain) {
+      return window.EmailInterface.isSignedIn() === 'true';
+    } // on none-DDG domains, where `availableInputTypes.email` is present, use it
+
+
     if (typeof ((_this$globalConfig$av = this.globalConfig.availableInputTypes) === null || _this$globalConfig$av === void 0 ? void 0 : _this$globalConfig$av.email) === 'boolean') {
       return this.globalConfig.availableInputTypes.email;
-    } // isDeviceSignedIn is only available on DDG domains...
+    } // ...on other domains we assume true because the script wouldn't exist otherwise
 
-
-    if (this.globalConfig.isDDGDomain) return window.EmailInterface.isSignedIn() === 'true'; // ...on other domains we assume true because the script wouldn't exist otherwise
 
     return true;
   }
@@ -11180,6 +11183,18 @@ class AndroidTransport extends _deviceApi.DeviceApiTransport {
     _defineProperty(this, "config", void 0);
 
     this.config = globalConfig;
+
+    if (this.config.isDDGTestMode) {
+      var _window$BrowserAutofi, _window$BrowserAutofi2;
+
+      if (typeof ((_window$BrowserAutofi = window.BrowserAutofill) === null || _window$BrowserAutofi === void 0 ? void 0 : _window$BrowserAutofi.getAutofillData) !== 'function') {
+        throw new Error('window.BrowserAutofill.getAutofillData missing');
+      }
+
+      if (typeof ((_window$BrowserAutofi2 = window.BrowserAutofill) === null || _window$BrowserAutofi2 === void 0 ? void 0 : _window$BrowserAutofi2.storeFormData) !== 'function') {
+        throw new Error('window.BrowserAutofill.storeFormData missing');
+      }
+    }
   }
   /**
    * @param {import("../../../packages/device-api").DeviceApiCall} deviceApiCall

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -2916,7 +2916,7 @@ class AndroidInterface extends _InterfacePrototype.default {
     // on DDG domains, always check via `window.EmailInterface.isSignedIn()`
     if (this.globalConfig.isDDGDomain) {
       return window.EmailInterface.isSignedIn() === 'true';
-    } // on none-DDG domains, where `availableInputTypes.email` is present, use it
+    } // on non-DDG domains, where `availableInputTypes.email` is present, use it
 
 
     if (typeof ((_this$globalConfig$av = this.globalConfig.availableInputTypes) === null || _this$globalConfig$av === void 0 ? void 0 : _this$globalConfig$av.email) === 'boolean') {


### PR DESCRIPTION
…o determine if logged in.

**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/0/1202528058497226/f

## Description

This ensures we always ask the device (on Android) for email status when on DDG domains. This is not affecting anything in production but is an urgent requirement for an internal build of Logins+ on Android.

## Steps to test

Tested manually with Craig (Android team) - there are no automated tests covering this (yet)