### PR TITLE
Ever more fixes

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4569,10 +4569,11 @@ class InterfacePrototype {
     if (!matchingForm) {
       var _event$target;
 
-      // check if the click happened on a button
+      const selector = _selectorsCss.SUBMIT_BUTTON_SELECTOR + ', a[href="#"], a[href^=javascript], *[onclick]'; // check if the click happened on a button
+
       const button =
       /** @type HTMLElement */
-      (_event$target = event.target) === null || _event$target === void 0 ? void 0 : _event$target.closest(_selectorsCss.SUBMIT_BUTTON_SELECTOR);
+      (_event$target = event.target) === null || _event$target === void 0 ? void 0 : _event$target.closest(selector);
       if (!button) return;
       const text = (0, _matching.removeExcessWhitespace)(button === null || button === void 0 ? void 0 : button.textContent);
       const hasRelevantText = /(log|sign).?(in|up)|continue|next|submit/i.test(text);
@@ -4787,6 +4788,19 @@ class Form {
 
       if (probableField !== null && probableField !== void 0 && probableField.value) {
         formValues.credentials.username = probableField.value;
+      } else {
+        // If we still don't have a username, try scanning the form's text for an email address
+        this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
+          var _elText$match;
+
+          const elText = (0, _autofillUtils.getText)(el);
+          const emailOrUsername = (_elText$match = elText.match( // https://www.emailregex.com/
+          /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/)) === null || _elText$match === void 0 ? void 0 : _elText$match[0];
+
+          if (emailOrUsername) {
+            formValues.credentials.username = emailOrUsername;
+          }
+        });
       }
     }
 
@@ -4933,14 +4947,6 @@ class Form {
     this.inputs[mainInputType].add(input);
     this.decorateInput(input);
     return this;
-  }
-
-  areAllInputsEmpty(inputType) {
-    let allEmpty = true;
-    this.execOnInputs(input => {
-      if (input.value) allEmpty = false;
-    }, inputType);
-    return allEmpty;
   }
 
   addListener(el, type, fn) {
@@ -5282,20 +5288,8 @@ class FormAnalyzer {
     });
   }
 
-  elementIs(el, type) {
-    return el.nodeName.toLowerCase() === type.toLowerCase();
-  }
-
-  getText(el) {
-    // for buttons, we don't care about descendants, just get the whole text as is
-    // this is important in order to give proper attribution of the text to the button
-    if (this.elementIs(el, 'BUTTON')) return (0, _matching.removeExcessWhitespace)(el.textContent);
-    if (this.elementIs(el, 'INPUT') && ['submit', 'button'].includes(el.type)) return el.value;
-    return (0, _matching.removeExcessWhitespace)(Array.from(el.childNodes).reduce((text, child) => this.elementIs(child, '#text') ? text + ' ' + child.textContent : text, ''));
-  }
-
   evaluateElement(el) {
-    const string = this.getText(el);
+    const string = (0, _autofillUtils.getText)(el);
 
     if (el.matches(this.matching.cssSelector('password'))) {
       // These are explicit signals by the web author, so we weigh them heavily
@@ -5318,7 +5312,7 @@ class FormAnalyzer {
     } // if a link points to relevant urls or contain contents outside the page…
 
 
-    if (this.elementIs(el, 'A') && el.href && el.href !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]')) {
+    if (el instanceof HTMLAnchorElement && el.href && el.href !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]')) {
       // …and matches one of the regexes, we assume the match is not pertinent to the current form
       this.updateSignal({
         string,
@@ -5348,7 +5342,7 @@ class FormAnalyzer {
 
     this.evaluateElAttributes(this.form); // Check form contents (skip select and option because they contain too much noise)
 
-    this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
+    this.form.querySelectorAll('*:not(select):not(option):not(script)').forEach(el => {
       // Check if element is not hidden. Note that we can't use offsetHeight
       // nor intersectionObserver, because the element could be outside the
       // viewport or its parent hidden
@@ -9833,18 +9827,23 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
   _attachListeners() {
     window.addEventListener('input', this);
-    window.addEventListener('keydown', this);
+    window.addEventListener('keydown', this, true);
   }
 
   _removeListeners() {
     window.removeEventListener('input', this);
-    window.removeEventListener('keydown', this);
+    window.removeEventListener('keydown', this, true);
   }
 
   handleEvent(event) {
     switch (event.type) {
       case 'keydown':
         if (['Escape', 'Tab', 'Enter'].includes(event.code)) {
+          if (event.code === 'Escape') {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+
           this.removeTooltip();
         }
 
@@ -10218,13 +10217,13 @@ class OverlayUIController extends _UIController.UIController {
 
   _attachListeners() {
     window.addEventListener('scroll', this);
-    window.addEventListener('keydown', this);
+    window.addEventListener('keydown', this, true);
     window.addEventListener('input', this);
   }
 
   _removeListeners() {
     window.removeEventListener('scroll', this);
-    window.removeEventListener('keydown', this);
+    window.removeEventListener('keydown', this, true);
     window.removeEventListener('input', this);
   }
 
@@ -10239,6 +10238,11 @@ class OverlayUIController extends _UIController.UIController {
       case 'keydown':
         {
           if (['Escape', 'Tab', 'Enter'].includes(event.code)) {
+            if (event.code === 'Escape') {
+              event.preventDefault();
+              event.stopImmediatePropagation();
+            }
+
             this.removeTooltip(event.type);
           }
 
@@ -10625,7 +10629,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.buttonMatchesFormType = exports.autofillEnabled = exports.addInlineStyles = exports.SIGN_IN_MSG = exports.ADDRESS_DOMAIN = void 0;
 exports.escapeXML = escapeXML;
-exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
+exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
 
 var _matching = require("./Form/matching.js");
 
@@ -10986,7 +10990,7 @@ const isLikelyASubmitButton = el => {
   return (el.getAttribute('type') === 'submit' || // is explicitly set as "submit"
   /primary|submit/i.test(el.className) || // has high-signal submit classes
   SUBMIT_BUTTON_REGEX.test(contentExcludingLabel) || // has high-signal text
-  el.offsetHeight * el.offsetWidth >= 10000) && // it's a large element, at least 250x40px
+  el.offsetHeight * el.offsetWidth >= 10000 && !/secondary/i.test(el.className)) && // it's a large element 250x40px
   !SUBMIT_BUTTON_UNLIKELY_REGEX.test(contentExcludingLabel + ' ' + ariaLabel);
 };
 /**
@@ -11007,8 +11011,24 @@ const buttonMatchesFormType = (el, formObj) => {
     return true;
   }
 };
+/**
+ * Get the text of an element
+ * @param {Element} el
+ * @returns {string}
+ */
+
 
 exports.buttonMatchesFormType = buttonMatchesFormType;
+
+const getText = el => {
+  // for buttons, we don't care about descendants, just get the whole text as is
+  // this is important in order to give proper attribution of the text to the button
+  if (el instanceof HTMLButtonElement) return (0, _matching.removeExcessWhitespace)(el.textContent);
+  if (el instanceof HTMLInputElement && ['submit', 'button'].includes(el.type)) return el.value;
+  return (0, _matching.removeExcessWhitespace)(Array.from(el.childNodes).reduce((text, child) => child instanceof Text ? text + ' ' + child.textContent : text, ''));
+};
+
+exports.getText = getText;
 
 },{"./Form/matching.js":26}],47:[function(require,module,exports){
 "use strict";

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -7,7 +7,8 @@ export const constants = {
         'email-autofill': 'email-autofill.html',
         'signup': 'signup.html',
         'login': 'login.html',
-        'loginWithPoorForm': 'login-poor-form.html'
+        'loginWithPoorForm': 'login-poor-form.html',
+        'loginWithFormInModal': 'login-in-modal.html'
     },
     fields: {
         email: {

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -338,6 +338,42 @@ export function loginPageWithPoorForm (page, server, opts) {
 }
 
 /**
+ * A wrapper around interactions for `integration-test/pages/login-in-modal.html`
+ *
+ * @param {import("playwright").Page} page
+ * @param {ServerWrapper} server
+ * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
+ */
+export function loginPageWithFormInModal (page, server, opts) {
+    const originalLoginPage = loginPage(page, server, opts)
+    return {
+        ...originalLoginPage,
+        async navigate () {
+            await page.goto(server.urlForPath(constants.pages['loginWithFormInModal']))
+        },
+        async openDialog () {
+            const button = await page.waitForSelector(`button:has-text("Click here to Login")`)
+            await button.click({ force: true })
+            await this.assertDialogOpen()
+        },
+        async assertDialogClose () {
+            const form = await page.locator('#login')
+            await expect(form).toBeHidden()
+        },
+        async assertDialogOpen () {
+            const form = await page.locator('#login')
+            await expect(form).toBeVisible()
+        },
+        async hitEscapeKey () {
+            await page.press('#login', 'Escape')
+        },
+        async clickOutsideTheDialog () {
+            await page.click('#random-text')
+        }
+    }
+}
+
+/**
  * A wrapper around interactions for `integration-test/pages/email-autofill.html`
  *
  * @param {import("playwright").Page} page

--- a/integration-test/pages/index.html
+++ b/integration-test/pages/index.html
@@ -11,7 +11,8 @@
 <ul>
     <li><a href="email-autofill.html">email-autofill.html</a></li>
     <li><a href="login.html">login.html</a></li>
-    <li><a href="poor-form.html">poor-form.html</a></li>
+    <li><a href="login-in-modal.html">login-in-modal.html</a></li>
+    <li><a href="login-poor-form.html">login-poor-form.html</a></li>
     <li><a href="signup.html">signup.html</a></li>
 </ul>
 </body>

--- a/integration-test/pages/login-in-modal.html
+++ b/integration-test/pages/login-in-modal.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Login form</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+
+<body>
+<p><a href="../index.html">[Home]</a></p>
+
+<p id="demo"><button type="button" id="open-modal">Click here to login</button></p>
+
+<p id="random-text">Some random text to use as "something outside the dialog element". Clicking here should close the dialog (if open).</p>
+
+<div class="dialog" hidden>
+  <form action="/login" id="login">
+    <h2>Log in</h2>
+    <fieldset>
+      <label for="email">Email</label>
+      <input id="email" type="email">
+      <label for="password">Password</label>
+      <input id="password" type="password">
+      <button type="submit">Log in</button>
+    </fieldset>
+  </form>
+</div>
+<script type="module">
+  const openModalBtn = document.getElementById('open-modal')
+  const dialogEl = document.querySelector('.dialog')
+  openModalBtn.addEventListener('click', () => {
+    dialogEl.removeAttribute('hidden')
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {dialogEl.setAttribute('hidden', ''), {once: true}}
+    })
+    window.addEventListener('pointerdown', (e) => {
+      if (!dialogEl.contains(e.target)) {dialogEl.setAttribute('hidden', ''), {once: true}}
+    })
+  })
+
+  const form = document.forms.login;
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+  })
+</script>
+</body>
+
+</html>

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -638,8 +638,9 @@ class InterfacePrototype {
         matchingForm?.submitHandler()
 
         if (!matchingForm) {
+            const selector = SUBMIT_BUTTON_SELECTOR + ', a[href="#"], a[href^=javascript], *[onclick]'
             // check if the click happened on a button
-            const button = /** @type HTMLElement */(event.target)?.closest(SUBMIT_BUTTON_SELECTOR)
+            const button = /** @type HTMLElement */(event.target)?.closest(selector)
             if (!button) return
 
             const text = removeExcessWhitespace(button?.textContent)

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -160,7 +160,7 @@ class Form {
                     const elText = getText(el)
                     const emailOrUsername = elText.match(
                         // https://www.emailregex.com/
-                        /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]*@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/
+                        /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/
                     )?.[0]
                     if (emailOrUsername) {
                         formValues.credentials.username = emailOrUsername

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -295,14 +295,6 @@ class Form {
         return this
     }
 
-    areAllInputsEmpty (inputType) {
-        let allEmpty = true
-        this.execOnInputs((input) => {
-            if (input.value) allEmpty = false
-        }, inputType)
-        return allEmpty
-    }
-
     addListener (el, type, fn) {
         el.addEventListener(type, fn)
         this.listeners.add({el, type, fn})

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -6,7 +6,8 @@ import {
     setValue,
     isEventWithinDax,
     isLikelyASubmitButton,
-    isVisible, buttonMatchesFormType
+    isVisible, buttonMatchesFormType,
+    getText
 } from '../autofill-utils.js'
 
 import {getInputSubtype, getInputMainType, createMatching, safeRegex} from './matching.js'
@@ -153,6 +154,18 @@ class Form {
             })
             if (probableField?.value) {
                 formValues.credentials.username = probableField.value
+            } else {
+                // If we still don't have a username, try scanning the form's text for an email address
+                this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
+                    const elText = getText(el)
+                    const emailOrUsername = elText.match(
+                        // https://www.emailregex.com/
+                        /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]*@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/
+                    )?.[0]
+                    if (emailOrUsername) {
+                        formValues.credentials.username = emailOrUsername
+                    }
+                })
             }
         }
 

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -109,6 +109,17 @@ describe('Test the form class reading values correctly', () => {
             expValues: {credentials: {username: 'testUsername', password: 'testPassword'}}
         },
         {
+            testCase: 'form with email in plain text',
+            form: `
+<form>
+    <span>Email: name@email.com</span>
+    <input type="password" value="testPassword" autocomplete="new-password" />
+    <button type="submit">Sign up</button>
+</form>`,
+            expHasValues: true,
+            expValues: {credentials: {username: 'name@email.com', password: 'testPassword'}}
+        },
+        {
             testCase: 'complete checkout form',
             form: `
 <form method="post" id="usrForm">

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -182,7 +182,7 @@ class FormAnalyzer {
         this.evaluateElAttributes(this.form)
 
         // Check form contents (skip select and option because they contain too much noise)
-        this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
+        this.form.querySelectorAll('*:not(select):not(option):not(script)').forEach(el => {
             // Check if element is not hidden. Note that we can't use offsetHeight
             // nor intersectionObserver, because the element could be outside the
             // viewport or its parent hidden

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -1,7 +1,7 @@
 import { removeExcessWhitespace, Matching } from './matching.js'
 import { constants } from '../constants.js'
 import { matchingConfiguration } from './matching-configuration.js'
-import { isLikelyASubmitButton } from '../autofill-utils.js'
+import { getText, isLikelyASubmitButton } from '../autofill-utils.js'
 
 class FormAnalyzer {
     /** @type HTMLElement */
@@ -139,25 +139,8 @@ class FormAnalyzer {
         })
     }
 
-    elementIs (el, type) {
-        return el.nodeName.toLowerCase() === type.toLowerCase()
-    }
-
-    getText (el) {
-        // for buttons, we don't care about descendants, just get the whole text as is
-        // this is important in order to give proper attribution of the text to the button
-        if (this.elementIs(el, 'BUTTON')) return removeExcessWhitespace(el.textContent)
-
-        if (this.elementIs(el, 'INPUT') && ['submit', 'button'].includes(el.type)) return el.value
-
-        return removeExcessWhitespace(
-            Array.from(el.childNodes).reduce((text, child) =>
-                this.elementIs(child, '#text') ? text + ' ' + child.textContent : text, '')
-        )
-    }
-
     evaluateElement (el) {
-        const string = this.getText(el)
+        const string = getText(el)
 
         if (el.matches(this.matching.cssSelector('password'))) {
             // These are explicit signals by the web author, so we weigh them heavily
@@ -176,7 +159,7 @@ class FormAnalyzer {
         }
         // if a link points to relevant urls or contain contents outside the page…
         if (
-            (this.elementIs(el, 'A') && el.href && el.href !== '#') ||
+            (el instanceof HTMLAnchorElement && el.href && el.href !== '#') ||
             (el.getAttribute('role') || '').toUpperCase() === 'LINK' ||
             el.matches('button[class*=secondary]')
         ) {

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -101,18 +101,22 @@ export class HTMLTooltipUIController extends UIController {
 
     _attachListeners () {
         window.addEventListener('input', this)
-        window.addEventListener('keydown', this)
+        window.addEventListener('keydown', this, true)
     }
 
     _removeListeners () {
         window.removeEventListener('input', this)
-        window.removeEventListener('keydown', this)
+        window.removeEventListener('keydown', this, true)
     }
 
     handleEvent (event) {
         switch (event.type) {
         case 'keydown':
             if (['Escape', 'Tab', 'Enter'].includes(event.code)) {
+                if (event.code === 'Escape') {
+                    event.preventDefault()
+                    event.stopImmediatePropagation()
+                }
                 this.removeTooltip()
             }
             break

--- a/src/UI/controllers/OverlayUIController.js
+++ b/src/UI/controllers/OverlayUIController.js
@@ -130,13 +130,13 @@ export class OverlayUIController extends UIController {
 
     _attachListeners () {
         window.addEventListener('scroll', this)
-        window.addEventListener('keydown', this)
+        window.addEventListener('keydown', this, true)
         window.addEventListener('input', this)
     }
 
     _removeListeners () {
         window.removeEventListener('scroll', this)
-        window.removeEventListener('keydown', this)
+        window.removeEventListener('keydown', this, true)
         window.removeEventListener('input', this)
     }
 
@@ -148,6 +148,10 @@ export class OverlayUIController extends UIController {
         }
         case 'keydown': {
             if (['Escape', 'Tab', 'Enter'].includes(event.code)) {
+                if (event.code === 'Escape') {
+                    event.preventDefault()
+                    event.stopImmediatePropagation()
+                }
                 this.removeTooltip(event.type)
             }
             break

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -283,7 +283,7 @@ const isLikelyASubmitButton = (el) => {
     return (el.getAttribute('type') === 'submit' || // is explicitly set as "submit"
     /primary|submit/i.test(el.className) || // has high-signal submit classes
     SUBMIT_BUTTON_REGEX.test(contentExcludingLabel) || // has high-signal text
-    el.offsetHeight * el.offsetWidth >= 10000) && // it's a large element, at least 250x40px
+    (el.offsetHeight * el.offsetWidth >= 10000 && !/secondary/i.test(el.className))) && // it's a large element 250x40px
     !SUBMIT_BUTTON_UNLIKELY_REGEX.test(contentExcludingLabel + ' ' + ariaLabel)
 }
 

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -1,4 +1,4 @@
-import { getInputSubtype } from './Form/matching.js'
+import {getInputSubtype, removeExcessWhitespace} from './Form/matching.js'
 
 const SIGN_IN_MSG = { signMeIn: true }
 
@@ -302,6 +302,24 @@ const buttonMatchesFormType = (el, formObj) => {
     }
 }
 
+/**
+ * Get the text of an element
+ * @param {Element} el
+ * @returns {string}
+ */
+const getText = (el) => {
+    // for buttons, we don't care about descendants, just get the whole text as is
+    // this is important in order to give proper attribution of the text to the button
+    if (el instanceof HTMLButtonElement) return removeExcessWhitespace(el.textContent)
+
+    if (el instanceof HTMLInputElement && ['submit', 'button'].includes(el.type)) return el.value
+
+    return removeExcessWhitespace(
+        Array.from(el.childNodes).reduce((text, child) =>
+            child instanceof Text ? text + ' ' + child.textContent : text, '')
+    )
+}
+
 export {
     notifyWebApp,
     sendAndWaitForAnswer,
@@ -319,5 +337,6 @@ export {
     formatDuckAddress,
     escapeXML,
     isLikelyASubmitButton,
-    buttonMatchesFormType
+    buttonMatchesFormType,
+    getText
 }

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4569,10 +4569,11 @@ class InterfacePrototype {
     if (!matchingForm) {
       var _event$target;
 
-      // check if the click happened on a button
+      const selector = _selectorsCss.SUBMIT_BUTTON_SELECTOR + ', a[href="#"], a[href^=javascript], *[onclick]'; // check if the click happened on a button
+
       const button =
       /** @type HTMLElement */
-      (_event$target = event.target) === null || _event$target === void 0 ? void 0 : _event$target.closest(_selectorsCss.SUBMIT_BUTTON_SELECTOR);
+      (_event$target = event.target) === null || _event$target === void 0 ? void 0 : _event$target.closest(selector);
       if (!button) return;
       const text = (0, _matching.removeExcessWhitespace)(button === null || button === void 0 ? void 0 : button.textContent);
       const hasRelevantText = /(log|sign).?(in|up)|continue|next|submit/i.test(text);
@@ -4787,6 +4788,19 @@ class Form {
 
       if (probableField !== null && probableField !== void 0 && probableField.value) {
         formValues.credentials.username = probableField.value;
+      } else {
+        // If we still don't have a username, try scanning the form's text for an email address
+        this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
+          var _elText$match;
+
+          const elText = (0, _autofillUtils.getText)(el);
+          const emailOrUsername = (_elText$match = elText.match( // https://www.emailregex.com/
+          /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/)) === null || _elText$match === void 0 ? void 0 : _elText$match[0];
+
+          if (emailOrUsername) {
+            formValues.credentials.username = emailOrUsername;
+          }
+        });
       }
     }
 
@@ -4933,14 +4947,6 @@ class Form {
     this.inputs[mainInputType].add(input);
     this.decorateInput(input);
     return this;
-  }
-
-  areAllInputsEmpty(inputType) {
-    let allEmpty = true;
-    this.execOnInputs(input => {
-      if (input.value) allEmpty = false;
-    }, inputType);
-    return allEmpty;
   }
 
   addListener(el, type, fn) {
@@ -5282,20 +5288,8 @@ class FormAnalyzer {
     });
   }
 
-  elementIs(el, type) {
-    return el.nodeName.toLowerCase() === type.toLowerCase();
-  }
-
-  getText(el) {
-    // for buttons, we don't care about descendants, just get the whole text as is
-    // this is important in order to give proper attribution of the text to the button
-    if (this.elementIs(el, 'BUTTON')) return (0, _matching.removeExcessWhitespace)(el.textContent);
-    if (this.elementIs(el, 'INPUT') && ['submit', 'button'].includes(el.type)) return el.value;
-    return (0, _matching.removeExcessWhitespace)(Array.from(el.childNodes).reduce((text, child) => this.elementIs(child, '#text') ? text + ' ' + child.textContent : text, ''));
-  }
-
   evaluateElement(el) {
-    const string = this.getText(el);
+    const string = (0, _autofillUtils.getText)(el);
 
     if (el.matches(this.matching.cssSelector('password'))) {
       // These are explicit signals by the web author, so we weigh them heavily
@@ -5318,7 +5312,7 @@ class FormAnalyzer {
     } // if a link points to relevant urls or contain contents outside the page…
 
 
-    if (this.elementIs(el, 'A') && el.href && el.href !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]')) {
+    if (el instanceof HTMLAnchorElement && el.href && el.href !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]')) {
       // …and matches one of the regexes, we assume the match is not pertinent to the current form
       this.updateSignal({
         string,
@@ -5348,7 +5342,7 @@ class FormAnalyzer {
 
     this.evaluateElAttributes(this.form); // Check form contents (skip select and option because they contain too much noise)
 
-    this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
+    this.form.querySelectorAll('*:not(select):not(option):not(script)').forEach(el => {
       // Check if element is not hidden. Note that we can't use offsetHeight
       // nor intersectionObserver, because the element could be outside the
       // viewport or its parent hidden
@@ -9833,18 +9827,23 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
   _attachListeners() {
     window.addEventListener('input', this);
-    window.addEventListener('keydown', this);
+    window.addEventListener('keydown', this, true);
   }
 
   _removeListeners() {
     window.removeEventListener('input', this);
-    window.removeEventListener('keydown', this);
+    window.removeEventListener('keydown', this, true);
   }
 
   handleEvent(event) {
     switch (event.type) {
       case 'keydown':
         if (['Escape', 'Tab', 'Enter'].includes(event.code)) {
+          if (event.code === 'Escape') {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+
           this.removeTooltip();
         }
 
@@ -10218,13 +10217,13 @@ class OverlayUIController extends _UIController.UIController {
 
   _attachListeners() {
     window.addEventListener('scroll', this);
-    window.addEventListener('keydown', this);
+    window.addEventListener('keydown', this, true);
     window.addEventListener('input', this);
   }
 
   _removeListeners() {
     window.removeEventListener('scroll', this);
-    window.removeEventListener('keydown', this);
+    window.removeEventListener('keydown', this, true);
     window.removeEventListener('input', this);
   }
 
@@ -10239,6 +10238,11 @@ class OverlayUIController extends _UIController.UIController {
       case 'keydown':
         {
           if (['Escape', 'Tab', 'Enter'].includes(event.code)) {
+            if (event.code === 'Escape') {
+              event.preventDefault();
+              event.stopImmediatePropagation();
+            }
+
             this.removeTooltip(event.type);
           }
 
@@ -10625,7 +10629,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.buttonMatchesFormType = exports.autofillEnabled = exports.addInlineStyles = exports.SIGN_IN_MSG = exports.ADDRESS_DOMAIN = void 0;
 exports.escapeXML = escapeXML;
-exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
+exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
 
 var _matching = require("./Form/matching.js");
 
@@ -10986,7 +10990,7 @@ const isLikelyASubmitButton = el => {
   return (el.getAttribute('type') === 'submit' || // is explicitly set as "submit"
   /primary|submit/i.test(el.className) || // has high-signal submit classes
   SUBMIT_BUTTON_REGEX.test(contentExcludingLabel) || // has high-signal text
-  el.offsetHeight * el.offsetWidth >= 10000) && // it's a large element, at least 250x40px
+  el.offsetHeight * el.offsetWidth >= 10000 && !/secondary/i.test(el.className)) && // it's a large element 250x40px
   !SUBMIT_BUTTON_UNLIKELY_REGEX.test(contentExcludingLabel + ' ' + ariaLabel);
 };
 /**
@@ -11007,8 +11011,24 @@ const buttonMatchesFormType = (el, formObj) => {
     return true;
   }
 };
+/**
+ * Get the text of an element
+ * @param {Element} el
+ * @returns {string}
+ */
+
 
 exports.buttonMatchesFormType = buttonMatchesFormType;
+
+const getText = el => {
+  // for buttons, we don't care about descendants, just get the whole text as is
+  // this is important in order to give proper attribution of the text to the button
+  if (el instanceof HTMLButtonElement) return (0, _matching.removeExcessWhitespace)(el.textContent);
+  if (el instanceof HTMLInputElement && ['submit', 'button'].includes(el.type)) return el.value;
+  return (0, _matching.removeExcessWhitespace)(Array.from(el.childNodes).reduce((text, child) => child instanceof Text ? text + ' ' + child.textContent : text, ''));
+};
+
+exports.getText = getText;
 
 },{"./Form/matching.js":26}],47:[function(require,module,exports){
 "use strict";


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/1198964220583541/1202621230892874/f

## Description
- Stop event propagation when `Escape` is used to close our tooltip (see [here](https://app.asana.com/0/0/1201810232939416/1202618491504581/f))
- Try to exclude secondary buttons when reading form submit buttons (fixes the [yahoo form mismatch](https://app.asana.com/0/1202427674957632/1202535734255841/f))
- Try reading text if a username is absent from the form (no hidden fields or anything like that fixes [navigatingcare](https://app.asana.com/0/1202427674957632/1202498211642921/f))
- Improve button detection on click (fixes [bell.ca](https://app.asana.com/0/1202427674957632/1202532785810204/f))

## Steps to test
Added automated tests and validated on the live sites.