### PR TITLE
Autofill pixels

### DIFF
--- a/integration-test/extension/background.js
+++ b/integration-test/extension/background.js
@@ -85,7 +85,7 @@ function init () {
             return sendResponse(getAddresses())
         } else if (message.addUserData) {
             return sendResponse(addUserData(message.addUserData, sender))
-        } else if (message.messageType === 'firePixel') {
+        } else if (message.messageType === 'sendJSPixel') {
             return sendResponse(firePixel(message.options))
         }
     })

--- a/integration-test/extension/background.js
+++ b/integration-test/extension/background.js
@@ -4,12 +4,18 @@ const userData = {
     userName: 'shane-123',
     nextAlias: random
 }
+// eslint-disable-next-line no-undef
+globalThis.pixels = []
 
 function getAddresses () {
     return {
         personalAddress: `${userData.userName}`,
         privateAddress: `${userData.nextAlias}`
     }
+}
+function firePixel ({pixelName}) {
+    // eslint-disable-next-line no-undef
+    globalThis.pixels.push(pixelName)
 }
 
 async function addUserData (userData, sender) {
@@ -79,6 +85,8 @@ function init () {
             return sendResponse(getAddresses())
         } else if (message.addUserData) {
             return sendResponse(addUserData(message.addUserData, sender))
+        } else if (message.messageType === 'firePixel') {
+            return sendResponse(firePixel(message.options))
         }
     })
 

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -556,6 +556,16 @@ export function emailAutofillPage (page, server) {
         async assertEmailValue (emailAddress) {
             const email = page.locator(selectors.identity)
             await expect(email).toHaveValue(emailAddress)
+        },
+        async assertPixelsFired (expectedPixels) {
+            let [backgroundPage] = await page.context().backgroundPages()
+            const backgroundPagePixels = await backgroundPage.evaluateHandle(() => {
+                // eslint-disable-next-line no-undef
+                return globalThis.pixels
+            })
+
+            const pixels = await backgroundPagePixels.jsonValue()
+            expect(pixels).toEqual(expectedPixels)
         }
 
     }

--- a/integration-test/tests/email-autofill.extension.spec.js
+++ b/integration-test/tests/email-autofill.extension.spec.js
@@ -38,7 +38,8 @@ test.describe('chrome extension', () => {
         // ensure autofill populates the field
         await emailPage.assertEmailValue(personalAddress)
 
-        // TODO: ensure pixel was fired
+        // ensure background page received pixel
+        await emailPage.assertPixelsFired(['autofill_personal_address'])
 
         // now ensure a second click into the input doesn't show the dropdown
         await emailPage.clickIntoInput()
@@ -54,5 +55,8 @@ test.describe('chrome extension', () => {
 
         // now ensure the second value is the private address
         await emailPage.assertEmailValue(privateAddress0)
+
+        // assert that the background page received  pixel
+        await emailPage.assertPixelsFired(['autofill_personal_address', 'autofill_private_address'])
     })
 })

--- a/integration-test/tests/email-autofill.extension.spec.js
+++ b/integration-test/tests/email-autofill.extension.spec.js
@@ -38,6 +38,8 @@ test.describe('chrome extension', () => {
         // ensure autofill populates the field
         await emailPage.assertEmailValue(personalAddress)
 
+        // TODO: ensure pixel was fired
+
         // now ensure a second click into the input doesn't show the dropdown
         await emailPage.clickIntoInput()
 

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -103,6 +103,14 @@ class ExtensionInterface extends InterfacePrototype {
         ))
     }
 
+    privateAddressUsed () {
+        chrome.runtime.sendMessage({privateAddressUsed: true})
+    }
+
+    personalAddressUsed () {
+        chrome.runtime.sendMessage({personalAddressUsed: true})
+    }
+
     /**
      * Used by the email web app
      * Settings page displays data of the logged in user data

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -9,6 +9,7 @@ import {
 } from '../autofill-utils.js'
 import {HTMLTooltipUIController} from '../UI/controllers/HTMLTooltipUIController.js'
 import {defaultOptions} from '../UI/HTMLTooltip.js'
+import { SendJSPixelCall } from '../deviceApiCalls/__generated__/deviceApiCalls.js'
 
 const POPUP_TYPES = {
     EmailProtection: 'EmailProtection',
@@ -103,12 +104,8 @@ class ExtensionInterface extends InterfacePrototype {
         ))
     }
 
-    privateAddressUsed () {
-        chrome.runtime.sendMessage({privateAddressUsed: true})
-    }
-
-    personalAddressUsed () {
-        chrome.runtime.sendMessage({personalAddressUsed: true})
+    firePixel (pixelName) {
+        this.deviceApi.notify(new SendJSPixelCall({pixelName}))
     }
 
     /**

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -525,10 +525,6 @@ class InterfacePrototype {
     /** @returns {Promise<EmailAddresses>} */
     async getAddresses () { throw new Error('unimplemented') }
 
-    personalAddressUsed () { }
-
-    privateAddressUsed () { }
-
     /** @returns {Promise<null|Record<any,any>>} */
     getUserData () { return Promise.resolve(null) }
 

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -525,6 +525,10 @@ class InterfacePrototype {
     /** @returns {Promise<EmailAddresses>} */
     async getAddresses () { throw new Error('unimplemented') }
 
+    personalAddressUsed () { }
+
+    privateAddressUsed () { }
+
     /** @returns {Promise<null|Record<any,any>>} */
     getUserData () { return Promise.resolve(null) }
 

--- a/src/UI/EmailHTMLTooltip.js
+++ b/src/UI/EmailHTMLTooltip.js
@@ -38,18 +38,15 @@ ${this.options.css}
             }
         }
 
-        const personalAddressUsed = this.device.personalAddressUsed.bind(this.device)
-        const privateAddressUsed = this.device.privateAddressUsed.bind(this.device)
+        const firePixel = this.device.firePixel.bind(this.device)
 
         this.registerClickableButton(this.usePersonalButton, () => {
             this.fillForm('personalAddress')
-            personalAddressUsed()
-            console.log('personalAddress selected')
+            firePixel('autofill_personal_address')
         })
         this.registerClickableButton(this.usePrivateButton, () => {
             this.fillForm('privateAddress')
-            privateAddressUsed()
-            console.log('privateAddress selected')
+            firePixel('autofill_private_address')
         })
 
         // Get the alias from the extension

--- a/src/UI/EmailHTMLTooltip.js
+++ b/src/UI/EmailHTMLTooltip.js
@@ -37,11 +37,19 @@ ${this.options.css}
                 this.addressEl.textContent = formatDuckAddress(addresses.personalAddress)
             }
         }
+
+        const personalAddressUsed = this.device.personalAddressUsed.bind(this.device)
+        const privateAddressUsed = this.device.privateAddressUsed.bind(this.device)
+
         this.registerClickableButton(this.usePersonalButton, () => {
             this.fillForm('personalAddress')
+            personalAddressUsed()
+            console.log('personalAddress selected')
         })
         this.registerClickableButton(this.usePrivateButton, () => {
             this.fillForm('privateAddress')
+            privateAddressUsed()
+            console.log('privateAddress selected')
         })
 
         // Get the alias from the extension

--- a/src/deviceApiCalls/__generated__/validators-ts.d.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.d.ts
@@ -654,7 +654,7 @@ export interface SelectedDetailParams {
  * Send pixels data to be fired from the native layer
  */
 export interface SendJSPixelParams {
-  pixelName: "autofill_identity";
+  pixelName: "autofill_identity" | "autofill_private_address" | "autofill_personal_address";
 }
 
 // setSize.params.json

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -150,7 +150,7 @@ export const selectedDetailParamsSchema = z.object({
 });
 
 export const sendJSPixelParamsSchema = z.object({
-    pixelName: z.literal("autofill_identity")
+    pixelName: z.union([z.literal("autofill_identity"), z.literal("autofill_private_address"), z.literal("autofill_personal_address")])
 });
 
 export const setSizeParamsSchema = z.object({

--- a/src/deviceApiCalls/schemas/sendJSPixel.params.json
+++ b/src/deviceApiCalls/schemas/sendJSPixel.params.json
@@ -10,6 +10,14 @@
         {
           "type": "string",
           "const": "autofill_identity"
+        },
+        {
+          "type": "string",
+          "const": "autofill_private_address"
+        },
+        {
+          "type": "string",
+          "const": "autofill_personal_address"
         }
       ]
     }

--- a/src/deviceApiCalls/transports/extension.transport.js
+++ b/src/deviceApiCalls/transports/extension.transport.js
@@ -89,8 +89,10 @@ async function extensionSpecificSendPixel (pixelName) {
     return new Promise(resolve => {
         chrome.runtime.sendMessage(
             {
-                firePixel: true,
-                pixelName
+                messageType: 'firePixel',
+                options: {
+                    pixelName
+                }
             },
             () => {
                 resolve(true)

--- a/src/deviceApiCalls/transports/extension.transport.js
+++ b/src/deviceApiCalls/transports/extension.transport.js
@@ -15,7 +15,6 @@ export class ExtensionTransport extends DeviceApiTransport {
     }
 
     async send (deviceApiCall) {
-        console.log({deviceApiCall})
         if (deviceApiCall instanceof GetRuntimeConfigurationCall) {
             return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this.config))
         }

--- a/src/deviceApiCalls/transports/extension.transport.js
+++ b/src/deviceApiCalls/transports/extension.transport.js
@@ -23,6 +23,7 @@ export class ExtensionTransport extends DeviceApiTransport {
             return deviceApiCall.result(await extensionSpecificGetAvailableInputTypes())
         }
 
+        // TODO: unify all calls to use deviceApiCall.method instead of all these if blocks
         if (deviceApiCall instanceof SendJSPixelCall) {
             return deviceApiCall.result(await extensionSpecificSendPixel(deviceApiCall.params.pixelName))
         }
@@ -88,7 +89,7 @@ async function extensionSpecificSendPixel (pixelName) {
     return new Promise(resolve => {
         chrome.runtime.sendMessage(
             {
-                messageType: 'firePixel',
+                messageType: 'sendJSPixel',
                 options: {
                     pixelName
                 }


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/0/1203562522878365/f

## Description
Send events when user selects Personal Duck Address or Private Duck Address.
Also added implementation for ExtensionInterface, which uses regular `chrome.runtime.sendMessage`


## Steps to test
1. Run integration tests: `npm run test:integration`
2. Test manually: Setup in the context of [duckduckgo-privacy-extension](https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1608), and inspect Chrome extension's background page. When you use autofill, you should now see autofill events in the Network tab.
