### PR TITLE
Fix types for ID

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -7708,7 +7708,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets credentials ready for autofill
-   * @param {Number} id - the credential id
+   * @param {CredentialsObject['id']} id - the credential id
    * @returns {APIResponseSingle<CredentialsObject>}
    */
 
@@ -7744,7 +7744,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets a single identity obj once the user requests it
-   * @param {Number} id
+   * @param {IdentityObject['id']} id
    * @returns {Promise<{success: IdentityObject|undefined}>}
    */
 
@@ -7762,7 +7762,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets a single complete credit card obj once the user requests it
-   * @param {Number} id
+   * @param {CreditCardObject['id']} id
    * @returns {APIResponse<CreditCardObject>}
    */
 
@@ -8709,7 +8709,7 @@ class InterfacePrototype {
    *
    * @param {InputTypeConfigs} config
    * @param {(CreditCardObject|IdentityObject|CredentialsObject)[]} items
-   * @param {string|number} id
+   * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
    */
 
 
@@ -8936,7 +8936,7 @@ class InterfacePrototype {
   getAccounts() {}
   /**
    * Gets credentials ready for autofill
-   * @param {number|string} id - the credential id
+   * @param {CredentialsObject['id']} id - the credential id
    * @returns {Promise<CredentialsObject|{success:CredentialsObject}>}
    */
 
@@ -15108,7 +15108,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
    *
    * @param {InputTypeConfigs} config
    * @param {(CreditCardObject | IdentityObject | CredentialsObject)[]} data
-   * @param {string | number} id
+   * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
    */
 
 

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -14320,6 +14320,11 @@ class Settings {
 
     if (!this.featureToggles["inputType_".concat(mainType)] && subtype !== 'emailAddress') {
       return false;
+    } // If it's an email field and Email Protection is enabled, return true regardless of other options
+
+
+    if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
+      return true;
     }
 
     if (((_this$availableInputT = this.availableInputTypes) === null || _this$availableInputT === void 0 ? void 0 : _this$availableInputT[mainType]) === undefined) {
@@ -14337,10 +14342,6 @@ class Settings {
       var _this$availableInputT4, _this$availableInputT5;
 
       return Boolean(((_this$availableInputT4 = this.availableInputTypes.creditCards) === null || _this$availableInputT4 === void 0 ? void 0 : _this$availableInputT4.expirationMonth) || ((_this$availableInputT5 = this.availableInputTypes.creditCards) === null || _this$availableInputT5 === void 0 ? void 0 : _this$availableInputT5.expirationYear));
-    }
-
-    if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
-      return true;
     }
 
     return Boolean((_this$availableInputT6 = this.availableInputTypes[mainType]) === null || _this$availableInputT6 === void 0 ? void 0 : _this$availableInputT6[subtype]);

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -10644,6 +10644,11 @@ class Settings {
 
     if (!this.featureToggles["inputType_".concat(mainType)] && subtype !== 'emailAddress') {
       return false;
+    } // If it's an email field and Email Protection is enabled, return true regardless of other options
+
+
+    if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
+      return true;
     }
 
     if (((_this$availableInputT = this.availableInputTypes) === null || _this$availableInputT === void 0 ? void 0 : _this$availableInputT[mainType]) === undefined) {
@@ -10661,10 +10666,6 @@ class Settings {
       var _this$availableInputT4, _this$availableInputT5;
 
       return Boolean(((_this$availableInputT4 = this.availableInputTypes.creditCards) === null || _this$availableInputT4 === void 0 ? void 0 : _this$availableInputT4.expirationMonth) || ((_this$availableInputT5 = this.availableInputTypes.creditCards) === null || _this$availableInputT5 === void 0 ? void 0 : _this$availableInputT5.expirationYear));
-    }
-
-    if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
-      return true;
     }
 
     return Boolean((_this$availableInputT6 = this.availableInputTypes[mainType]) === null || _this$availableInputT6 === void 0 ? void 0 : _this$availableInputT6[subtype]);

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4032,7 +4032,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets credentials ready for autofill
-   * @param {Number} id - the credential id
+   * @param {CredentialsObject['id']} id - the credential id
    * @returns {APIResponseSingle<CredentialsObject>}
    */
 
@@ -4068,7 +4068,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets a single identity obj once the user requests it
-   * @param {Number} id
+   * @param {IdentityObject['id']} id
    * @returns {Promise<{success: IdentityObject|undefined}>}
    */
 
@@ -4086,7 +4086,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets a single complete credit card obj once the user requests it
-   * @param {Number} id
+   * @param {CreditCardObject['id']} id
    * @returns {APIResponse<CreditCardObject>}
    */
 
@@ -5033,7 +5033,7 @@ class InterfacePrototype {
    *
    * @param {InputTypeConfigs} config
    * @param {(CreditCardObject|IdentityObject|CredentialsObject)[]} items
-   * @param {string|number} id
+   * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
    */
 
 
@@ -5260,7 +5260,7 @@ class InterfacePrototype {
   getAccounts() {}
   /**
    * Gets credentials ready for autofill
-   * @param {number|string} id - the credential id
+   * @param {CredentialsObject['id']} id - the credential id
    * @returns {Promise<CredentialsObject|{success:CredentialsObject}>}
    */
 
@@ -11432,7 +11432,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
    *
    * @param {InputTypeConfigs} config
    * @param {(CreditCardObject | IdentityObject | CredentialsObject)[]} data
-   * @param {string | number} id
+   * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
    */
 
 

--- a/docs/runtime.android.md
+++ b/docs/runtime.android.md
@@ -76,11 +76,44 @@ Directly replace the line above in the following way:
 
 `str.replace('// INJECT availableInputTypes HERE', 'contentScope = {JSON_HERE}') + ';'`
 
+See: [../src/schema/availableInputTypes.json](../src/deviceApiCalls/schemas/availableInputTypes.json).
+
+This represents which input types we can autofill for the current user. Values are `true` if we can autofill the
+field type with at least one item. For example, if we have two credential items and the first only has a username
+and the second only has a password, both fields will be `true`. The email value is the same as returned by the 
+`isSignedIn()` method. At this time `identities` and `creditCards` are optional as they are not supported on Android.
+
 ```javascript
 // INJECT availableInputTypes HERE
 availableInputTypes = {
   "email": true,
-  "credentials": true
+  "credentials": {
+      "username": true,
+      "password": true
+  },
+  "identities": {
+    "firstName": false,
+    "middleName": false,
+    "lastName": false,
+    "birthdayDay": false,
+    "birthdayMonth": false,
+    "birthdayYear": false,
+    "addressStreet": false,
+    "addressStreet2": false,
+    "addressCity": false,
+    "addressProvince": false,
+    "addressPostalCode": false,
+    "addressCountryCode": false,
+    "phone": false,
+    "emailAddress": false
+  },
+  "creditCards": {
+    "cardName": false,
+    "cardSecurityCode": false,
+    "expirationMonth": false,
+    "expirationYear": false,
+    "cardNumber": false
+  }
 }
 ```
 

--- a/docs/runtime.ios.md
+++ b/docs/runtime.ios.md
@@ -70,13 +70,41 @@ see:
 
 - [../src/deviceApiCalls/schemas/getAvailableInputTypes.result.json](../src/deviceApiCalls/schemas/getAvailableInputTypes.result.json)
 
-This represents which input types we can autofill for the current user.
+This represents which input types we can autofill for the current user. Values are `true` if we can autofill the
+field type with at least one item. For example, if we have two credential items and the first only has a username
+and the second only has a password, both fields will be `true`.
 
 ```json
 {
   "success": {
     "email": true,
-    "credentials": true
+    "credentials": {
+      "username": true,
+      "password": true
+    },
+    "identities": {
+      "firstName": false,
+      "middleName": false,
+      "lastName": false,
+      "birthdayDay": false,
+      "birthdayMonth": false,
+      "birthdayYear": false,
+      "addressStreet": false,
+      "addressStreet2": false,
+      "addressCity": false,
+      "addressProvince": false,
+      "addressPostalCode": false,
+      "addressCountryCode": false,
+      "phone": false,
+      "emailAddress": false
+    },
+    "creditCards": {
+      "cardName": false,
+      "cardSecurityCode": false,
+      "expirationMonth": false,
+      "expirationYear": false,
+      "cardNumber": false
+    }
   }
 }
 ```

--- a/docs/runtime.windows.md
+++ b/docs/runtime.windows.md
@@ -88,10 +88,42 @@ where `event.data` is:
 {
   "type": "getAvailableInputTypesResponse",
   "success": {
-    "credentials": true
+    "email": false,
+    "credentials": {
+      "username": true,
+      "password": true
+    },
+    "identities": {
+      "firstName": false,
+      "middleName": false,
+      "lastName": false,
+      "birthdayDay": false,
+      "birthdayMonth": false,
+      "birthdayYear": false,
+      "addressStreet": false,
+      "addressStreet2": false,
+      "addressCity": false,
+      "addressProvince": false,
+      "addressPostalCode": false,
+      "addressCountryCode": false,
+      "phone": false,
+      "emailAddress": false
+    },
+    "creditCards": {
+      "cardName": false,
+      "cardSecurityCode": false,
+      "expirationMonth": false,
+      "expirationYear": false,
+      "cardNumber": false
+    }
   }
 }
 ```
+
+This represents which input types we can autofill for the current user. Values are `true` if we can autofill the
+field type with at least one item. For example, if we have two credential items and the first only has a username
+and the second only has a password, both fields will be `true`. At this time `identities` and `creditCards` are
+optional as they are not supported on Windows.
 
 ---
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -21,30 +21,48 @@ The platform in question will deliver feature toggles (boolean flags) based on d
 
 `settings.availableInputTypes` 
 
-Another set of boolean flags, this time indicating which data types the 
-current user can autofill. This is domain specific.
+Another set of boolean flags, this time indicating which data types the current user can autofill.
+Credentials are domain-specific. These represent which input types we can autofill for the current user.
+Values are `true` if we can autofill the field type with at least one item. For example, if we have two
+credential items and the first only has a username and the second only has a password, both fields will be `true`.
 
-- `credentials` - true if the user has credentials stored for the current domain
-- `identities` - true if the user has identities stored (not domain specific)
-- `creditCards` - true if the user has creditCards stored (not domain specific)
-- `email` - true if the user has logged into email protection (not domain specific)
-  - note: `availableInputTypes.email` is only current used on android. In the future all platforms will migrate to this.
+Note: `availableInputTypes.email` is only currently used on android. In the future all platforms will migrate to this.
+
+```json
+{
+  "email": Boolean,
+  "credentials": {
+    "username": Boolean,
+    "password": Boolean
+  },
+  "identities": {
+    "firstName": Boolean,
+    "middleName": Boolean,
+    "lastName": Boolean,
+    "birthdayDay": Boolean,
+    "birthdayMonth": Boolean,
+    "birthdayYear": Boolean,
+    "addressStreet": Boolean,
+    "addressStreet2": Boolean,
+    "addressCity": Boolean,
+    "addressProvince": Boolean,
+    "addressPostalCode": Boolean,
+    "addressCountryCode": Boolean,
+    "phone": Boolean,
+    "emailAddress": Boolean
+  },
+  "creditCards": {
+    "cardName": Boolean,
+    "cardSecurityCode": Boolean,
+    "expirationMonth": Boolean,
+    "expirationYear": Boolean,
+    "cardNumber": Boolean
+  }
+}
+```
 
 ## Methods
 
-`settings.refresh(availableInputTypesOverrides)`
+`settings.refresh()`
 
-Initially, this is called as an additional step that follows data access when the page loads, but
-the long-term goal is to remove all initial data access and do everything through this.
-
-**Note:** This method currently accepts 'availableInputTypesOverrides' as a way to support the current version of `macOS`. macOS currently determines which data types it supports by fetching user data on page load, so we use that data to derive `availableInputTypes`. In the future, once macOS supports `getAvailableInputTypes` then we can remove this override.
-
-```javascript
-// if we're executing on macOS, use old methods as overrides for `availableInputTypes`
-const macOSoverrides = isMac ? {
-    credentials: this.hasLocalCredentials(),
-    identities: this.hasLocalIdentities(),
-    ...etc
-} : {}
-await settings.refresh(overrides)
-```
+Initially, this is called as an additional step that follows data access when the page loads.

--- a/src/DeviceInterface/AppleDeviceInterface.js
+++ b/src/DeviceInterface/AppleDeviceInterface.js
@@ -211,7 +211,7 @@ class AppleDeviceInterface extends InterfacePrototype {
 
     /**
      * Gets credentials ready for autofill
-     * @param {Number} id - the credential id
+     * @param {CredentialsObject['id']} id - the credential id
      * @returns {APIResponseSingle<CredentialsObject>}
      */
     getAutofillCredentials (id) {
@@ -241,7 +241,7 @@ class AppleDeviceInterface extends InterfacePrototype {
 
     /**
      * Gets a single identity obj once the user requests it
-     * @param {Number} id
+     * @param {IdentityObject['id']} id
      * @returns {Promise<{success: IdentityObject|undefined}>}
      */
     getAutofillIdentity (id) {
@@ -251,7 +251,7 @@ class AppleDeviceInterface extends InterfacePrototype {
 
     /**
      * Gets a single complete credit card obj once the user requests it
-     * @param {Number} id
+     * @param {CreditCardObject['id']} id
      * @returns {APIResponse<CreditCardObject>}
      */
     getAutofillCreditCard (id) {

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -421,7 +421,7 @@ class InterfacePrototype {
      *
      * @param {InputTypeConfigs} config
      * @param {(CreditCardObject|IdentityObject|CredentialsObject)[]} items
-     * @param {string|number} id
+     * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
      */
     onSelect (config, items, id) {
         id = String(id)
@@ -596,7 +596,7 @@ class InterfacePrototype {
     getAccounts () {}
     /**
      * Gets credentials ready for autofill
-     * @param {number|string} id - the credential id
+     * @param {CredentialsObject['id']} id - the credential id
      * @returns {Promise<CredentialsObject|{success:CredentialsObject}>}
      */
     async getAutofillCredentials (id) {

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -169,6 +169,11 @@ export class Settings {
             return false
         }
 
+        // If it's an email field and Email Protection is enabled, return true regardless of other options
+        if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
+            return true
+        }
+
         if (this.availableInputTypes?.[mainType] === undefined) {
             const availableInputTypesFromRemote = await this.getAvailableInputTypes()
             this.setAvailableInputTypes(availableInputTypesFromRemote)
@@ -180,10 +185,6 @@ export class Settings {
 
         if (subtype === 'expiration') {
             return Boolean(this.availableInputTypes.creditCards?.expirationMonth || this.availableInputTypes.creditCards?.expirationYear)
-        }
-
-        if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
-            return true
         }
 
         return Boolean(this.availableInputTypes[mainType]?.[subtype])

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -209,7 +209,7 @@ export class HTMLTooltipUIController extends UIController {
      *
      * @param {InputTypeConfigs} config
      * @param {(CreditCardObject | IdentityObject | CredentialsObject)[]} data
-     * @param {string | number} id
+     * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
      */
     _onSelect (config, data, id) {
         return this._options.device.onSelect(config, data, id)

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -7708,7 +7708,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets credentials ready for autofill
-   * @param {Number} id - the credential id
+   * @param {CredentialsObject['id']} id - the credential id
    * @returns {APIResponseSingle<CredentialsObject>}
    */
 
@@ -7744,7 +7744,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets a single identity obj once the user requests it
-   * @param {Number} id
+   * @param {IdentityObject['id']} id
    * @returns {Promise<{success: IdentityObject|undefined}>}
    */
 
@@ -7762,7 +7762,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets a single complete credit card obj once the user requests it
-   * @param {Number} id
+   * @param {CreditCardObject['id']} id
    * @returns {APIResponse<CreditCardObject>}
    */
 
@@ -8709,7 +8709,7 @@ class InterfacePrototype {
    *
    * @param {InputTypeConfigs} config
    * @param {(CreditCardObject|IdentityObject|CredentialsObject)[]} items
-   * @param {string|number} id
+   * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
    */
 
 
@@ -8936,7 +8936,7 @@ class InterfacePrototype {
   getAccounts() {}
   /**
    * Gets credentials ready for autofill
-   * @param {number|string} id - the credential id
+   * @param {CredentialsObject['id']} id - the credential id
    * @returns {Promise<CredentialsObject|{success:CredentialsObject}>}
    */
 
@@ -15108,7 +15108,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
    *
    * @param {InputTypeConfigs} config
    * @param {(CreditCardObject | IdentityObject | CredentialsObject)[]} data
-   * @param {string | number} id
+   * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
    */
 
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -14320,6 +14320,11 @@ class Settings {
 
     if (!this.featureToggles["inputType_".concat(mainType)] && subtype !== 'emailAddress') {
       return false;
+    } // If it's an email field and Email Protection is enabled, return true regardless of other options
+
+
+    if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
+      return true;
     }
 
     if (((_this$availableInputT = this.availableInputTypes) === null || _this$availableInputT === void 0 ? void 0 : _this$availableInputT[mainType]) === undefined) {
@@ -14337,10 +14342,6 @@ class Settings {
       var _this$availableInputT4, _this$availableInputT5;
 
       return Boolean(((_this$availableInputT4 = this.availableInputTypes.creditCards) === null || _this$availableInputT4 === void 0 ? void 0 : _this$availableInputT4.expirationMonth) || ((_this$availableInputT5 = this.availableInputTypes.creditCards) === null || _this$availableInputT5 === void 0 ? void 0 : _this$availableInputT5.expirationYear));
-    }
-
-    if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
-      return true;
     }
 
     return Boolean((_this$availableInputT6 = this.availableInputTypes[mainType]) === null || _this$availableInputT6 === void 0 ? void 0 : _this$availableInputT6[subtype]);

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -10644,6 +10644,11 @@ class Settings {
 
     if (!this.featureToggles["inputType_".concat(mainType)] && subtype !== 'emailAddress') {
       return false;
+    } // If it's an email field and Email Protection is enabled, return true regardless of other options
+
+
+    if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
+      return true;
     }
 
     if (((_this$availableInputT = this.availableInputTypes) === null || _this$availableInputT === void 0 ? void 0 : _this$availableInputT[mainType]) === undefined) {
@@ -10661,10 +10666,6 @@ class Settings {
       var _this$availableInputT4, _this$availableInputT5;
 
       return Boolean(((_this$availableInputT4 = this.availableInputTypes.creditCards) === null || _this$availableInputT4 === void 0 ? void 0 : _this$availableInputT4.expirationMonth) || ((_this$availableInputT5 = this.availableInputTypes.creditCards) === null || _this$availableInputT5 === void 0 ? void 0 : _this$availableInputT5.expirationYear));
-    }
-
-    if (subtype === 'emailAddress' && this.featureToggles.emailProtection && this.availableInputTypes.email) {
-      return true;
     }
 
     return Boolean((_this$availableInputT6 = this.availableInputTypes[mainType]) === null || _this$availableInputT6 === void 0 ? void 0 : _this$availableInputT6[subtype]);

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4032,7 +4032,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets credentials ready for autofill
-   * @param {Number} id - the credential id
+   * @param {CredentialsObject['id']} id - the credential id
    * @returns {APIResponseSingle<CredentialsObject>}
    */
 
@@ -4068,7 +4068,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets a single identity obj once the user requests it
-   * @param {Number} id
+   * @param {IdentityObject['id']} id
    * @returns {Promise<{success: IdentityObject|undefined}>}
    */
 
@@ -4086,7 +4086,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
   /**
    * Gets a single complete credit card obj once the user requests it
-   * @param {Number} id
+   * @param {CreditCardObject['id']} id
    * @returns {APIResponse<CreditCardObject>}
    */
 
@@ -5033,7 +5033,7 @@ class InterfacePrototype {
    *
    * @param {InputTypeConfigs} config
    * @param {(CreditCardObject|IdentityObject|CredentialsObject)[]} items
-   * @param {string|number} id
+   * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
    */
 
 
@@ -5260,7 +5260,7 @@ class InterfacePrototype {
   getAccounts() {}
   /**
    * Gets credentials ready for autofill
-   * @param {number|string} id - the credential id
+   * @param {CredentialsObject['id']} id - the credential id
    * @returns {Promise<CredentialsObject|{success:CredentialsObject}>}
    */
 
@@ -11432,7 +11432,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
    *
    * @param {InputTypeConfigs} config
    * @param {(CreditCardObject | IdentityObject | CredentialsObject)[]} data
-   * @param {string | number} id
+   * @param {CreditCardObject['id']|IdentityObject['id']|CredentialsObject['id']} id
    */
 
 


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** NA
**CC:** @szanto90balazs @CDRussell

## Description
Tom today was confused by the fact that some of our code seemed to expect Numbers for IDs, but we changed that a long time ago. This fixes the types to inherit the `id` type from their parent object so in the future we get them updated for free. No rush with this.

## Steps to test
NA, just type changes.