### PR TITLE
Rename autofill content script message and format

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -7309,7 +7309,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   async isEnabled() {
     return new Promise(resolve => {
       chrome.runtime.sendMessage({
-        registeredTempAutofillContentScript: true,
+        messageType: 'registeredAutofillContentScript',
         documentUrl: window.location.href
       }, response => {
         if (response && 'site' in response) {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -3633,7 +3633,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   async isEnabled() {
     return new Promise(resolve => {
       chrome.runtime.sendMessage({
-        registeredTempAutofillContentScript: true,
+        messageType: 'registeredAutofillContentScript',
         documentUrl: window.location.href
       }, response => {
         if (response && 'site' in response) {

--- a/integration-test/extension/background.js
+++ b/integration-test/extension/background.js
@@ -57,7 +57,7 @@ async function addUserData (userData, sender) {
     }
 }
 
-function registeredTempAutofillContentScript () {
+function registeredAutofillContentScript () {
     return {
         debug: false,
         site: {
@@ -70,8 +70,8 @@ function registeredTempAutofillContentScript () {
 
 function init () {
     chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-        if (message.registeredTempAutofillContentScript) {
-            return sendResponse(registeredTempAutofillContentScript())
+        if (message.messageType === 'registeredAutofillContentScript') {
+            return sendResponse(registeredAutofillContentScript())
         } else if (message.getAddresses) {
             return sendResponse(getAddresses())
         } else if (message.refreshAlias) {

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -28,7 +28,7 @@ class ExtensionInterface extends InterfacePrototype {
         return new Promise(resolve => {
             chrome.runtime.sendMessage(
                 {
-                    registeredTempAutofillContentScript: true,
+                    messageType: 'registeredAutofillContentScript',
                     documentUrl: window.location.href
                 },
                 (response) => {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -7309,7 +7309,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   async isEnabled() {
     return new Promise(resolve => {
       chrome.runtime.sendMessage({
-        registeredTempAutofillContentScript: true,
+        messageType: 'registeredAutofillContentScript',
         documentUrl: window.location.href
       }, response => {
         if (response && 'site' in response) {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -3633,7 +3633,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   async isEnabled() {
     return new Promise(resolve => {
       chrome.runtime.sendMessage({
-        registeredTempAutofillContentScript: true,
+        messageType: 'registeredAutofillContentScript',
         documentUrl: window.location.href
       }, response => {
         if (response && 'site' in response) {


### PR DESCRIPTION
**Reviewer:** @jonathanKingston 
**Asana:** https://app.asana.com/0/1162895505193104/1202817610595239/f

## Description

Updates temp naming, as well as aligning with the `messageType` key format in the extension. This changes only affects the extension integration -- corresponding extension PR: https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1354

## Steps to test

Test in corresponding extension branch -- https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1354