### PR TITLE
Extension considered signed in when personal address is saved

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -7275,7 +7275,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   isDeviceSignedIn() {
-    return this.hasLocalAddresses;
+    // If we have a personal address saved, consider the extension signed in
+    return !!this.getLocalAddresses().personalAddress;
   }
 
   setupAutofill() {
@@ -7283,7 +7284,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   postInit() {
-    if (this.hasLocalAddresses) {
+    if (this.isDeviceSignedIn()) {
       const cleanup = this.scanner.init();
       this.addLogoutListener(cleanup);
     }

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -3599,7 +3599,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   isDeviceSignedIn() {
-    return this.hasLocalAddresses;
+    // If we have a personal address saved, consider the extension signed in
+    return !!this.getLocalAddresses().personalAddress;
   }
 
   setupAutofill() {
@@ -3607,7 +3608,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   postInit() {
-    if (this.hasLocalAddresses) {
+    if (this.isDeviceSignedIn()) {
       const cleanup = this.scanner.init();
       this.addLogoutListener(cleanup);
     }

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -41,7 +41,8 @@ class ExtensionInterface extends InterfacePrototype {
     }
 
     isDeviceSignedIn () {
-        return this.hasLocalAddresses
+        // If we have a personal address saved, consider the extension signed in
+        return !!this.getLocalAddresses().personalAddress
     }
 
     setupAutofill () {
@@ -49,7 +50,7 @@ class ExtensionInterface extends InterfacePrototype {
     }
 
     postInit () {
-        if (this.hasLocalAddresses) {
+        if (this.isDeviceSignedIn()) {
             const cleanup = this.scanner.init()
             this.addLogoutListener(cleanup)
         }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -7275,7 +7275,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   isDeviceSignedIn() {
-    return this.hasLocalAddresses;
+    // If we have a personal address saved, consider the extension signed in
+    return !!this.getLocalAddresses().personalAddress;
   }
 
   setupAutofill() {
@@ -7283,7 +7284,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   postInit() {
-    if (this.hasLocalAddresses) {
+    if (this.isDeviceSignedIn()) {
       const cleanup = this.scanner.init();
       this.addLogoutListener(cleanup);
     }

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -3599,7 +3599,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   isDeviceSignedIn() {
-    return this.hasLocalAddresses;
+    // If we have a personal address saved, consider the extension signed in
+    return !!this.getLocalAddresses().personalAddress;
   }
 
   setupAutofill() {
@@ -3607,7 +3608,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   postInit() {
-    if (this.hasLocalAddresses) {
+    if (this.isDeviceSignedIn()) {
       const cleanup = this.scanner.init();
       this.addLogoutListener(cleanup);
     }


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** Possibly related to https://app.asana.com/0/1198567644089701/1203172395139030/f

## Description

We've had support issues that users sometimes can't log in. I don't believe this is the cause, but the symptoms match what's reported, so fixing this will hopefully remove a possible occurrence of this issue.

Previously the exntension was only considered signed in when both a personal and private address were available. However, it's possible that the extension won't be able to generate a private duck address (e.g. invalid token, firewall, API down, etc.) This updates the logic to consider the extension to be signed in when just a personal address is saved.

## Steps to test

1. Sign up for a Duck Address using Firefox on sandbox site
2. Extension attempts to generate a private duck address using sandbox API token against production, which fails
3. You are not logged in to the web app, although the extension shows as logged in from the extension settings page
