### PR TITLE
Make Asana release script more resilient

### DIFF
--- a/scripts/release/asana-create-tasks.js
+++ b/scripts/release/asana-create-tasks.js
@@ -78,16 +78,18 @@ const waitForJobSuccess = async (job_gid, attempts = 1) => {
     const maxAttempts = 20
 
     return new Promise(async (resolve, reject) => {
-        if (attempts <= maxAttempts) {
             const { status } = await asana.jobs.getJob(job_gid)
             if (status === 'succeeded') {
                 return resolve(status)
             }
             attempts += 1
+
+        if (attempts > maxAttempts) {
+            return reject(new Error(`The job ${job_gid} took too long to execute`))
+        }
+
             await timersPromises.setTimeout(interval)
             return waitForJobSuccess(job_gid, attempts)
-        }
-        reject(new Error(`The job ${job_gid} took too long to execute`))
     })
 }
 
@@ -111,6 +113,8 @@ const asanaCreateTasks = async () => {
 
     await asana.tasks.addProjectForTask(new_task.gid, { project: autofillProjectGid, section: releaseSectionGid })
 
+    // The duplicateTask job returns when the task itself has been duplicated, ignoring the subtasks.
+    // We want to wait that the job completes so that we can fetch all the subtasks correctly.
     await waitForJobSuccess(duplicateTaskJobGid)
 
     // Getting subtasks...

--- a/scripts/release/asana-create-tasks.js
+++ b/scripts/release/asana-create-tasks.js
@@ -78,18 +78,18 @@ const waitForJobSuccess = async (job_gid, attempts = 1) => {
     const maxAttempts = 20
 
     return new Promise(async (resolve, reject) => {
-            const { status } = await asana.jobs.getJob(job_gid)
-            if (status === 'succeeded') {
-                return resolve(status)
-            }
-            attempts += 1
+        const { status } = await asana.jobs.getJob(job_gid)
+        if (status === 'succeeded') {
+            return resolve(status)
+        }
+        attempts += 1
 
         if (attempts > maxAttempts) {
             return reject(new Error(`The job ${job_gid} took too long to execute`))
         }
 
-            await timersPromises.setTimeout(interval)
-            return waitForJobSuccess(job_gid, attempts)
+        await timersPromises.setTimeout(interval)
+        return waitForJobSuccess(job_gid, attempts)
     })
 }
 


### PR DESCRIPTION
**Reviewer:** @alistairjcbrown 
**Asana:** https://app.asana.com/0/1198964220583541/1203352551432357/f

## Description
If the Asana API takes too long to complete the initial task duplication (happened yesterday for the first time), our script won't be able to update the subtasks because they are not yet created. This change waits for the job to complete before moving on, so we're sure the tasks are there and can be updated.

## Steps to test
I've run the Asana script locally, forcing a couple of scenarios. All good. 👍