### PR TITLE
Email protection signup triggering

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8036,7 +8036,7 @@ var _HTMLTooltip = require("../UI/HTMLTooltip.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const POPUP_TYPES = {
+const TOOLTIP_TYPES = {
   EmailProtection: 'EmailProtection',
   EmailSignup: 'EmailSignup'
 };
@@ -8052,31 +8052,41 @@ class ExtensionInterface extends _InterfacePrototype.default {
       testMode: this.isTestMode()
     };
     const tooltipKinds = {
-      [POPUP_TYPES.EmailProtection]: 'legacy',
-      [POPUP_TYPES.EmailSignup]: 'emailsignup'
+      [TOOLTIP_TYPES.EmailProtection]: 'legacy',
+      [TOOLTIP_TYPES.EmailSignup]: 'emailsignup'
     };
-    const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[POPUP_TYPES.EmailProtection];
+    const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
     return new _HTMLTooltipUIController.HTMLTooltipUIController({
       tooltipKind,
       device: this
     }, htmlTooltipOptions);
   }
 
-  get hasDismissedEmailSignup() {
-    // TODO -- implement peristed dismissed timestamp
-    return false;
-  }
-
   getShowingTooltip() {
     if (this.hasLocalAddresses) {
-      return POPUP_TYPES.EmailProtection;
+      return TOOLTIP_TYPES.EmailProtection;
     }
 
-    if (this.settings.featureToggles.emailProtection_incontext_signup && !this.hasDismissedEmailSignup) {
-      return POPUP_TYPES.EmailSignup;
+    if (this.settings.featureToggles.emailProtection_incontext_signup && this.settings.incontextSignupDismissed === false) {
+      return TOOLTIP_TYPES.EmailSignup;
     }
 
     return null;
+  }
+
+  onIncontextSignupDismissed() {
+    this.settings.setIncontextSignupDismissed(true);
+    chrome.runtime.sendMessage({
+      messageType: 'setIncontextSignupDismissedAt',
+      options: {
+        value: new Date().getTime()
+      }
+    });
+    this.removeAutofillFromUI();
+  }
+
+  removeAutofillFromUI() {
+    this._scannerCleanup && this._scannerCleanup();
   }
 
   async isEnabled() {
@@ -8102,21 +8112,24 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
   postInit() {
     switch (this.getShowingTooltip()) {
-      case POPUP_TYPES.EmailProtection:
+      case TOOLTIP_TYPES.EmailProtection:
         {
-          const cleanup = this.scanner.init();
-          this.addLogoutListener(cleanup);
+          this._scannerCleanup = this.scanner.init();
+          this.addLogoutListener(() => {
+            this.removeAutofillFromUI();
+          });
           break;
         }
 
-      case POPUP_TYPES.EmailSignup:
+      case TOOLTIP_TYPES.EmailSignup:
         {
-          this.scanner.init();
+          this._scannerCleanup = this.scanner.init();
           break;
         }
 
       default:
         {
+          // Don't do anyhing if we don't have a tooltip to show
           break;
         }
     }
@@ -8425,9 +8438,12 @@ class InterfacePrototype {
   /** @type { PMData } */
 
 
+  onIncontextSignupDismissed() {}
   /**
    * @returns {import('../Form/matching').SupportedTypes}
    */
+
+
   getCurrentInputType() {
     throw new Error('Not implemented');
   }
@@ -14342,6 +14358,8 @@ class Settings {
 
   /** @type {boolean | null} */
 
+  /** @type {boolean | null} */
+
   /**
    * @param {GlobalConfig} config
    * @param {DeviceApi} deviceApi
@@ -14358,6 +14376,8 @@ class Settings {
     _defineProperty(this, "_runtimeConfiguration", null);
 
     _defineProperty(this, "_enabled", null);
+
+    _defineProperty(this, "_incontextSignupDismissed", null);
 
     this.deviceApi = deviceApi;
     this.globalConfig = config;
@@ -14411,6 +14431,22 @@ class Settings {
         console.log('isDDGTestMode: getFeatureToggles: ❌', e);
       }
 
+      return null;
+    }
+  }
+  /**
+   * @returns {Promise<boolean|null>}
+   */
+
+
+  async getIncontextSignupDismissed() {
+    try {
+      var _runtimeConfig$userPr4, _runtimeConfig$userPr5, _runtimeConfig$userPr6;
+
+      const runtimeConfig = await this._getRuntimeConfiguration();
+      const incontextSignupSettings = (0, _index.validate)((_runtimeConfig$userPr4 = runtimeConfig.userPreferences) === null || _runtimeConfig$userPr4 === void 0 ? void 0 : (_runtimeConfig$userPr5 = _runtimeConfig$userPr4.features) === null || _runtimeConfig$userPr5 === void 0 ? void 0 : (_runtimeConfig$userPr6 = _runtimeConfig$userPr5.incontextSignup) === null || _runtimeConfig$userPr6 === void 0 ? void 0 : _runtimeConfig$userPr6.settings, _validatorsZod.incontextSignupSettingsSchema);
+      return Boolean(incontextSignupSettings.dismissedAt);
+    } catch (e) {
       return null;
     }
   }
@@ -14469,7 +14505,8 @@ class Settings {
   async refresh() {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
-    this.setAvailableInputTypes(await this.getAvailableInputTypes()); // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
+    this.setAvailableInputTypes(await this.getAvailableInputTypes());
+    this.setIncontextSignupDismissed(await this.getIncontextSignupDismissed()); // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
 
     if (typeof this.enabled === 'boolean') {
       if (!this.enabled) {
@@ -14572,6 +14609,20 @@ class Settings {
 
   setEnabled(enabled) {
     this._enabled = enabled;
+  }
+  /** @returns {boolean|null} */
+
+
+  get incontextSignupDismissed() {
+    return this._incontextSignupDismissed;
+  }
+  /**
+   * @param {boolean|null} incontextSignupDismissed
+   */
+
+
+  setIncontextSignupDismissed(incontextSignupDismissed) {
+    this._incontextSignupDismissed = incontextSignupDismissed;
   }
 
 }
@@ -14784,7 +14835,8 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
     this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                Not Now\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
-    this.registerClickableButton(this.dismissEmailSignup, () => {// TODO: Persist dismissal
+    this.registerClickableButton(this.dismissEmailSignup, () => {
+      device.onIncontextSignupDismissed();
     });
     this.init();
     return this;
@@ -15872,7 +15924,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.buttonMatchesFormType = exports.autofillEnabled = exports.addInlineStyles = exports.SIGN_IN_MSG = exports.ADDRESS_DOMAIN = void 0;
 exports.escapeXML = escapeXML;
-exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
+exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedConfig = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
 
 var _matching = require("./Form/matching.js");
 
@@ -15948,11 +16000,23 @@ const isAutofillEnabledFromProcessedConfig = processedConfig => {
   }
 
   return true;
+};
+
+exports.isAutofillEnabledFromProcessedConfig = isAutofillEnabledFromProcessedConfig;
+
+const isIncontextSignupEnabledFromProcessedConfig = processedConfig => {
+  const site = processedConfig.site;
+
+  if (site.isBroken || !site.enabledFeatures.includes('incontextSignup')) {
+    return false;
+  }
+
+  return true;
 }; // Access the original setter (needed to bypass React's implementation on mobile)
 // @ts-ignore
 
 
-exports.isAutofillEnabledFromProcessedConfig = isAutofillEnabledFromProcessedConfig;
+exports.isIncontextSignupEnabledFromProcessedConfig = isIncontextSignupEnabledFromProcessedConfig;
 const originalSet = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
 /**
  * Ensures the value is set properly and dispatches events to simulate real user action
@@ -16662,7 +16726,7 @@ exports.SendJSPixelCall = SendJSPixelCall;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
+exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
 
 var _zod = require("zod");
 
@@ -16840,6 +16904,12 @@ const userPreferencesSchema = _zod.z.object({
 });
 
 exports.userPreferencesSchema = userPreferencesSchema;
+
+const incontextSignupSettingsSchema = _zod.z.object({
+  dismissedAt: _zod.z.number().optional()
+});
+
+exports.incontextSignupSettingsSchema = incontextSignupSettingsSchema;
 
 const runtimeConfigurationSchema = _zod.z.object({
   contentScope: contentScopeSchema,
@@ -17257,6 +17327,8 @@ exports.ExtensionTransport = ExtensionTransport;
 async function extensionSpecificRuntimeConfiguration(globalConfig) {
   const contentScope = await getContentScopeConfig();
   const emailProtectionEnabled = (0, _autofillUtils.isAutofillEnabledFromProcessedConfig)(contentScope);
+  const incontextSignupEnabled = (0, _autofillUtils.isIncontextSignupEnabledFromProcessedConfig)(contentScope);
+  const incontextSignupDismissedAt = await getIncontextSignupDismissedAt();
   return {
     success: {
       // @ts-ignore
@@ -17267,8 +17339,14 @@ async function extensionSpecificRuntimeConfiguration(globalConfig) {
           autofill: {
             settings: {
               featureToggles: { ..._Settings.Settings.defaults.featureToggles,
-                emailProtection: emailProtectionEnabled
+                emailProtection: emailProtectionEnabled,
+                emailProtection_incontext_signup: incontextSignupEnabled
               }
+            }
+          },
+          incontextSignup: {
+            settings: {
+              dismissedAt: incontextSignupDismissedAt
             }
           }
         }
@@ -17315,6 +17393,16 @@ async function extensionSpecificSendPixel(pixelName) {
       }
     }, () => {
       resolve(true);
+    });
+  });
+}
+
+async function getIncontextSignupDismissedAt() {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({
+      messageType: 'getIncontextSignupDismissedAt'
+    }, response => {
+      resolve(response);
     });
   });
 }

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8120,6 +8120,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
     switch (this.getShowingTooltip()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
+          var _this$activeForm;
+
           this._scannerCleanup = this.scanner.init();
           this.addLogoutListener(() => {
             this.resetAutofillUI();
@@ -8132,6 +8134,13 @@ class ExtensionInterface extends _InterfacePrototype.default {
               });
             }
           });
+
+          if ((_this$activeForm = this.activeForm) !== null && _this$activeForm !== void 0 && _this$activeForm.activeInput) {
+            var _this$activeForm2;
+
+            this.attachTooltip(this.activeForm, (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.activeInput, null, 'postSignup');
+          }
+
           break;
         }
 
@@ -8752,7 +8761,7 @@ class InterfacePrototype {
    * @param {import("../Form/Form").Form} form
    * @param {HTMLInputElement} input
    * @param {{ x: number; y: number; } | null} click
-   * @param {'userInitiated' | 'autoprompt'} trigger
+   * @param {import('../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
    */
 
 
@@ -8761,7 +8770,7 @@ class InterfacePrototype {
 
     let trigger = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'userInitiated';
     // Avoid flashing tooltip from background tabs on macOS
-    if (document.visibilityState !== 'visible') return; // Only autoprompt on mobile devices
+    if (document.visibilityState !== 'visible' && trigger !== 'postSignup') return; // Only autoprompt on mobile devices
 
     if (trigger === 'autoprompt' && !this.globalConfig.isMobileApp) return; // Only fire autoprompt once
 
@@ -15846,7 +15855,7 @@ exports.UIController = void 0;
  * @property {{x: number, y: number}|null} click The click positioning
  * @property {TopContextData} topContextData
  * @property {import("../../DeviceInterface/InterfacePrototype").default} device
- * @property {'userInitiated' | 'autoprompt'} trigger
+ * @property {import('../../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
  */
 
 /**
@@ -17068,7 +17077,7 @@ const getAutofillDataRequestSchema = _zod.z.object({
   inputType: _zod.z.string(),
   mainType: _zod.z.union([_zod.z.literal("credentials"), _zod.z.literal("identities"), _zod.z.literal("creditCards")]),
   subType: _zod.z.string(),
-  trigger: _zod.z.union([_zod.z.literal("userInitiated"), _zod.z.literal("autoprompt")]).optional(),
+  trigger: _zod.z.union([_zod.z.literal("userInitiated"), _zod.z.literal("autoprompt"), _zod.z.literal("postSignup")]).optional(),
   serializedInputContext: _zod.z.string().optional(),
   triggerContext: triggerContextSchema.optional()
 });

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8062,6 +8062,12 @@ class ExtensionInterface extends _InterfacePrototype.default {
     return null;
   }
 
+  onIncontextSignup() {
+    this.firePixel({
+      pixelName: 'incontext_get_email_protection'
+    });
+  }
+
   onIncontextSignupDismissed() {
     // Check if the email signup tooltip has previously been dismissed.
     // If it has, make the dismissal persist and remove it from the page.
@@ -8072,9 +8078,15 @@ class ExtensionInterface extends _InterfacePrototype.default {
         value: new Date().getTime()
       }));
       this.removeAutofillUIFromPage();
+      this.firePixel({
+        pixelName: 'incontext_dismiss_persisted'
+      });
     } else {
       this.emailSignupInitialDismissal = true;
       this.removeTooltip();
+      this.firePixel({
+        pixelName: 'incontext_dismiss_initial'
+      });
     }
   }
 
@@ -8462,6 +8474,8 @@ class InterfacePrototype {
   }
   /** @type { PMData } */
 
+
+  onIncontextSignup() {}
 
   onIncontextSignupDismissed() {}
   /**
@@ -14870,11 +14884,15 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {
       device.onIncontextSignupDismissed();
+    });
+    this.getEmailSignup = this.shadow.querySelector('.js-get-email-signup');
+    this.registerClickableButton(this.getEmailSignup, () => {
+      device.onIncontextSignup();
     });
     this.init();
     return this;
@@ -15294,6 +15312,10 @@ class HTMLTooltipUIController extends _UIController.UIController {
     }
 
     if (this._options.tooltipKind === 'emailsignup') {
+      this._options.device.firePixel({
+        pixelName: 'incontext_show'
+      });
+
       return new _EmailSignupHTMLTooltop.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
     } // collect the data for each item to display
 
@@ -17027,6 +17049,14 @@ const sendJSPixelParamsSchema = _zod.z.union([_zod.z.object({
   pixelName: _zod.z.literal("autofill_personal_address")
 }), _zod.z.object({
   pixelName: _zod.z.literal("autofill_private_address")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_show")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_get_email_protection")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_dismiss_persisted")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_dismiss_initial")
 })]);
 
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8043,14 +8043,14 @@ class ExtensionInterface extends _InterfacePrototype.default {
       [TOOLTIP_TYPES.EmailProtection]: 'legacy',
       [TOOLTIP_TYPES.EmailSignup]: 'emailsignup'
     };
-    const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
+    const tooltipKind = tooltipKinds[this.getActiveTooltipType()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
     return new _HTMLTooltipUIController.HTMLTooltipUIController({
       tooltipKind,
       device: this
     }, htmlTooltipOptions);
   }
 
-  getShowingTooltip() {
+  getActiveTooltipType() {
     if (this.hasLocalAddresses) {
       return TOOLTIP_TYPES.EmailProtection;
     }
@@ -8129,7 +8129,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   postInit() {
-    switch (this.getShowingTooltip()) {
+    switch (this.getActiveTooltipType()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
           var _this$activeForm;
@@ -8270,6 +8270,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   addLogoutListener(handler) {
+    // Make sure there's only one log out listener attached by removing the
+    // previous logout listener first, if it exists.
     if (this._logoutListenerHandler) {
       chrome.runtime.onMessage.removeListener(this._logoutListenerHandler);
     } // Cleanup on logout events
@@ -9711,7 +9713,7 @@ class Form {
 
     this.form = form;
     this.matching = matching || (0, _matching.createMatching)();
-    this.formAnalyzer = new _FormAnalyzer.default(form, input, deviceInterface.globalConfig, matching);
+    this.formAnalyzer = new _FormAnalyzer.default(form, input, matching);
     this.isLogin = this.formAnalyzer.isLogin;
     this.isSignup = this.formAnalyzer.isSignup;
     this.isHybrid = this.formAnalyzer.isHybrid;
@@ -10309,10 +10311,9 @@ class FormAnalyzer {
   /**
    * @param {HTMLElement} form
    * @param {HTMLInputElement|HTMLSelectElement} input
-   * @param {GlobalConfig} config
    * @param {Matching} [matching]
    */
-  constructor(form, input, config, matching) {
+  constructor(form, input, matching) {
     _defineProperty(this, "form", void 0);
 
     _defineProperty(this, "matching", void 0);
@@ -10336,12 +10337,7 @@ class FormAnalyzer {
      * @type {boolean}
      */
 
-    this.isHybrid = false; // Avoid autofill on Email Protection web app
-
-    if (config.isDDGDomain) {
-      return this;
-    }
-
+    this.isHybrid = false;
     this.evaluateElAttributes(input, 3, true);
     form ? this.evaluateForm() : this.evaluatePage();
     return this;

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8034,6 +8034,8 @@ var _HTMLTooltipUIController = require("../UI/controllers/HTMLTooltipUIControlle
 
 var _HTMLTooltip = require("../UI/HTMLTooltip.js");
 
+var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const TOOLTIP_TYPES = {
@@ -8076,17 +8078,15 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
   onIncontextSignupDismissed() {
     this.settings.setIncontextSignupDismissed(true);
-    chrome.runtime.sendMessage({
-      messageType: 'setIncontextSignupDismissedAt',
-      options: {
-        value: new Date().getTime()
-      }
-    });
+    this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+      value: new Date().getTime()
+    }));
     this.removeAutofillUIFromPage();
   }
 
   async resetAutofillUI() {
-    this.removeAutofillUIFromPage(); // Start the setup process again
+    this.removeAutofillUIFromPage(); // TOOD: can we use recategorizeAllInputs here?
+    // Start the setup process again
 
     await this.refreshSettings();
     await this.setupAutofill(); // TODO: Do we need this to be called?
@@ -8265,7 +8265,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
 exports.ExtensionInterface = ExtensionInterface;
 
-},{"../UI/HTMLTooltip.js":53,"../UI/controllers/HTMLTooltipUIController.js":54,"../autofill-utils.js":60,"./InterfacePrototype.js":27}],27:[function(require,module,exports){
+},{"../UI/HTMLTooltip.js":53,"../UI/controllers/HTMLTooltipUIController.js":54,"../autofill-utils.js":60,"../deviceApiCalls/__generated__/deviceApiCalls.js":64,"./InterfacePrototype.js":27}],27:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15224,7 +15224,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   }
 
   destroy() {
-    this.removeTooltip('destroy');
+    this.removeTooltip();
 
     this._removeListeners();
 
@@ -16523,7 +16523,7 @@ exports.constants = constants;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.StoreFormDataCall = exports.SetSizeCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
+exports.StoreFormDataCall = exports.SetSizeCall = exports.SetIncontextSignupDismissedAtCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetIncontextSignupDismissedAtCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
 
 var _validatorsZod = require("./validators.zod.js");
 
@@ -16747,8 +16747,44 @@ class SendJSPixelCall extends _deviceApi.DeviceApiCall {
   }
 
 }
+/**
+ * @extends {DeviceApiCall<setIncontextSignupDismissedAtSchema, any>} 
+ */
+
 
 exports.SendJSPixelCall = SendJSPixelCall;
+
+class SetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "setIncontextSignupDismissedAt");
+
+    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupDismissedAtSchema);
+  }
+
+}
+/**
+ * @extends {DeviceApiCall<any, getIncontextSignupDismissedAtSchema>} 
+ */
+
+
+exports.SetIncontextSignupDismissedAtCall = SetIncontextSignupDismissedAtCall;
+
+class GetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "getIncontextSignupDismissedAt");
+
+    _defineProperty(this, "id", "getIncontextSignupDismissedAt");
+
+    _defineProperty(this, "resultValidator", _validatorsZod.getIncontextSignupDismissedAtSchema);
+  }
+
+}
+
+exports.GetIncontextSignupDismissedAtCall = GetIncontextSignupDismissedAtCall;
 
 },{"../../../packages/device-api":14,"./validators.zod.js":65}],65:[function(require,module,exports){
 "use strict";
@@ -16756,7 +16792,7 @@ exports.SendJSPixelCall = SendJSPixelCall;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
+exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.setIncontextSignupDismissedAtSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getIncontextSignupDismissedAtSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
 
 var _zod = require("zod");
 
@@ -16910,6 +16946,14 @@ const getAvailableInputTypesResultSchema = _zod.z.object({
 
 exports.getAvailableInputTypesResultSchema = getAvailableInputTypesResultSchema;
 
+const getIncontextSignupDismissedAtSchema = _zod.z.object({
+  success: _zod.z.object({
+    value: _zod.z.number().optional()
+  })
+});
+
+exports.getIncontextSignupDismissedAtSchema = getIncontextSignupDismissedAtSchema;
+
 const contentScopeSchema = _zod.z.object({
   features: _zod.z.record(_zod.z.object({
     exceptions: _zod.z.array(_zod.z.unknown()),
@@ -16968,6 +17012,12 @@ const sendJSPixelParamsSchema = _zod.z.union([_zod.z.object({
 })]);
 
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;
+
+const setIncontextSignupDismissedAtSchema = _zod.z.object({
+  value: _zod.z.number().optional()
+});
+
+exports.setIncontextSignupDismissedAtSchema = setIncontextSignupDismissedAtSchema;
 
 const setSizeParamsSchema = _zod.z.object({
   height: _zod.z.number(),
@@ -17330,11 +17380,19 @@ class ExtensionTransport extends _index.DeviceApiTransport {
 
   async send(deviceApiCall) {
     if (deviceApiCall instanceof _deviceApiCalls.GetRuntimeConfigurationCall) {
-      return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this.config));
+      return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this));
     }
 
     if (deviceApiCall instanceof _deviceApiCalls.GetAvailableInputTypesCall) {
       return deviceApiCall.result(await extensionSpecificGetAvailableInputTypes());
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params.value));
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.GetIncontextSignupDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificGetIncontextSignupDismissedAt());
     } // TODO: unify all calls to use deviceApiCall.method instead of all these if blocks
 
 
@@ -17347,18 +17405,20 @@ class ExtensionTransport extends _index.DeviceApiTransport {
 
 }
 /**
- * @param {GlobalConfig} globalConfig
+ * @param {ExtensionTransport} deviceApi
  * @returns {Promise<ReturnType<GetRuntimeConfigurationCall['result']>>}
  */
 
 
 exports.ExtensionTransport = ExtensionTransport;
 
-async function extensionSpecificRuntimeConfiguration(globalConfig) {
+async function extensionSpecificRuntimeConfiguration(deviceApi) {
+  var _deviceApi$config;
+
   const contentScope = await getContentScopeConfig();
   const emailProtectionEnabled = (0, _autofillUtils.isAutofillEnabledFromProcessedConfig)(contentScope);
   const incontextSignupEnabled = (0, _autofillUtils.isIncontextSignupEnabledFromProcessedConfig)(contentScope);
-  const incontextSignupDismissedAt = await getIncontextSignupDismissedAt();
+  const incontextSignupDismissedAt = await deviceApi.send(new _deviceApiCalls.GetIncontextSignupDismissedAtCall(null));
   return {
     success: {
       // @ts-ignore
@@ -17376,13 +17436,13 @@ async function extensionSpecificRuntimeConfiguration(globalConfig) {
           },
           incontextSignup: {
             settings: {
-              dismissedAt: incontextSignupDismissedAt
+              dismissedAt: incontextSignupDismissedAt.success.value
             }
           }
         }
       },
       // @ts-ignore
-      userUnprotectedDomains: globalConfig === null || globalConfig === void 0 ? void 0 : globalConfig.userUnprotectedDomains
+      userUnprotectedDomains: (_deviceApi$config = deviceApi.config) === null || _deviceApi$config === void 0 ? void 0 : _deviceApi$config.userUnprotectedDomains
     }
   };
 }
@@ -17427,12 +17487,25 @@ async function extensionSpecificSendPixel(pixelName) {
   });
 }
 
-async function getIncontextSignupDismissedAt() {
+async function extensionSpecificGetIncontextSignupDismissedAt() {
   return new Promise(resolve => {
     chrome.runtime.sendMessage({
       messageType: 'getIncontextSignupDismissedAt'
     }, response => {
       resolve(response);
+    });
+  });
+}
+
+async function extensionSpecificSetIncontextSignupDismissedAt(value) {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({
+      messageType: 'setIncontextSignupDismissedAt',
+      options: {
+        value
+      }
+    }, () => {
+      resolve(true);
     });
   });
 }

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8097,11 +8097,19 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   onIncontextSignupDismissed() {
-    this.settings.setIncontextSignupDismissed(true);
-    this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
-      value: new Date().getTime()
-    }));
-    this.removeAutofillUIFromPage();
+    // Check if the email signup tooltip has previously been dismissed.
+    // If it has, make the dismissal persist and remove it from the page.
+    // If it hasn't, set a flag for next time and just hide the tooltip.
+    if (this.emailSignupInitialDismissal) {
+      this.settings.setIncontextSignupDismissed(true);
+      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+        value: new Date().getTime()
+      }));
+      this.removeAutofillUIFromPage();
+    } else {
+      this.emailSignupInitialDismissal = true;
+      this.removeTooltip();
+    }
   }
 
   async resetAutofillUI(callback) {
@@ -8394,6 +8402,8 @@ class InterfacePrototype {
     _defineProperty(this, "initialSetupDelayMs", 0);
 
     _defineProperty(this, "autopromptFired", false);
+
+    _defineProperty(this, "emailSignupInitialDismissal", false);
 
     _defineProperty(this, "passwordGenerator", new _PasswordGenerator.PasswordGenerator());
 
@@ -14873,7 +14883,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                Not Now\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15252,16 +15252,19 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     _defineProperty(this, "_activeInputType", 'unknown');
 
+    _defineProperty(this, "_activeInput", void 0);
+
+    _defineProperty(this, "_activeInputOriginalAutocomplete", void 0);
+
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
   }
+
   /**
    * Cleans up after this UI controller by removing the tooltip and all
    * listeners.
    */
-
-
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
@@ -15285,6 +15288,9 @@ class HTMLTooltipUIController extends _UIController.UIController {
     const tooltip = this.createTooltip(getPosition, topContextData);
     this.setActiveTooltip(tooltip);
     form.showingTooltip(input);
+    this._activeInput = input;
+    this._activeInputOriginalAutocomplete = input.getAttribute('autocomplete');
+    input.setAttribute('autocomplete', 'off');
   }
   /**
    * Actually create the HTML Tooltip
@@ -15423,6 +15429,17 @@ class HTMLTooltipUIController extends _UIController.UIController {
       this._activeTooltip.remove();
 
       this._activeTooltip = null;
+    }
+
+    if (this._activeInput) {
+      if (this._activeInputOriginalAutocomplete) {
+        this._activeInput.setAttribute('autocomplete', this._activeInputOriginalAutocomplete);
+      } else {
+        this._activeInput.removeAttribute('autocomplete');
+      }
+
+      this._activeInput = null;
+      this._activeInputOriginalAutocomplete = null;
     }
   }
   /**

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4421,11 +4421,19 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   onIncontextSignupDismissed() {
-    this.settings.setIncontextSignupDismissed(true);
-    this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
-      value: new Date().getTime()
-    }));
-    this.removeAutofillUIFromPage();
+    // Check if the email signup tooltip has previously been dismissed.
+    // If it has, make the dismissal persist and remove it from the page.
+    // If it hasn't, set a flag for next time and just hide the tooltip.
+    if (this.emailSignupInitialDismissal) {
+      this.settings.setIncontextSignupDismissed(true);
+      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+        value: new Date().getTime()
+      }));
+      this.removeAutofillUIFromPage();
+    } else {
+      this.emailSignupInitialDismissal = true;
+      this.removeTooltip();
+    }
   }
 
   async resetAutofillUI(callback) {
@@ -4718,6 +4726,8 @@ class InterfacePrototype {
     _defineProperty(this, "initialSetupDelayMs", 0);
 
     _defineProperty(this, "autopromptFired", false);
+
+    _defineProperty(this, "emailSignupInitialDismissal", false);
 
     _defineProperty(this, "passwordGenerator", new _PasswordGenerator.PasswordGenerator());
 
@@ -11197,7 +11207,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                Not Now\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4367,14 +4367,14 @@ class ExtensionInterface extends _InterfacePrototype.default {
       [TOOLTIP_TYPES.EmailProtection]: 'legacy',
       [TOOLTIP_TYPES.EmailSignup]: 'emailsignup'
     };
-    const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
+    const tooltipKind = tooltipKinds[this.getActiveTooltipType()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
     return new _HTMLTooltipUIController.HTMLTooltipUIController({
       tooltipKind,
       device: this
     }, htmlTooltipOptions);
   }
 
-  getShowingTooltip() {
+  getActiveTooltipType() {
     if (this.hasLocalAddresses) {
       return TOOLTIP_TYPES.EmailProtection;
     }
@@ -4453,7 +4453,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   postInit() {
-    switch (this.getShowingTooltip()) {
+    switch (this.getActiveTooltipType()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
           var _this$activeForm;
@@ -4594,6 +4594,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   addLogoutListener(handler) {
+    // Make sure there's only one log out listener attached by removing the
+    // previous logout listener first, if it exists.
     if (this._logoutListenerHandler) {
       chrome.runtime.onMessage.removeListener(this._logoutListenerHandler);
     } // Cleanup on logout events
@@ -6035,7 +6037,7 @@ class Form {
 
     this.form = form;
     this.matching = matching || (0, _matching.createMatching)();
-    this.formAnalyzer = new _FormAnalyzer.default(form, input, deviceInterface.globalConfig, matching);
+    this.formAnalyzer = new _FormAnalyzer.default(form, input, matching);
     this.isLogin = this.formAnalyzer.isLogin;
     this.isSignup = this.formAnalyzer.isSignup;
     this.isHybrid = this.formAnalyzer.isHybrid;
@@ -6633,10 +6635,9 @@ class FormAnalyzer {
   /**
    * @param {HTMLElement} form
    * @param {HTMLInputElement|HTMLSelectElement} input
-   * @param {GlobalConfig} config
    * @param {Matching} [matching]
    */
-  constructor(form, input, config, matching) {
+  constructor(form, input, matching) {
     _defineProperty(this, "form", void 0);
 
     _defineProperty(this, "matching", void 0);
@@ -6660,12 +6661,7 @@ class FormAnalyzer {
      * @type {boolean}
      */
 
-    this.isHybrid = false; // Avoid autofill on Email Protection web app
-
-    if (config.isDDGDomain) {
-      return this;
-    }
-
+    this.isHybrid = false;
     this.evaluateElAttributes(input, 3, true);
     form ? this.evaluateForm() : this.evaluatePage();
     return this;

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -11576,16 +11576,19 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     _defineProperty(this, "_activeInputType", 'unknown');
 
+    _defineProperty(this, "_activeInput", void 0);
+
+    _defineProperty(this, "_activeInputOriginalAutocomplete", void 0);
+
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
   }
+
   /**
    * Cleans up after this UI controller by removing the tooltip and all
    * listeners.
    */
-
-
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
@@ -11609,6 +11612,9 @@ class HTMLTooltipUIController extends _UIController.UIController {
     const tooltip = this.createTooltip(getPosition, topContextData);
     this.setActiveTooltip(tooltip);
     form.showingTooltip(input);
+    this._activeInput = input;
+    this._activeInputOriginalAutocomplete = input.getAttribute('autocomplete');
+    input.setAttribute('autocomplete', 'off');
   }
   /**
    * Actually create the HTML Tooltip
@@ -11747,6 +11753,17 @@ class HTMLTooltipUIController extends _UIController.UIController {
       this._activeTooltip.remove();
 
       this._activeTooltip = null;
+    }
+
+    if (this._activeInput) {
+      if (this._activeInputOriginalAutocomplete) {
+        this._activeInput.setAttribute('autocomplete', this._activeInputOriginalAutocomplete);
+      } else {
+        this._activeInput.removeAttribute('autocomplete');
+      }
+
+      this._activeInput = null;
+      this._activeInputOriginalAutocomplete = null;
     }
   }
   /**

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4408,14 +4408,13 @@ class ExtensionInterface extends _InterfacePrototype.default {
     this.removeAutofillUIFromPage();
   }
 
-  async resetAutofillUI() {
+  async resetAutofillUI(callback) {
     this.removeAutofillUIFromPage(); // TOOD: can we use recategorizeAllInputs here?
     // Start the setup process again
 
     await this.refreshSettings();
-    await this.setupAutofill(); // TODO: Do we need this to be called?
-    // await this.setupSettingsPage({shouldLog: true})
-
+    await this.setupAutofill();
+    if (callback) await callback();
     this.uiController = this.createUIController();
     await this.postInit();
   }
@@ -4551,7 +4550,9 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
       switch (message.type) {
         case 'ddgUserReady':
-          this.resetAutofillUI();
+          this.resetAutofillUI(() => this.setupSettingsPage({
+            shouldLog: true
+          }));
           break;
 
         case 'contextualAutofill':
@@ -10450,8 +10451,6 @@ class DefaultScanner {
 
 
   init() {
-    var _this = this;
-
     const delay = this.options.initialDelay; // if the delay is zero, (chrome/firefox etc) then use `requestIdleCallback`
 
     if (delay === 0) {
@@ -10461,25 +10460,22 @@ class DefaultScanner {
       setTimeout(() => this.scanAndObserve(), delay);
     }
 
-    return function () {
-      let {
-        silent
-      } = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {
-        silent: false
-      };
-      // remove Dax, listeners, timers, and observers
-      clearTimeout(_this.debounceTimer);
+    return () => {
+      var _this$device$activeFo;
 
-      _this.mutObs.disconnect();
+      const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
 
-      _this.forms.forEach(form => {
+      clearTimeout(this.debounceTimer);
+      this.mutObs.disconnect();
+      this.forms.forEach(form => {
         form.resetAllInputs();
         form.removeAllDecorations();
       });
+      this.forms.clear(); // Bring the user back to the input they were interacting with
 
-      _this.forms.clear();
+      activeInput === null || activeInput === void 0 ? void 0 : activeInput.focus();
 
-      if (_this.device.globalConfig.isDDGDomain && !silent) {
+      if (this.device.globalConfig.isDDGDomain) {
         (0, _autofillUtils.notifyWebApp)({
           deviceSignedIn: {
             value: false

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4379,7 +4379,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
       return TOOLTIP_TYPES.EmailProtection;
     }
 
-    if (this.settings.featureToggles.emailProtection_incontext_signup && this.settings.incontextSignupDismissed === false) {
+    if (this.settings.featureToggles.emailProtection_incontext_signup && this.settings.incontextSignupPermanentlyDismissed === false) {
       return TOOLTIP_TYPES.EmailSignup;
     }
 
@@ -4396,9 +4396,9 @@ class ExtensionInterface extends _InterfacePrototype.default {
     // Check if the email signup tooltip has previously been dismissed.
     // If it has, make the dismissal persist and remove it from the page.
     // If it hasn't, set a flag for next time and just hide the tooltip.
-    if (this.emailSignupInitialDismissal) {
-      this.settings.setIncontextSignupDismissed(true);
-      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+    if (this.settings.incontextSignupInitiallyDismissed) {
+      this.settings.setIncontextSignupPermanentlyDismissed(true);
+      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupPermanentlyDismissedAtCall({
         value: new Date().getTime()
       }));
       this.removeAutofillUIFromPage();
@@ -4406,7 +4406,10 @@ class ExtensionInterface extends _InterfacePrototype.default {
         pixelName: 'incontext_dismiss_persisted'
       });
     } else {
-      this.emailSignupInitialDismissal = true;
+      this.settings.setIncontextSignupInitiallyDismissed(true);
+      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupInitiallyDismissedAtCall({
+        value: new Date().getTime()
+      }));
       this.removeTooltip();
       this.firePixel({
         pixelName: 'incontext_dismiss_initial'
@@ -4715,8 +4718,6 @@ class InterfacePrototype {
     _defineProperty(this, "initialSetupDelayMs", 0);
 
     _defineProperty(this, "autopromptFired", false);
-
-    _defineProperty(this, "emailSignupInitialDismissal", false);
 
     _defineProperty(this, "passwordGenerator", new _PasswordGenerator.PasswordGenerator());
 
@@ -10732,6 +10733,8 @@ class Settings {
 
   /** @type {boolean | null} */
 
+  /** @type {boolean | null} */
+
   /**
    * @param {GlobalConfig} config
    * @param {DeviceApi} deviceApi
@@ -10749,7 +10752,9 @@ class Settings {
 
     _defineProperty(this, "_enabled", null);
 
-    _defineProperty(this, "_incontextSignupDismissed", null);
+    _defineProperty(this, "_incontextSignupInitiallyDismissed", null);
+
+    _defineProperty(this, "_incontextSignupPermanentlyDismissed", null);
 
     this.deviceApi = deviceApi;
     this.globalConfig = config;
@@ -10811,13 +10816,25 @@ class Settings {
    */
 
 
-  async getIncontextSignupDismissed() {
+  async getIncontextSignupInitiallyDismissed() {
     try {
       var _runtimeConfig$userPr4, _runtimeConfig$userPr5, _runtimeConfig$userPr6;
 
       const runtimeConfig = await this._getRuntimeConfiguration();
       const incontextSignupSettings = (0, _index.validate)((_runtimeConfig$userPr4 = runtimeConfig.userPreferences) === null || _runtimeConfig$userPr4 === void 0 ? void 0 : (_runtimeConfig$userPr5 = _runtimeConfig$userPr4.features) === null || _runtimeConfig$userPr5 === void 0 ? void 0 : (_runtimeConfig$userPr6 = _runtimeConfig$userPr5.incontextSignup) === null || _runtimeConfig$userPr6 === void 0 ? void 0 : _runtimeConfig$userPr6.settings, _validatorsZod.incontextSignupSettingsSchema);
-      return Boolean(incontextSignupSettings.dismissedAt);
+      return Boolean(incontextSignupSettings.initiallyDismissedAt);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  async getIncontextSignupPermanentlyDismissed() {
+    try {
+      var _runtimeConfig$userPr7, _runtimeConfig$userPr8, _runtimeConfig$userPr9;
+
+      const runtimeConfig = await this._getRuntimeConfiguration();
+      const incontextSignupSettings = (0, _index.validate)((_runtimeConfig$userPr7 = runtimeConfig.userPreferences) === null || _runtimeConfig$userPr7 === void 0 ? void 0 : (_runtimeConfig$userPr8 = _runtimeConfig$userPr7.features) === null || _runtimeConfig$userPr8 === void 0 ? void 0 : (_runtimeConfig$userPr9 = _runtimeConfig$userPr8.incontextSignup) === null || _runtimeConfig$userPr9 === void 0 ? void 0 : _runtimeConfig$userPr9.settings, _validatorsZod.incontextSignupSettingsSchema);
+      return Boolean(incontextSignupSettings.permanentlyDismissedAt);
     } catch (e) {
       return null;
     }
@@ -10878,7 +10895,8 @@ class Settings {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
     this.setAvailableInputTypes(await this.getAvailableInputTypes());
-    this.setIncontextSignupDismissed(await this.getIncontextSignupDismissed()); // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
+    this.setIncontextSignupInitiallyDismissed(await this.getIncontextSignupInitiallyDismissed());
+    this.setIncontextSignupPermanentlyDismissed(await this.getIncontextSignupPermanentlyDismissed()); // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
 
     if (typeof this.enabled === 'boolean') {
       if (!this.enabled) {
@@ -10985,16 +11003,30 @@ class Settings {
   /** @returns {boolean|null} */
 
 
-  get incontextSignupDismissed() {
-    return this._incontextSignupDismissed;
+  get incontextSignupInitiallyDismissed() {
+    return this._incontextSignupInitiallyDismissed;
   }
   /**
-   * @param {boolean|null} incontextSignupDismissed
+   * @param {boolean|null} incontextSignupInitiallyDismissed
    */
 
 
-  setIncontextSignupDismissed(incontextSignupDismissed) {
-    this._incontextSignupDismissed = incontextSignupDismissed;
+  setIncontextSignupInitiallyDismissed(incontextSignupInitiallyDismissed) {
+    this._incontextSignupInitiallyDismissed = incontextSignupInitiallyDismissed;
+  }
+  /** @returns {boolean|null} */
+
+
+  get incontextSignupPermanentlyDismissed() {
+    return this._incontextSignupPermanentlyDismissed;
+  }
+  /**
+   * @param {boolean|null} incontextSignupPermanentlyDismissed
+   */
+
+
+  setIncontextSignupPermanentlyDismissed(incontextSignupPermanentlyDismissed) {
+    this._incontextSignupPermanentlyDismissed = incontextSignupPermanentlyDismissed;
   }
 
 }
@@ -11204,7 +11236,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.settings.incontextSignupInitiallyDismissed ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {
@@ -12900,7 +12932,7 @@ exports.constants = constants;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.StoreFormDataCall = exports.SetSizeCall = exports.SetIncontextSignupDismissedAtCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetIncontextSignupDismissedAtCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
+exports.StoreFormDataCall = exports.SetSizeCall = exports.SetIncontextSignupPermanentlyDismissedAtCall = exports.SetIncontextSignupInitiallyDismissedAtCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetIncontextSignupDismissedAtCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
 
 var _validatorsZod = require("./validators.zod.js");
 
@@ -13125,19 +13157,36 @@ class SendJSPixelCall extends _deviceApi.DeviceApiCall {
 
 }
 /**
- * @extends {DeviceApiCall<setIncontextSignupDismissedAtSchema, any>} 
+ * @extends {DeviceApiCall<setIncontextSignupInitiallyDismissedAtSchema, any>} 
  */
 
 
 exports.SendJSPixelCall = SendJSPixelCall;
 
-class SetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+class SetIncontextSignupInitiallyDismissedAtCall extends _deviceApi.DeviceApiCall {
   constructor() {
     super(...arguments);
 
-    _defineProperty(this, "method", "setIncontextSignupDismissedAt");
+    _defineProperty(this, "method", "setIncontextSignupInitiallyDismissedAt");
 
-    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupDismissedAtSchema);
+    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupInitiallyDismissedAtSchema);
+  }
+
+}
+/**
+ * @extends {DeviceApiCall<setIncontextSignupPermanentlyDismissedAtSchema, any>} 
+ */
+
+
+exports.SetIncontextSignupInitiallyDismissedAtCall = SetIncontextSignupInitiallyDismissedAtCall;
+
+class SetIncontextSignupPermanentlyDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "setIncontextSignupPermanentlyDismissedAt");
+
+    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupPermanentlyDismissedAtSchema);
   }
 
 }
@@ -13146,7 +13195,7 @@ class SetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
  */
 
 
-exports.SetIncontextSignupDismissedAtCall = SetIncontextSignupDismissedAtCall;
+exports.SetIncontextSignupPermanentlyDismissedAtCall = SetIncontextSignupPermanentlyDismissedAtCall;
 
 class GetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
   constructor() {
@@ -13169,7 +13218,7 @@ exports.GetIncontextSignupDismissedAtCall = GetIncontextSignupDismissedAtCall;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.setIncontextSignupDismissedAtSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getIncontextSignupDismissedAtSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
+exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.setIncontextSignupPermanentlyDismissedAtSchema = exports.setIncontextSignupInitiallyDismissedAtSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getIncontextSignupDismissedAtSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
 const credentialsSchema = null;
 exports.credentialsSchema = credentialsSchema;
 const availableInputTypesSchema = null;
@@ -13210,8 +13259,10 @@ const selectedDetailParamsSchema = null;
 exports.selectedDetailParamsSchema = selectedDetailParamsSchema;
 const sendJSPixelParamsSchema = null;
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;
-const setIncontextSignupDismissedAtSchema = null;
-exports.setIncontextSignupDismissedAtSchema = setIncontextSignupDismissedAtSchema;
+const setIncontextSignupInitiallyDismissedAtSchema = null;
+exports.setIncontextSignupInitiallyDismissedAtSchema = setIncontextSignupInitiallyDismissedAtSchema;
+const setIncontextSignupPermanentlyDismissedAtSchema = null;
+exports.setIncontextSignupPermanentlyDismissedAtSchema = setIncontextSignupPermanentlyDismissedAtSchema;
 const setSizeParamsSchema = null;
 exports.setSizeParamsSchema = setSizeParamsSchema;
 const outgoingCredentialsSchema = null;
@@ -13536,8 +13587,12 @@ class ExtensionTransport extends _index.DeviceApiTransport {
       return deviceApiCall.result(await extensionSpecificGetAvailableInputTypes());
     }
 
-    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupDismissedAtCall) {
-      return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params));
+    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupInitiallyDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificSetIncontextSignupInitiallyDismissedAtCall(deviceApiCall.params));
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupPermanentlyDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificSetIncontextSignupPermanentlyDismissedAtCall(deviceApiCall.params));
     }
 
     if (deviceApiCall instanceof _deviceApiCalls.GetIncontextSignupDismissedAtCall) {
@@ -13585,7 +13640,8 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
           },
           incontextSignup: {
             settings: {
-              dismissedAt: incontextSignupDismissedAt.success.value
+              initiallyDismissedAt: incontextSignupDismissedAt.success.initiallyDismissedAt,
+              permanentlyDismissedAt: incontextSignupDismissedAt.success.permanentlyDismissedAt
             }
           }
         }
@@ -13644,14 +13700,29 @@ async function extensionSpecificGetIncontextSignupDismissedAt() {
   });
 }
 /**
- * @param {import('../__generated__/validators-ts').SetIncontextSignupDismissedAt} params
+ * @param {import('../__generated__/validators-ts').SetIncontextSignupInitiallyDismissedAt} params
  */
 
 
-async function extensionSpecificSetIncontextSignupDismissedAt(params) {
+async function extensionSpecificSetIncontextSignupInitiallyDismissedAtCall(params) {
   return new Promise(resolve => {
     chrome.runtime.sendMessage({
-      messageType: 'setIncontextSignupDismissedAt',
+      messageType: 'setIncontextSignupInitiallyDismissedAt',
+      options: params
+    }, () => {
+      resolve(true);
+    });
+  });
+}
+/**
+ * @param {import('../__generated__/validators-ts').SetIncontextSignupPermanentlyDismissedAt} params
+ */
+
+
+async function extensionSpecificSetIncontextSignupPermanentlyDismissedAtCall(params) {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({
+      messageType: 'setIncontextSignupPermanentlyDismissedAt',
       options: params
     }, () => {
       resolve(true);

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4386,6 +4386,12 @@ class ExtensionInterface extends _InterfacePrototype.default {
     return null;
   }
 
+  onIncontextSignup() {
+    this.firePixel({
+      pixelName: 'incontext_get_email_protection'
+    });
+  }
+
   onIncontextSignupDismissed() {
     // Check if the email signup tooltip has previously been dismissed.
     // If it has, make the dismissal persist and remove it from the page.
@@ -4396,9 +4402,15 @@ class ExtensionInterface extends _InterfacePrototype.default {
         value: new Date().getTime()
       }));
       this.removeAutofillUIFromPage();
+      this.firePixel({
+        pixelName: 'incontext_dismiss_persisted'
+      });
     } else {
       this.emailSignupInitialDismissal = true;
       this.removeTooltip();
+      this.firePixel({
+        pixelName: 'incontext_dismiss_initial'
+      });
     }
   }
 
@@ -4786,6 +4798,8 @@ class InterfacePrototype {
   }
   /** @type { PMData } */
 
+
+  onIncontextSignup() {}
 
   onIncontextSignupDismissed() {}
   /**
@@ -11194,11 +11208,15 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {
       device.onIncontextSignupDismissed();
+    });
+    this.getEmailSignup = this.shadow.querySelector('.js-get-email-signup');
+    this.registerClickableButton(this.getEmailSignup, () => {
+      device.onIncontextSignup();
     });
     this.init();
     return this;
@@ -11618,6 +11636,10 @@ class HTMLTooltipUIController extends _UIController.UIController {
     }
 
     if (this._options.tooltipKind === 'emailsignup') {
+      this._options.device.firePixel({
+        pixelName: 'incontext_show'
+      });
+
       return new _EmailSignupHTMLTooltop.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
     } // collect the data for each item to display
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4406,11 +4406,25 @@ class ExtensionInterface extends _InterfacePrototype.default {
         value: new Date().getTime()
       }
     });
-    this.removeAutofillFromUI();
+    this.removeAutofillUIFromPage();
   }
 
-  removeAutofillFromUI() {
-    this._scannerCleanup && this._scannerCleanup();
+  async resetAutofillUI() {
+    this.removeAutofillUIFromPage(); // Start the setup process again
+
+    await this.refreshSettings();
+    await this.setupAutofill(); // TODO: Do we need this to be called?
+    // await this.setupSettingsPage({shouldLog: true})
+
+    this.uiController = this.createUIController();
+    await this.postInit();
+  }
+
+  removeAutofillUIFromPage() {
+    var _this$uiController, _this$_scannerCleanup;
+
+    (_this$uiController = this.uiController) === null || _this$uiController === void 0 ? void 0 : _this$uiController.destroy();
+    (_this$_scannerCleanup = this._scannerCleanup) === null || _this$_scannerCleanup === void 0 ? void 0 : _this$_scannerCleanup.call(this);
   }
 
   async isEnabled() {
@@ -4440,7 +4454,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
         {
           this._scannerCleanup = this.scanner.init();
           this.addLogoutListener(() => {
-            this.removeAutofillFromUI();
+            this.resetAutofillUI();
           });
           break;
         }
@@ -4537,15 +4551,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
       switch (message.type) {
         case 'ddgUserReady':
-          this.setupAutofill().then(() => {
-            this.refreshSettings().then(() => {
-              this.setupSettingsPage({
-                shouldLog: true
-              }).then(() => {
-                return this.postInit();
-              });
-            });
-          });
+          this.resetAutofillUI();
           break;
 
         case 'contextualAutofill':
@@ -4565,12 +4571,18 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   addLogoutListener(handler) {
-    // Cleanup on logout events
-    chrome.runtime.onMessage.addListener((message, sender) => {
+    if (this._logoutListenerHandler) {
+      chrome.runtime.onMessage.removeListener(this._logoutListenerHandler);
+    } // Cleanup on logout events
+
+
+    this._logoutListenerHandler = (message, sender) => {
       if (sender.id === chrome.runtime.id && message.type === 'logout') {
         handler();
       }
-    });
+    };
+
+    chrome.runtime.onMessage.addListener(this._logoutListenerHandler);
   }
 
 }
@@ -10438,6 +10450,8 @@ class DefaultScanner {
 
 
   init() {
+    var _this = this;
+
     const delay = this.options.initialDelay; // if the delay is zero, (chrome/firefox etc) then use `requestIdleCallback`
 
     if (delay === 0) {
@@ -10447,17 +10461,25 @@ class DefaultScanner {
       setTimeout(() => this.scanAndObserve(), delay);
     }
 
-    return () => {
+    return function () {
+      let {
+        silent
+      } = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {
+        silent: false
+      };
       // remove Dax, listeners, timers, and observers
-      clearTimeout(this.debounceTimer);
-      this.mutObs.disconnect();
-      this.forms.forEach(form => {
+      clearTimeout(_this.debounceTimer);
+
+      _this.mutObs.disconnect();
+
+      _this.forms.forEach(form => {
         form.resetAllInputs();
         form.removeAllDecorations();
       });
-      this.forms.clear();
 
-      if (this.device.globalConfig.isDDGDomain) {
+      _this.forms.clear();
+
+      if (_this.device.globalConfig.isDDGDomain && !silent) {
         (0, _autofillUtils.notifyWebApp)({
           deviceSignedIn: {
             value: false
@@ -11523,6 +11545,14 @@ class HTMLTooltipUIController extends _UIController.UIController {
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
+  }
+
+  destroy() {
+    this.removeTooltip('destroy');
+
+    this._removeListeners();
+
+    window.removeEventListener('pointerdown', this, true);
   }
   /**
    * @param {import('./UIController').AttachArgs} args

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4444,6 +4444,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
     switch (this.getShowingTooltip()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
+          var _this$activeForm;
+
           this._scannerCleanup = this.scanner.init();
           this.addLogoutListener(() => {
             this.resetAutofillUI();
@@ -4456,6 +4458,13 @@ class ExtensionInterface extends _InterfacePrototype.default {
               });
             }
           });
+
+          if ((_this$activeForm = this.activeForm) !== null && _this$activeForm !== void 0 && _this$activeForm.activeInput) {
+            var _this$activeForm2;
+
+            this.attachTooltip(this.activeForm, (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.activeInput, null, 'postSignup');
+          }
+
           break;
         }
 
@@ -5076,7 +5085,7 @@ class InterfacePrototype {
    * @param {import("../Form/Form").Form} form
    * @param {HTMLInputElement} input
    * @param {{ x: number; y: number; } | null} click
-   * @param {'userInitiated' | 'autoprompt'} trigger
+   * @param {import('../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
    */
 
 
@@ -5085,7 +5094,7 @@ class InterfacePrototype {
 
     let trigger = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'userInitiated';
     // Avoid flashing tooltip from background tabs on macOS
-    if (document.visibilityState !== 'visible') return; // Only autoprompt on mobile devices
+    if (document.visibilityState !== 'visible' && trigger !== 'postSignup') return; // Only autoprompt on mobile devices
 
     if (trigger === 'autoprompt' && !this.globalConfig.isMobileApp) return; // Only fire autoprompt once
 
@@ -12170,7 +12179,7 @@ exports.UIController = void 0;
  * @property {{x: number, y: number}|null} click The click positioning
  * @property {TopContextData} topContextData
  * @property {import("../../DeviceInterface/InterfacePrototype").default} device
- * @property {'userInitiated' | 'autoprompt'} trigger
+ * @property {import('../../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
  */
 
 /**

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4358,6 +4358,8 @@ var _HTMLTooltipUIController = require("../UI/controllers/HTMLTooltipUIControlle
 
 var _HTMLTooltip = require("../UI/HTMLTooltip.js");
 
+var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const TOOLTIP_TYPES = {
@@ -4400,17 +4402,15 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
   onIncontextSignupDismissed() {
     this.settings.setIncontextSignupDismissed(true);
-    chrome.runtime.sendMessage({
-      messageType: 'setIncontextSignupDismissedAt',
-      options: {
-        value: new Date().getTime()
-      }
-    });
+    this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+      value: new Date().getTime()
+    }));
     this.removeAutofillUIFromPage();
   }
 
   async resetAutofillUI() {
-    this.removeAutofillUIFromPage(); // Start the setup process again
+    this.removeAutofillUIFromPage(); // TOOD: can we use recategorizeAllInputs here?
+    // Start the setup process again
 
     await this.refreshSettings();
     await this.setupAutofill(); // TODO: Do we need this to be called?
@@ -4589,7 +4589,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
 exports.ExtensionInterface = ExtensionInterface;
 
-},{"../UI/HTMLTooltip.js":45,"../UI/controllers/HTMLTooltipUIController.js":46,"../autofill-utils.js":52,"./InterfacePrototype.js":19}],19:[function(require,module,exports){
+},{"../UI/HTMLTooltip.js":45,"../UI/controllers/HTMLTooltipUIController.js":46,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"./InterfacePrototype.js":19}],19:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11548,7 +11548,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   }
 
   destroy() {
-    this.removeTooltip('destroy');
+    this.removeTooltip();
 
     this._removeListeners();
 
@@ -12847,7 +12847,7 @@ exports.constants = constants;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.StoreFormDataCall = exports.SetSizeCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
+exports.StoreFormDataCall = exports.SetSizeCall = exports.SetIncontextSignupDismissedAtCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetIncontextSignupDismissedAtCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
 
 var _validatorsZod = require("./validators.zod.js");
 
@@ -13071,8 +13071,44 @@ class SendJSPixelCall extends _deviceApi.DeviceApiCall {
   }
 
 }
+/**
+ * @extends {DeviceApiCall<setIncontextSignupDismissedAtSchema, any>} 
+ */
+
 
 exports.SendJSPixelCall = SendJSPixelCall;
+
+class SetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "setIncontextSignupDismissedAt");
+
+    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupDismissedAtSchema);
+  }
+
+}
+/**
+ * @extends {DeviceApiCall<any, getIncontextSignupDismissedAtSchema>} 
+ */
+
+
+exports.SetIncontextSignupDismissedAtCall = SetIncontextSignupDismissedAtCall;
+
+class GetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "getIncontextSignupDismissedAt");
+
+    _defineProperty(this, "id", "getIncontextSignupDismissedAt");
+
+    _defineProperty(this, "resultValidator", _validatorsZod.getIncontextSignupDismissedAtSchema);
+  }
+
+}
+
+exports.GetIncontextSignupDismissedAtCall = GetIncontextSignupDismissedAtCall;
 
 },{"../../../packages/device-api":6,"./validators.zod.js":57}],57:[function(require,module,exports){
 "use strict";
@@ -13080,7 +13116,7 @@ exports.SendJSPixelCall = SendJSPixelCall;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
+exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.setIncontextSignupDismissedAtSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getIncontextSignupDismissedAtSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
 const credentialsSchema = null;
 exports.credentialsSchema = credentialsSchema;
 const availableInputTypesSchema = null;
@@ -13107,6 +13143,8 @@ const getAutofillInitDataResponseSchema = null;
 exports.getAutofillInitDataResponseSchema = getAutofillInitDataResponseSchema;
 const getAvailableInputTypesResultSchema = null;
 exports.getAvailableInputTypesResultSchema = getAvailableInputTypesResultSchema;
+const getIncontextSignupDismissedAtSchema = null;
+exports.getIncontextSignupDismissedAtSchema = getIncontextSignupDismissedAtSchema;
 const contentScopeSchema = null;
 exports.contentScopeSchema = contentScopeSchema;
 const userPreferencesSchema = null;
@@ -13119,6 +13157,8 @@ const selectedDetailParamsSchema = null;
 exports.selectedDetailParamsSchema = selectedDetailParamsSchema;
 const sendJSPixelParamsSchema = null;
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;
+const setIncontextSignupDismissedAtSchema = null;
+exports.setIncontextSignupDismissedAtSchema = setIncontextSignupDismissedAtSchema;
 const setSizeParamsSchema = null;
 exports.setSizeParamsSchema = setSizeParamsSchema;
 const outgoingCredentialsSchema = null;
@@ -13436,11 +13476,19 @@ class ExtensionTransport extends _index.DeviceApiTransport {
 
   async send(deviceApiCall) {
     if (deviceApiCall instanceof _deviceApiCalls.GetRuntimeConfigurationCall) {
-      return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this.config));
+      return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this));
     }
 
     if (deviceApiCall instanceof _deviceApiCalls.GetAvailableInputTypesCall) {
       return deviceApiCall.result(await extensionSpecificGetAvailableInputTypes());
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params.value));
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.GetIncontextSignupDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificGetIncontextSignupDismissedAt());
     } // TODO: unify all calls to use deviceApiCall.method instead of all these if blocks
 
 
@@ -13453,18 +13501,20 @@ class ExtensionTransport extends _index.DeviceApiTransport {
 
 }
 /**
- * @param {GlobalConfig} globalConfig
+ * @param {ExtensionTransport} deviceApi
  * @returns {Promise<ReturnType<GetRuntimeConfigurationCall['result']>>}
  */
 
 
 exports.ExtensionTransport = ExtensionTransport;
 
-async function extensionSpecificRuntimeConfiguration(globalConfig) {
+async function extensionSpecificRuntimeConfiguration(deviceApi) {
+  var _deviceApi$config;
+
   const contentScope = await getContentScopeConfig();
   const emailProtectionEnabled = (0, _autofillUtils.isAutofillEnabledFromProcessedConfig)(contentScope);
   const incontextSignupEnabled = (0, _autofillUtils.isIncontextSignupEnabledFromProcessedConfig)(contentScope);
-  const incontextSignupDismissedAt = await getIncontextSignupDismissedAt();
+  const incontextSignupDismissedAt = await deviceApi.send(new _deviceApiCalls.GetIncontextSignupDismissedAtCall(null));
   return {
     success: {
       // @ts-ignore
@@ -13482,13 +13532,13 @@ async function extensionSpecificRuntimeConfiguration(globalConfig) {
           },
           incontextSignup: {
             settings: {
-              dismissedAt: incontextSignupDismissedAt
+              dismissedAt: incontextSignupDismissedAt.success.value
             }
           }
         }
       },
       // @ts-ignore
-      userUnprotectedDomains: globalConfig === null || globalConfig === void 0 ? void 0 : globalConfig.userUnprotectedDomains
+      userUnprotectedDomains: (_deviceApi$config = deviceApi.config) === null || _deviceApi$config === void 0 ? void 0 : _deviceApi$config.userUnprotectedDomains
     }
   };
 }
@@ -13533,12 +13583,25 @@ async function extensionSpecificSendPixel(pixelName) {
   });
 }
 
-async function getIncontextSignupDismissedAt() {
+async function extensionSpecificGetIncontextSignupDismissedAt() {
   return new Promise(resolve => {
     chrome.runtime.sendMessage({
       messageType: 'getIncontextSignupDismissedAt'
     }, response => {
       resolve(response);
+    });
+  });
+}
+
+async function extensionSpecificSetIncontextSignupDismissedAt(value) {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({
+      messageType: 'setIncontextSignupDismissedAt',
+      options: {
+        value
+      }
+    }, () => {
+      resolve(true);
     });
   });
 }

--- a/integration-test/extension/background.js
+++ b/integration-test/extension/background.js
@@ -87,6 +87,10 @@ function init () {
             return sendResponse(addUserData(message.addUserData, sender))
         } else if (message.messageType === 'sendJSPixel') {
             return sendResponse(firePixel(message.options))
+        } else if (message.messageType === 'getIncontextSignupDismissedAt') {
+            return sendResponse({ success: {} })
+        } else if (message.messageType === 'setIncontextSignupDismissedAt') {
+            return sendResponse()
         }
     })
 

--- a/src/DeviceInterface/AndroidInterface.js
+++ b/src/DeviceInterface/AndroidInterface.js
@@ -1,5 +1,5 @@
 import InterfacePrototype from './InterfacePrototype.js'
-import {autofillEnabled, sendAndWaitForAnswer, notifyWebApp} from '../autofill-utils.js'
+import {autofillEnabled, sendAndWaitForAnswer} from '../autofill-utils.js'
 import { NativeUIController } from '../UI/controllers/NativeUIController.js'
 import {processConfig} from '@duckduckgo/content-scope-scripts/src/apple-utils'
 
@@ -45,15 +45,6 @@ class AndroidInterface extends InterfacePrototype {
 
     }
 
-    postInit () {
-        const cleanup = this.scanner.init()
-        this.addLogoutListener(() => {
-            cleanup()
-            if (this.globalConfig.isDDGDomain) {
-                notifyWebApp({ deviceSignedIn: {value: false} })
-            }
-        })
-    }
     /**
      * Used by the email web app
      * Settings page displays data of the logged in user data

--- a/src/DeviceInterface/AndroidInterface.js
+++ b/src/DeviceInterface/AndroidInterface.js
@@ -1,5 +1,5 @@
 import InterfacePrototype from './InterfacePrototype.js'
-import {autofillEnabled, sendAndWaitForAnswer} from '../autofill-utils.js'
+import {autofillEnabled, sendAndWaitForAnswer, notifyWebApp} from '../autofill-utils.js'
 import { NativeUIController } from '../UI/controllers/NativeUIController.js'
 import {processConfig} from '@duckduckgo/content-scope-scripts/src/apple-utils'
 
@@ -47,7 +47,12 @@ class AndroidInterface extends InterfacePrototype {
 
     postInit () {
         const cleanup = this.scanner.init()
-        this.addLogoutListener(cleanup)
+        this.addLogoutListener(() => {
+            cleanup()
+            if (this.globalConfig.isDDGDomain) {
+                notifyWebApp({ deviceSignedIn: {value: false} })
+            }
+        })
     }
     /**
      * Used by the email web app

--- a/src/DeviceInterface/AppleDeviceInterface.js
+++ b/src/DeviceInterface/AppleDeviceInterface.js
@@ -1,5 +1,5 @@
 import InterfacePrototype from './InterfacePrototype.js'
-import { formatDuckAddress, autofillEnabled } from '../autofill-utils.js'
+import { formatDuckAddress, autofillEnabled, notifyWebApp } from '../autofill-utils.js'
 import { processConfig } from '@duckduckgo/content-scope-scripts/src/apple-utils'
 import { defaultOptions } from '../UI/HTMLTooltip.js'
 import { HTMLTooltipUIController } from '../UI/controllers/HTMLTooltipUIController.js'
@@ -85,7 +85,12 @@ class AppleDeviceInterface extends InterfacePrototype {
             this.scanner.forms.forEach(form => form.redecorateAllInputs())
         }
         const cleanup = this.scanner.init()
-        this.addLogoutListener(cleanup)
+        this.addLogoutListener(() => {
+            cleanup()
+            if (this.globalConfig.isDDGDomain) {
+                notifyWebApp({ deviceSignedIn: {value: false} })
+            }
+        })
     }
 
     /**

--- a/src/DeviceInterface/AppleDeviceInterface.js
+++ b/src/DeviceInterface/AppleDeviceInterface.js
@@ -1,5 +1,5 @@
 import InterfacePrototype from './InterfacePrototype.js'
-import { formatDuckAddress, autofillEnabled, notifyWebApp } from '../autofill-utils.js'
+import { formatDuckAddress, autofillEnabled } from '../autofill-utils.js'
 import { processConfig } from '@duckduckgo/content-scope-scripts/src/apple-utils'
 import { defaultOptions } from '../UI/HTMLTooltip.js'
 import { HTMLTooltipUIController } from '../UI/controllers/HTMLTooltipUIController.js'
@@ -78,19 +78,6 @@ class AppleDeviceInterface extends InterfacePrototype {
                 await this.getAddresses()
             }
         }
-    }
-
-    async postInit () {
-        if (this.isDeviceSignedIn()) {
-            this.scanner.forms.forEach(form => form.redecorateAllInputs())
-        }
-        const cleanup = this.scanner.init()
-        this.addLogoutListener(() => {
-            cleanup()
-            if (this.globalConfig.isDDGDomain) {
-                notifyWebApp({ deviceSignedIn: {value: false} })
-            }
-        })
     }
 
     /**

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -50,9 +50,17 @@ class ExtensionInterface extends InterfacePrototype {
     }
 
     onIncontextSignupDismissed () {
-        this.settings.setIncontextSignupDismissed(true)
-        this.deviceApi.notify(new SetIncontextSignupDismissedAtCall({ value: new Date().getTime() }))
-        this.removeAutofillUIFromPage()
+        // Check if the email signup tooltip has previously been dismissed.
+        // If it has, make the dismissal persist and remove it from the page.
+        // If it hasn't, set a flag for next time and just hide the tooltip.
+        if (this.emailSignupInitialDismissal) {
+            this.settings.setIncontextSignupDismissed(true)
+            this.deviceApi.notify(new SetIncontextSignupDismissedAtCall({ value: new Date().getTime() }))
+            this.removeAutofillUIFromPage()
+        } else {
+            this.emailSignupInitialDismissal = true
+            this.removeTooltip()
+        }
     }
 
     async resetAutofillUI (callback) {

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -115,6 +115,11 @@ class ExtensionInterface extends InterfacePrototype {
                     notifyWebApp({ deviceSignedIn: {value: false} })
                 }
             })
+
+            if (this.activeForm?.activeInput) {
+                this.attachTooltip(this.activeForm, this.activeForm?.activeInput, null, 'postSignup')
+            }
+
             break
         }
         case TOOLTIP_TYPES.EmailSignup: {

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -10,7 +10,10 @@ import {
 } from '../autofill-utils.js'
 import {HTMLTooltipUIController} from '../UI/controllers/HTMLTooltipUIController.js'
 import {defaultOptions} from '../UI/HTMLTooltip.js'
-import { SetIncontextSignupDismissedAtCall } from '../deviceApiCalls/__generated__/deviceApiCalls.js'
+import {
+    SetIncontextSignupInitiallyDismissedAtCall,
+    SetIncontextSignupPermanentlyDismissedAtCall
+} from '../deviceApiCalls/__generated__/deviceApiCalls.js'
 
 const TOOLTIP_TYPES = {
     EmailProtection: 'EmailProtection',
@@ -42,7 +45,7 @@ class ExtensionInterface extends InterfacePrototype {
             return TOOLTIP_TYPES.EmailProtection
         }
 
-        if (this.settings.featureToggles.emailProtection_incontext_signup && this.settings.incontextSignupDismissed === false) {
+        if (this.settings.featureToggles.emailProtection_incontext_signup && this.settings.incontextSignupPermanentlyDismissed === false) {
             return TOOLTIP_TYPES.EmailSignup
         }
 
@@ -57,13 +60,14 @@ class ExtensionInterface extends InterfacePrototype {
         // Check if the email signup tooltip has previously been dismissed.
         // If it has, make the dismissal persist and remove it from the page.
         // If it hasn't, set a flag for next time and just hide the tooltip.
-        if (this.emailSignupInitialDismissal) {
-            this.settings.setIncontextSignupDismissed(true)
-            this.deviceApi.notify(new SetIncontextSignupDismissedAtCall({ value: new Date().getTime() }))
+        if (this.settings.incontextSignupInitiallyDismissed) {
+            this.settings.setIncontextSignupPermanentlyDismissed(true)
+            this.deviceApi.notify(new SetIncontextSignupPermanentlyDismissedAtCall({ value: new Date().getTime() }))
             this.removeAutofillUIFromPage()
             this.firePixel({pixelName: 'incontext_dismiss_persisted'})
         } else {
-            this.emailSignupInitialDismissal = true
+            this.settings.setIncontextSignupInitiallyDismissed(true)
+            this.deviceApi.notify(new SetIncontextSignupInitiallyDismissedAtCall({ value: new Date().getTime() }))
             this.removeTooltip()
             this.firePixel({pixelName: 'incontext_dismiss_initial'})
         }

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -5,7 +5,8 @@ import {
     sendAndWaitForAnswer,
     setValue,
     formatDuckAddress,
-    isAutofillEnabledFromProcessedConfig
+    isAutofillEnabledFromProcessedConfig,
+    notifyWebApp
 } from '../autofill-utils.js'
 import {HTMLTooltipUIController} from '../UI/controllers/HTMLTooltipUIController.js'
 import {defaultOptions} from '../UI/HTMLTooltip.js'
@@ -57,8 +58,6 @@ class ExtensionInterface extends InterfacePrototype {
     async resetAutofillUI (callback) {
         this.removeAutofillUIFromPage()
 
-        // TOOD: can we use recategorizeAllInputs here?
-
         // Start the setup process again
         await this.refreshSettings()
         await this.setupAutofill()
@@ -104,6 +103,9 @@ class ExtensionInterface extends InterfacePrototype {
             this._scannerCleanup = this.scanner.init()
             this.addLogoutListener(() => {
                 this.resetAutofillUI()
+                if (this.globalConfig.isDDGDomain) {
+                    notifyWebApp({ deviceSignedIn: {value: false} })
+                }
             })
             break
         }

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -49,6 +49,10 @@ class ExtensionInterface extends InterfacePrototype {
         return null
     }
 
+    onIncontextSignup () {
+        this.firePixel({pixelName: 'incontext_get_email_protection'})
+    }
+
     onIncontextSignupDismissed () {
         // Check if the email signup tooltip has previously been dismissed.
         // If it has, make the dismissal persist and remove it from the page.
@@ -57,9 +61,11 @@ class ExtensionInterface extends InterfacePrototype {
             this.settings.setIncontextSignupDismissed(true)
             this.deviceApi.notify(new SetIncontextSignupDismissedAtCall({ value: new Date().getTime() }))
             this.removeAutofillUIFromPage()
+            this.firePixel({pixelName: 'incontext_dismiss_persisted'})
         } else {
             this.emailSignupInitialDismissal = true
             this.removeTooltip()
+            this.firePixel({pixelName: 'incontext_dismiss_initial'})
         }
     }
 

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -9,6 +9,7 @@ import {
 } from '../autofill-utils.js'
 import {HTMLTooltipUIController} from '../UI/controllers/HTMLTooltipUIController.js'
 import {defaultOptions} from '../UI/HTMLTooltip.js'
+import { SetIncontextSignupDismissedAtCall } from '../deviceApiCalls/__generated__/deviceApiCalls.js'
 
 const TOOLTIP_TYPES = {
     EmailProtection: 'EmailProtection',
@@ -49,17 +50,14 @@ class ExtensionInterface extends InterfacePrototype {
 
     onIncontextSignupDismissed () {
         this.settings.setIncontextSignupDismissed(true)
-        chrome.runtime.sendMessage({
-            messageType: 'setIncontextSignupDismissedAt',
-            options: {
-                value: new Date().getTime()
-            }
-        })
+        this.deviceApi.notify(new SetIncontextSignupDismissedAtCall({ value: new Date().getTime() }))
         this.removeAutofillUIFromPage()
     }
 
     async resetAutofillUI () {
         this.removeAutofillUIFromPage()
+
+        // TOOD: can we use recategorizeAllInputs here?
 
         // Start the setup process again
         await this.refreshSettings()

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -54,7 +54,7 @@ class ExtensionInterface extends InterfacePrototype {
         this.removeAutofillUIFromPage()
     }
 
-    async resetAutofillUI () {
+    async resetAutofillUI (callback) {
         this.removeAutofillUIFromPage()
 
         // TOOD: can we use recategorizeAllInputs here?
@@ -63,8 +63,7 @@ class ExtensionInterface extends InterfacePrototype {
         await this.refreshSettings()
         await this.setupAutofill()
 
-        // TODO: Do we need this to be called?
-        // await this.setupSettingsPage({shouldLog: true})
+        if (callback) await callback()
 
         this.uiController = this.createUIController()
         await this.postInit()
@@ -196,7 +195,7 @@ class ExtensionInterface extends InterfacePrototype {
 
             switch (message.type) {
             case 'ddgUserReady':
-                this.resetAutofillUI()
+                this.resetAutofillUI(() => this.setupSettingsPage({shouldLog: true}))
                 break
             case 'contextualAutofill':
                 setValue(activeEl, formatDuckAddress(message.alias), this.globalConfig)

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -32,12 +32,12 @@ class ExtensionInterface extends InterfacePrototype {
             [TOOLTIP_TYPES.EmailProtection]: 'legacy',
             [TOOLTIP_TYPES.EmailSignup]: 'emailsignup'
         }
-        const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection]
+        const tooltipKind = tooltipKinds[this.getActiveTooltipType()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection]
 
         return new HTMLTooltipUIController({ tooltipKind, device: this }, htmlTooltipOptions)
     }
 
-    getShowingTooltip () {
+    getActiveTooltipType () {
         if (this.hasLocalAddresses) {
             return TOOLTIP_TYPES.EmailProtection
         }
@@ -112,7 +112,7 @@ class ExtensionInterface extends InterfacePrototype {
     }
 
     postInit () {
-        switch (this.getShowingTooltip()) {
+        switch (this.getActiveTooltipType()) {
         case TOOLTIP_TYPES.EmailProtection: {
             this._scannerCleanup = this.scanner.init()
             this.addLogoutListener(() => {
@@ -237,6 +237,8 @@ class ExtensionInterface extends InterfacePrototype {
     }
 
     addLogoutListener (handler) {
+        // Make sure there's only one log out listener attached by removing the
+        // previous logout listener first, if it exists.
         if (this._logoutListenerHandler) {
             chrome.runtime.onMessage.removeListener(this._logoutListenerHandler)
         }

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -124,6 +124,8 @@ class InterfacePrototype {
         topContextData: undefined
     }
 
+    onIncontextSignup () {}
+
     onIncontextSignupDismissed () {}
 
     /**

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -297,8 +297,6 @@ class InterfacePrototype {
         await this.settings.refresh()
     }
 
-    postInit () {}
-
     async isEnabled () {
         return autofillEnabled(this.globalConfig)
     }
@@ -320,6 +318,16 @@ class InterfacePrototype {
             window.addEventListener('load', handler)
             document.addEventListener('readystatechange', handler)
         }
+    }
+
+    postInit () {
+        const cleanup = this.scanner.init()
+        this.addLogoutListener(() => {
+            cleanup()
+            if (this.globalConfig.isDDGDomain) {
+                notifyWebApp({ deviceSignedIn: {value: false} })
+            }
+        })
     }
 
     /**

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -44,8 +44,6 @@ class InterfacePrototype {
     initialSetupDelayMs = 0
     autopromptFired = false
 
-    emailSignupInitialDismissal = false
-
     /** @type {PasswordGenerator} */
     passwordGenerator = new PasswordGenerator();
 

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -398,11 +398,11 @@ class InterfacePrototype {
      * @param {import("../Form/Form").Form} form
      * @param {HTMLInputElement} input
      * @param {{ x: number; y: number; } | null} click
-     * @param {'userInitiated' | 'autoprompt'} trigger
+     * @param {import('../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
      */
     attachTooltip (form, input, click, trigger = 'userInitiated') {
         // Avoid flashing tooltip from background tabs on macOS
-        if (document.visibilityState !== 'visible') return
+        if (document.visibilityState !== 'visible' && trigger !== 'postSignup') return
         // Only autoprompt on mobile devices
         if (trigger === 'autoprompt' && !this.globalConfig.isMobileApp) return
         // Only fire autoprompt once

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -44,6 +44,8 @@ class InterfacePrototype {
     initialSetupDelayMs = 0
     autopromptFired = false
 
+    emailSignupInitialDismissal = false
+
     /** @type {PasswordGenerator} */
     passwordGenerator = new PasswordGenerator();
 

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -122,6 +122,8 @@ class InterfacePrototype {
         topContextData: undefined
     }
 
+    onIncontextSignupDismissed () {}
+
     /**
      * @returns {import('../Form/matching').SupportedTypes}
      */

--- a/src/DeviceInterface/WindowsInterface.js
+++ b/src/DeviceInterface/WindowsInterface.js
@@ -23,8 +23,7 @@ export class WindowsInterface extends InterfacePrototype {
     }
 
     postInit () {
-        const cleanup = this.scanner.init()
-        this.addLogoutListener(cleanup)
+        super.postInit()
         this.ready = true
     }
 

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -44,7 +44,7 @@ class Form {
     constructor (form, input, deviceInterface, matching, shouldAutoprompt = false) {
         this.form = form
         this.matching = matching || createMatching()
-        this.formAnalyzer = new FormAnalyzer(form, input, matching)
+        this.formAnalyzer = new FormAnalyzer(form, input, deviceInterface.globalConfig, matching)
         this.isLogin = this.formAnalyzer.isLogin
         this.isSignup = this.formAnalyzer.isSignup
         this.isHybrid = this.formAnalyzer.isHybrid

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -44,7 +44,7 @@ class Form {
     constructor (form, input, deviceInterface, matching, shouldAutoprompt = false) {
         this.form = form
         this.matching = matching || createMatching()
-        this.formAnalyzer = new FormAnalyzer(form, input, deviceInterface.globalConfig, matching)
+        this.formAnalyzer = new FormAnalyzer(form, input, matching)
         this.isLogin = this.formAnalyzer.isLogin
         this.isSignup = this.formAnalyzer.isSignup
         this.isHybrid = this.formAnalyzer.isHybrid

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -18,9 +18,10 @@ class FormAnalyzer {
     /**
      * @param {HTMLElement} form
      * @param {HTMLInputElement|HTMLSelectElement} input
+     * @param {GlobalConfig} config
      * @param {Matching} [matching]
      */
-    constructor (form, input, matching) {
+    constructor (form, input, config, matching) {
         this.form = form
         this.matching = matching || new Matching(matchingConfiguration)
         /**
@@ -40,8 +41,8 @@ class FormAnalyzer {
          */
         this.isHybrid = false
 
-        // Avoid autofill on our signup page
-        if (window.location.href.match(/^https:\/\/(.+\.)?duckduckgo\.com\/email\/choose-address/i)) {
+        // Avoid autofill on Email Protection web app
+        if (config.isDDGDomain) {
             return this
         }
 

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -18,10 +18,9 @@ class FormAnalyzer {
     /**
      * @param {HTMLElement} form
      * @param {HTMLInputElement|HTMLSelectElement} input
-     * @param {GlobalConfig} config
      * @param {Matching} [matching]
      */
-    constructor (form, input, config, matching) {
+    constructor (form, input, matching) {
         this.form = form
         this.matching = matching || new Matching(matchingConfiguration)
         /**
@@ -40,11 +39,6 @@ class FormAnalyzer {
          * @type {boolean}
          */
         this.isHybrid = false
-
-        // Avoid autofill on Email Protection web app
-        if (config.isDDGDomain) {
-            return this
-        }
 
         this.evaluateElAttributes(input, 3, true)
         form ? this.evaluateForm() : this.evaluatePage()

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -85,16 +85,23 @@ class DefaultScanner {
             // otherwise, use the delay time to defer the initial scan
             setTimeout(() => this.scanAndObserve(), delay)
         }
-        return ({ silent } = { silent: false }) => {
+        return () => {
+            const activeInput = this.device.activeForm?.activeInput
+
             // remove Dax, listeners, timers, and observers
             clearTimeout(this.debounceTimer)
             this.mutObs.disconnect()
+
             this.forms.forEach(form => {
                 form.resetAllInputs()
                 form.removeAllDecorations()
             })
             this.forms.clear()
-            if (this.device.globalConfig.isDDGDomain && !silent) {
+
+            // Bring the user back to the input they were interacting with
+            activeInput?.focus()
+
+            if (this.device.globalConfig.isDDGDomain) {
                 notifyWebApp({ deviceSignedIn: {value: false} })
             }
         }

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -85,7 +85,7 @@ class DefaultScanner {
             // otherwise, use the delay time to defer the initial scan
             setTimeout(() => this.scanAndObserve(), delay)
         }
-        return () => {
+        return ({ silent } = { silent: false }) => {
             // remove Dax, listeners, timers, and observers
             clearTimeout(this.debounceTimer)
             this.mutObs.disconnect()
@@ -94,7 +94,7 @@ class DefaultScanner {
                 form.removeAllDecorations()
             })
             this.forms.clear()
-            if (this.device.globalConfig.isDDGDomain) {
+            if (this.device.globalConfig.isDDGDomain && !silent) {
                 notifyWebApp({ deviceSignedIn: {value: false} })
             }
         }

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -1,5 +1,4 @@
 import { Form } from './Form/Form.js'
-import { notifyWebApp } from './autofill-utils.js'
 import { SUBMIT_BUTTON_SELECTOR, FORM_INPUTS_SELECTOR } from './Form/selectors-css.js'
 import { createMatching } from './Form/matching.js'
 
@@ -100,10 +99,6 @@ class DefaultScanner {
 
             // Bring the user back to the input they were interacting with
             activeInput?.focus()
-
-            if (this.device.globalConfig.isDDGDomain) {
-                notifyWebApp({ deviceSignedIn: {value: false} })
-            }
         }
     }
 
@@ -121,6 +116,11 @@ class DefaultScanner {
      * @param context
      */
     findEligibleInputs (context) {
+        // Avoid autofill on Email Protection web app
+        if (this.device.globalConfig.isDDGDomain) {
+            return this
+        }
+
         if ('matches' in context && context.matches?.(FORM_INPUTS_SELECTOR)) {
             this.addInput(context)
         } else {

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -1,6 +1,6 @@
 import {validate} from '../packages/device-api/index.js'
 import {GetAvailableInputTypesCall, GetRuntimeConfigurationCall} from './deviceApiCalls/__generated__/deviceApiCalls.js'
-import {autofillSettingsSchema} from './deviceApiCalls/__generated__/validators.zod.js'
+import {autofillSettingsSchema, incontextSignupSettingsSchema} from './deviceApiCalls/__generated__/validators.zod.js'
 import {autofillEnabled} from './autofill-utils.js'
 import {processConfig} from '@duckduckgo/content-scope-scripts/src/apple-utils'
 
@@ -35,6 +35,8 @@ export class Settings {
     _runtimeConfiguration = null
     /** @type {boolean | null} */
     _enabled = null
+    /** @type {boolean | null} */
+    _incontextSignupDismissed = null
 
     /**
      * @param {GlobalConfig} config
@@ -92,6 +94,19 @@ export class Settings {
     }
 
     /**
+     * @returns {Promise<boolean|null>}
+     */
+    async getIncontextSignupDismissed () {
+        try {
+            const runtimeConfig = await this._getRuntimeConfiguration()
+            const incontextSignupSettings = validate(runtimeConfig.userPreferences?.features?.incontextSignup?.settings, incontextSignupSettingsSchema)
+            return Boolean(incontextSignupSettings.dismissedAt)
+        } catch (e) {
+            return null
+        }
+    }
+
+    /**
      * Get runtime configuration, but only once.
      *
      * Some platforms may be reading this directly from inlined variables, whilst others
@@ -142,6 +157,7 @@ export class Settings {
         this.setEnabled(await this.getEnabled())
         this.setFeatureToggles(await this.getFeatureToggles())
         this.setAvailableInputTypes(await this.getAvailableInputTypes())
+        this.setIncontextSignupDismissed(await this.getIncontextSignupDismissed())
 
         // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
         if (typeof this.enabled === 'boolean') {
@@ -276,5 +292,17 @@ export class Settings {
      */
     setEnabled (enabled) {
         this._enabled = enabled
+    }
+
+    /** @returns {boolean|null} */
+    get incontextSignupDismissed () {
+        return this._incontextSignupDismissed
+    }
+
+    /**
+     * @param {boolean|null} incontextSignupDismissed
+     */
+    setIncontextSignupDismissed (incontextSignupDismissed) {
+        this._incontextSignupDismissed = incontextSignupDismissed
     }
 }

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -36,7 +36,9 @@ export class Settings {
     /** @type {boolean | null} */
     _enabled = null
     /** @type {boolean | null} */
-    _incontextSignupDismissed = null
+    _incontextSignupInitiallyDismissed = null
+    /** @type {boolean | null} */
+    _incontextSignupPermanentlyDismissed = null
 
     /**
      * @param {GlobalConfig} config
@@ -96,11 +98,21 @@ export class Settings {
     /**
      * @returns {Promise<boolean|null>}
      */
-    async getIncontextSignupDismissed () {
+    async getIncontextSignupInitiallyDismissed () {
         try {
             const runtimeConfig = await this._getRuntimeConfiguration()
             const incontextSignupSettings = validate(runtimeConfig.userPreferences?.features?.incontextSignup?.settings, incontextSignupSettingsSchema)
-            return Boolean(incontextSignupSettings.dismissedAt)
+            return Boolean(incontextSignupSettings.initiallyDismissedAt)
+        } catch (e) {
+            return null
+        }
+    }
+
+    async getIncontextSignupPermanentlyDismissed () {
+        try {
+            const runtimeConfig = await this._getRuntimeConfiguration()
+            const incontextSignupSettings = validate(runtimeConfig.userPreferences?.features?.incontextSignup?.settings, incontextSignupSettingsSchema)
+            return Boolean(incontextSignupSettings.permanentlyDismissedAt)
         } catch (e) {
             return null
         }
@@ -157,7 +169,8 @@ export class Settings {
         this.setEnabled(await this.getEnabled())
         this.setFeatureToggles(await this.getFeatureToggles())
         this.setAvailableInputTypes(await this.getAvailableInputTypes())
-        this.setIncontextSignupDismissed(await this.getIncontextSignupDismissed())
+        this.setIncontextSignupInitiallyDismissed(await this.getIncontextSignupInitiallyDismissed())
+        this.setIncontextSignupPermanentlyDismissed(await this.getIncontextSignupPermanentlyDismissed())
 
         // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
         if (typeof this.enabled === 'boolean') {
@@ -295,14 +308,26 @@ export class Settings {
     }
 
     /** @returns {boolean|null} */
-    get incontextSignupDismissed () {
-        return this._incontextSignupDismissed
+    get incontextSignupInitiallyDismissed () {
+        return this._incontextSignupInitiallyDismissed
     }
 
     /**
-     * @param {boolean|null} incontextSignupDismissed
+     * @param {boolean|null} incontextSignupInitiallyDismissed
      */
-    setIncontextSignupDismissed (incontextSignupDismissed) {
-        this._incontextSignupDismissed = incontextSignupDismissed
+    setIncontextSignupInitiallyDismissed (incontextSignupInitiallyDismissed) {
+        this._incontextSignupInitiallyDismissed = incontextSignupInitiallyDismissed
+    }
+
+    /** @returns {boolean|null} */
+    get incontextSignupPermanentlyDismissed () {
+        return this._incontextSignupPermanentlyDismissed
+    }
+
+    /**
+     * @param {boolean|null} incontextSignupPermanentlyDismissed
+     */
+    setIncontextSignupPermanentlyDismissed (incontextSignupPermanentlyDismissed) {
+        this._incontextSignupPermanentlyDismissed = incontextSignupPermanentlyDismissed
     }
 }

--- a/src/UI/EmailSignupHTMLTooltop.js
+++ b/src/UI/EmailSignupHTMLTooltop.js
@@ -23,7 +23,7 @@ ${this.options.css}
                 Get Email Protection
             </a>
             <button class="ghost js-dismiss-email-signup">
-                ${device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later'}
+                ${device.settings.incontextSignupInitiallyDismissed ? "Don't Ask Again" : 'Maybe Later'}
             </button>
         </div>
     </div>

--- a/src/UI/EmailSignupHTMLTooltop.js
+++ b/src/UI/EmailSignupHTMLTooltop.js
@@ -23,7 +23,7 @@ ${this.options.css}
                 Get Email Protection
             </a>
             <button class="ghost js-dismiss-email-signup">
-                Not Now
+                ${device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later'}
             </button>
         </div>
     </div>

--- a/src/UI/EmailSignupHTMLTooltop.js
+++ b/src/UI/EmailSignupHTMLTooltop.js
@@ -19,7 +19,7 @@ ${this.options.css}
             forwarding messages to your inbox?
         </p>
         <div class="notice-controls">
-            <a href="https://duckduckgo.com/email/start-incontext" target="_blank" class="primary">
+            <a href="https://duckduckgo.com/email/start-incontext" target="_blank" class="primary js-get-email-signup">
                 Get Email Protection
             </a>
             <button class="ghost js-dismiss-email-signup">
@@ -30,10 +30,15 @@ ${this.options.css}
 </div>`
 
         this.tooltip = this.shadow.querySelector('.tooltip')
-        this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup')
 
+        this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup')
         this.registerClickableButton(this.dismissEmailSignup, () => {
             device.onIncontextSignupDismissed()
+        })
+
+        this.getEmailSignup = this.shadow.querySelector('.js-get-email-signup')
+        this.registerClickableButton(this.getEmailSignup, () => {
+            device.onIncontextSignup()
         })
 
         this.init()

--- a/src/UI/EmailSignupHTMLTooltop.js
+++ b/src/UI/EmailSignupHTMLTooltop.js
@@ -33,7 +33,7 @@ ${this.options.css}
         this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup')
 
         this.registerClickableButton(this.dismissEmailSignup, () => {
-            // TODO: Persist dismissal
+            device.onIncontextSignupDismissed()
         })
 
         this.init()

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -92,6 +92,7 @@ export class HTMLTooltipUIController extends UIController {
         }
 
         if (this._options.tooltipKind === 'emailsignup') {
+            this._options.device.firePixel({pixelName: 'incontext_show'})
             return new EmailSignupHTMLTooltip(config, topContextData.inputType, getPosition, tooltipOptions)
                 .render(this._options.device)
         }

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -45,6 +45,12 @@ export class HTMLTooltipUIController extends UIController {
         window.addEventListener('pointerdown', this, true)
     }
 
+    destroy () {
+        this.removeTooltip('destroy')
+        this._removeListeners()
+        window.removeEventListener('pointerdown', this, true)
+    }
+
     /**
      * @param {import('./UIController').AttachArgs} args
      */

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -45,6 +45,9 @@ export class HTMLTooltipUIController extends UIController {
         window.addEventListener('pointerdown', this, true)
     }
 
+    _activeInput;
+    _activeInputOriginalAutocomplete;
+
     /**
      * Cleans up after this UI controller by removing the tooltip and all
      * listeners.
@@ -65,6 +68,10 @@ export class HTMLTooltipUIController extends UIController {
         const tooltip = this.createTooltip(getPosition, topContextData)
         this.setActiveTooltip(tooltip)
         form.showingTooltip(input)
+
+        this._activeInput = input
+        this._activeInputOriginalAutocomplete = input.getAttribute('autocomplete')
+        input.setAttribute('autocomplete', 'off')
     }
 
     /**
@@ -194,6 +201,16 @@ export class HTMLTooltipUIController extends UIController {
             this._removeListeners()
             this._activeTooltip.remove()
             this._activeTooltip = null
+        }
+
+        if (this._activeInput) {
+            if (this._activeInputOriginalAutocomplete) {
+                this._activeInput.setAttribute('autocomplete', this._activeInputOriginalAutocomplete)
+            } else {
+                this._activeInput.removeAttribute('autocomplete')
+            }
+            this._activeInput = null
+            this._activeInputOriginalAutocomplete = null
         }
     }
 

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -45,9 +45,12 @@ export class HTMLTooltipUIController extends UIController {
         window.addEventListener('pointerdown', this, true)
     }
 
+    /**
+     * Cleans up after this UI controller by removing the tooltip and all
+     * listeners.
+     */
     destroy () {
         this.removeTooltip()
-        this._removeListeners()
         window.removeEventListener('pointerdown', this, true)
     }
 

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -46,7 +46,7 @@ export class HTMLTooltipUIController extends UIController {
     }
 
     destroy () {
-        this.removeTooltip('destroy')
+        this.removeTooltip()
         this._removeListeners()
         window.removeEventListener('pointerdown', this, true)
     }

--- a/src/UI/controllers/UIController.js
+++ b/src/UI/controllers/UIController.js
@@ -6,7 +6,7 @@
  * @property {{x: number, y: number}|null} click The click positioning
  * @property {TopContextData} topContextData
  * @property {import("../../DeviceInterface/InterfacePrototype").default} device
- * @property {'userInitiated' | 'autoprompt'} trigger
+ * @property {import('../../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
  */
 
 /**

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -58,6 +58,15 @@ const isAutofillEnabledFromProcessedConfig = (processedConfig) => {
     return true
 }
 
+const isIncontextSignupEnabledFromProcessedConfig = (processedConfig) => {
+    const site = processedConfig.site
+    if (site.isBroken || !site.enabledFeatures.includes('incontextSignup')) {
+        return false
+    }
+
+    return true
+}
+
 // Access the original setter (needed to bypass React's implementation on mobile)
 // @ts-ignore
 const originalSet = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set
@@ -346,6 +355,7 @@ export {
     notifyWebApp,
     sendAndWaitForAnswer,
     isAutofillEnabledFromProcessedConfig,
+    isIncontextSignupEnabledFromProcessedConfig,
     autofillEnabled,
     setValue,
     safeExecute,

--- a/src/deviceApiCalls/__generated__/deviceApiCalls.js
+++ b/src/deviceApiCalls/__generated__/deviceApiCalls.js
@@ -12,7 +12,9 @@ import {
     selectedDetailParamsSchema,
     askToUnlockProviderResultSchema,
     checkCredentialsProviderStatusResultSchema,
-    sendJSPixelParamsSchema
+    sendJSPixelParamsSchema,
+    setIncontextSignupDismissedAtSchema,
+    getIncontextSignupDismissedAtSchema
 } from "./validators.zod.js"
 import { DeviceApiCall } from "../../../packages/device-api";
 
@@ -107,4 +109,19 @@ export class CheckCredentialsProviderStatusCall extends DeviceApiCall {
 export class SendJSPixelCall extends DeviceApiCall {
   method = "sendJSPixel"
   paramsValidator = sendJSPixelParamsSchema
+}
+/**
+ * @extends {DeviceApiCall<setIncontextSignupDismissedAtSchema, any>} 
+ */
+export class SetIncontextSignupDismissedAtCall extends DeviceApiCall {
+  method = "setIncontextSignupDismissedAt"
+  paramsValidator = setIncontextSignupDismissedAtSchema
+}
+/**
+ * @extends {DeviceApiCall<any, getIncontextSignupDismissedAtSchema>} 
+ */
+export class GetIncontextSignupDismissedAtCall extends DeviceApiCall {
+  method = "getIncontextSignupDismissedAt"
+  id = "getIncontextSignupDismissedAt"
+  resultValidator = getIncontextSignupDismissedAtSchema
 }

--- a/src/deviceApiCalls/__generated__/deviceApiCalls.js
+++ b/src/deviceApiCalls/__generated__/deviceApiCalls.js
@@ -13,7 +13,8 @@ import {
     askToUnlockProviderResultSchema,
     checkCredentialsProviderStatusResultSchema,
     sendJSPixelParamsSchema,
-    setIncontextSignupDismissedAtSchema,
+    setIncontextSignupInitiallyDismissedAtSchema,
+    setIncontextSignupPermanentlyDismissedAtSchema,
     getIncontextSignupDismissedAtSchema
 } from "./validators.zod.js"
 import { DeviceApiCall } from "../../../packages/device-api";
@@ -111,11 +112,18 @@ export class SendJSPixelCall extends DeviceApiCall {
   paramsValidator = sendJSPixelParamsSchema
 }
 /**
- * @extends {DeviceApiCall<setIncontextSignupDismissedAtSchema, any>} 
+ * @extends {DeviceApiCall<setIncontextSignupInitiallyDismissedAtSchema, any>} 
  */
-export class SetIncontextSignupDismissedAtCall extends DeviceApiCall {
-  method = "setIncontextSignupDismissedAt"
-  paramsValidator = setIncontextSignupDismissedAtSchema
+export class SetIncontextSignupInitiallyDismissedAtCall extends DeviceApiCall {
+  method = "setIncontextSignupInitiallyDismissedAt"
+  paramsValidator = setIncontextSignupInitiallyDismissedAtSchema
+}
+/**
+ * @extends {DeviceApiCall<setIncontextSignupPermanentlyDismissedAtSchema, any>} 
+ */
+export class SetIncontextSignupPermanentlyDismissedAtCall extends DeviceApiCall {
+  method = "setIncontextSignupPermanentlyDismissedAt"
+  paramsValidator = setIncontextSignupPermanentlyDismissedAtSchema
 }
 /**
  * @extends {DeviceApiCall<any, getIncontextSignupDismissedAtSchema>} 

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -681,6 +681,18 @@ export type SendJSPixelParams =
     }
   | {
       pixelName: "autofill_private_address";
+    }
+  | {
+      pixelName: "incontext_show";
+    }
+  | {
+      pixelName: "incontext_get_email_protection";
+    }
+  | {
+      pixelName: "incontext_dismiss_persisted";
+    }
+  | {
+      pixelName: "incontext_dismiss_initial";
     };
 
 // setIncontextSignupDismissedAt.params.json

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -527,6 +527,15 @@ export interface GenericError {
   message: string;
 }
 
+// incontext-signup-settings.json
+
+/**
+ * Delivered as part of Runtime Configuration, but needs to live here since Runtime Configuration can contain settings for many features
+ */
+export interface IncontextSignupSettings {
+  dismissedAt?: number;
+}
+
 // providerStatusUpdated.json
 
 export interface ProviderStatusUpdated {

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -325,7 +325,7 @@ export interface GetAutofillDataRequest {
   /**
    * Signals that the prompt was triggered automatically rather than by user action
    */
-  trigger?: "userInitiated" | "autoprompt";
+  trigger?: "userInitiated" | "autoprompt" | "postSignup";
   /**
    * Serialized JSON that will be picked up once the 'parent' requests its initial data
    */

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -475,6 +475,17 @@ export interface GenericError {
   message: string;
 }
 
+// getIncontextSignupDismissedAt.result.json
+
+/**
+ * Gets the time that the in-context Email Protection sign-up message was dismissed, if set
+ */
+export interface GetIncontextSignupDismissedAt {
+  success: {
+    value?: number;
+  };
+}
+
 // getRuntimeConfiguration.result.json
 
 /**
@@ -671,6 +682,15 @@ export type SendJSPixelParams =
   | {
       pixelName: "autofill_private_address";
     };
+
+// setIncontextSignupDismissedAt.params.json
+
+/**
+ * Sets the time that the in-context Email Protection sign-up message was dismissed
+ */
+export interface SetIncontextSignupDismissedAt {
+  value?: number;
+}
 
 // setSize.params.json
 

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -482,7 +482,8 @@ export interface GenericError {
  */
 export interface GetIncontextSignupDismissedAt {
   success: {
-    value?: number;
+    initiallyDismissedAt?: number;
+    permanentlyDismissedAt?: number;
   };
 }
 
@@ -544,7 +545,8 @@ export interface GenericError {
  * Delivered as part of Runtime Configuration, but needs to live here since Runtime Configuration can contain settings for many features
  */
 export interface IncontextSignupSettings {
-  dismissedAt?: number;
+  initiallyDismissedAt?: number;
+  permanentlyDismissedAt?: number;
 }
 
 // providerStatusUpdated.json
@@ -695,12 +697,21 @@ export type SendJSPixelParams =
       pixelName: "incontext_dismiss_initial";
     };
 
-// setIncontextSignupDismissedAt.params.json
+// setIncontextSignupInitiallyDismissedAt.params.json
 
 /**
- * Sets the time that the in-context Email Protection sign-up message was dismissed
+ * Sets the time that the in-context Email Protection sign-up message was initially dismissed
  */
-export interface SetIncontextSignupDismissedAt {
+export interface SetIncontextSignupInitiallyDismissedAt {
+  value?: number;
+}
+
+// setIncontextSignupPermanentlyDismissedAt.params.json
+
+/**
+ * Sets the time that the in-context Email Protection sign-up message was permanently dismissed
+ */
+export interface SetIncontextSignupPermanentlyDismissedAt {
   value?: number;
 }
 

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -175,6 +175,14 @@ export const sendJSPixelParamsSchema = z.union([z.object({
         pixelName: z.literal("autofill_personal_address")
     }), z.object({
         pixelName: z.literal("autofill_private_address")
+    }), z.object({
+        pixelName: z.literal("incontext_show")
+    }), z.object({
+        pixelName: z.literal("incontext_get_email_protection")
+    }), z.object({
+        pixelName: z.literal("incontext_dismiss_persisted")
+    }), z.object({
+        pixelName: z.literal("incontext_dismiss_initial")
     })]);
 
 export const setIncontextSignupDismissedAtSchema = z.object({

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -126,7 +126,8 @@ export const getAvailableInputTypesResultSchema = z.object({
 
 export const getIncontextSignupDismissedAtSchema = z.object({
     success: z.object({
-        value: z.number().optional()
+        initiallyDismissedAt: z.number().optional(),
+        permanentlyDismissedAt: z.number().optional()
     })
 });
 
@@ -152,7 +153,8 @@ export const userPreferencesSchema = z.object({
 });
 
 export const incontextSignupSettingsSchema = z.object({
-    dismissedAt: z.number().optional()
+    initiallyDismissedAt: z.number().optional(),
+    permanentlyDismissedAt: z.number().optional()
 });
 
 export const runtimeConfigurationSchema = z.object({
@@ -185,7 +187,11 @@ export const sendJSPixelParamsSchema = z.union([z.object({
         pixelName: z.literal("incontext_dismiss_initial")
     })]);
 
-export const setIncontextSignupDismissedAtSchema = z.object({
+export const setIncontextSignupInitiallyDismissedAtSchema = z.object({
+    value: z.number().optional()
+});
+
+export const setIncontextSignupPermanentlyDismissedAtSchema = z.object({
     value: z.number().optional()
 });
 

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -145,6 +145,10 @@ export const userPreferencesSchema = z.object({
     }))
 });
 
+export const incontextSignupSettingsSchema = z.object({
+    dismissedAt: z.number().optional()
+});
+
 export const runtimeConfigurationSchema = z.object({
     contentScope: contentScopeSchema,
     userUnprotectedDomains: z.array(z.string()),

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -211,7 +211,7 @@ export const getAutofillDataRequestSchema = z.object({
     inputType: z.string(),
     mainType: z.union([z.literal("credentials"), z.literal("identities"), z.literal("creditCards")]),
     subType: z.string(),
-    trigger: z.union([z.literal("userInitiated"), z.literal("autoprompt")]).optional(),
+    trigger: z.union([z.literal("userInitiated"), z.literal("autoprompt"), z.literal("postSignup")]).optional(),
     serializedInputContext: z.string().optional(),
     triggerContext: triggerContextSchema.optional()
 });

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -124,6 +124,12 @@ export const getAvailableInputTypesResultSchema = z.object({
     error: genericErrorSchema.optional()
 });
 
+export const getIncontextSignupDismissedAtSchema = z.object({
+    success: z.object({
+        value: z.number().optional()
+    })
+});
+
 export const contentScopeSchema = z.object({
     features: z.record(z.object({
         exceptions: z.array(z.unknown()),
@@ -170,6 +176,10 @@ export const sendJSPixelParamsSchema = z.union([z.object({
     }), z.object({
         pixelName: z.literal("autofill_private_address")
     })]);
+
+export const setIncontextSignupDismissedAtSchema = z.object({
+    value: z.number().optional()
+});
 
 export const setSizeParamsSchema = z.object({
     height: z.number(),

--- a/src/deviceApiCalls/deviceApiCalls.json
+++ b/src/deviceApiCalls/deviceApiCalls.json
@@ -48,8 +48,11 @@
   "sendJSPixel": {
     "paramsValidator": "./schemas/sendJSPixel.params.json"
   },
-  "setIncontextSignupDismissedAt": {
-    "paramsValidator": "./schemas/setIncontextSignupDismissedAt.params.json"
+  "setIncontextSignupInitiallyDismissedAt": {
+    "paramsValidator": "./schemas/setIncontextSignupInitiallyDismissedAt.params.json"
+  },
+  "setIncontextSignupPermanentlyDismissedAt": {
+    "paramsValidator": "./schemas/setIncontextSignupPermanentlyDismissedAt.params.json"
   },
   "getIncontextSignupDismissedAt": {
     "id": "getIncontextSignupDismissedAt",

--- a/src/deviceApiCalls/deviceApiCalls.json
+++ b/src/deviceApiCalls/deviceApiCalls.json
@@ -47,5 +47,12 @@
   },
   "sendJSPixel": {
     "paramsValidator": "./schemas/sendJSPixel.params.json"
+  },
+  "setIncontextSignupDismissedAt": {
+    "paramsValidator": "./schemas/setIncontextSignupDismissedAt.params.json"
+  },
+  "getIncontextSignupDismissedAt": {
+    "id": "getIncontextSignupDismissedAt",
+    "resultValidator": "./schemas/getIncontextSignupDismissedAt.result.json"
   }
 }

--- a/src/deviceApiCalls/schemas/getAutofillData.params.json
+++ b/src/deviceApiCalls/schemas/getAutofillData.params.json
@@ -25,7 +25,7 @@
     "trigger": {
       "description": "Signals that the prompt was triggered automatically rather than by user action",
       "type": "string",
-      "enum": ["userInitiated", "autoprompt"]
+      "enum": ["userInitiated", "autoprompt", "postSignup"]
     },
     "serializedInputContext": {
       "description": "Serialized JSON that will be picked up once the 'parent' requests its initial data",

--- a/src/deviceApiCalls/schemas/getIncontextSignupDismissedAt.result.json
+++ b/src/deviceApiCalls/schemas/getIncontextSignupDismissedAt.result.json
@@ -9,7 +9,10 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "value": {
+                "initiallyDismissedAt": {
+                    "type": "number"
+                },
+                "permanentlyDismissedAt": {
                     "type": "number"
                 }
             },

--- a/src/deviceApiCalls/schemas/getIncontextSignupDismissedAt.result.json
+++ b/src/deviceApiCalls/schemas/getIncontextSignupDismissedAt.result.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GetIncontextSignupDismissedAt",
+    "type": "object",
+    "description": "Gets the time that the in-context Email Protection sign-up message was dismissed, if set",
+    "additionalProperties": false,
+    "properties": {
+        "success": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "value": {
+                    "type": "number"
+                }
+            },
+            "required": []
+        }
+    },
+    "required": [
+        "success"
+    ]
+}

--- a/src/deviceApiCalls/schemas/incontext-signup-settings.json
+++ b/src/deviceApiCalls/schemas/incontext-signup-settings.json
@@ -5,7 +5,10 @@
     "additionalProperties": false,
     "description": "Delivered as part of Runtime Configuration, but needs to live here since Runtime Configuration can contain settings for many features",
     "properties": {
-        "dismissedAt": {
+        "initiallyDismissedAt": {
+            "type": "number"
+        },
+        "permanentlyDismissedAt": {
             "type": "number"
         }
     }

--- a/src/deviceApiCalls/schemas/incontext-signup-settings.json
+++ b/src/deviceApiCalls/schemas/incontext-signup-settings.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "IncontextSignupSettings",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Delivered as part of Runtime Configuration, but needs to live here since Runtime Configuration can contain settings for many features",
+    "properties": {
+        "dismissedAt": {
+            "type": "number"
+        }
+    }
+}

--- a/src/deviceApiCalls/schemas/sendJSPixel.params.json
+++ b/src/deviceApiCalls/schemas/sendJSPixel.params.json
@@ -48,6 +48,54 @@
         "pixelName"
       ],
       "additionalProperties": false
+    },
+    {
+      "properties": {
+        "pixelName": {
+          "type": "string",
+          "const": "incontext_show"
+        }
+      },
+      "required": [
+        "pixelName"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "pixelName": {
+          "type": "string",
+          "const": "incontext_get_email_protection"
+        }
+      },
+      "required": [
+        "pixelName"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "pixelName": {
+          "type": "string",
+          "const": "incontext_dismiss_persisted"
+        }
+      },
+      "required": [
+        "pixelName"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "pixelName": {
+          "type": "string",
+          "const": "incontext_dismiss_initial"
+        }
+      },
+      "required": [
+        "pixelName"
+      ],
+      "additionalProperties": false
     }
   ]
 }

--- a/src/deviceApiCalls/schemas/setIncontextSignupDismissedAt.params.json
+++ b/src/deviceApiCalls/schemas/setIncontextSignupDismissedAt.params.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "SetIncontextSignupDismissedAt",
+    "type": "object",
+    "description": "Sets the time that the in-context Email Protection sign-up message was dismissed",
+    "additionalProperties": false,
+    "properties": {
+        "value": {
+            "type": "number"
+        }
+    },
+    "required": []
+}

--- a/src/deviceApiCalls/schemas/setIncontextSignupInitiallyDismissedAt.params.json
+++ b/src/deviceApiCalls/schemas/setIncontextSignupInitiallyDismissedAt.params.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "SetIncontextSignupDismissedAt",
+    "title": "SetIncontextSignupInitiallyDismissedAt",
     "type": "object",
-    "description": "Sets the time that the in-context Email Protection sign-up message was dismissed",
+    "description": "Sets the time that the in-context Email Protection sign-up message was initially dismissed",
     "additionalProperties": false,
     "properties": {
         "value": {

--- a/src/deviceApiCalls/schemas/setIncontextSignupPermanentlyDismissedAt.params.json
+++ b/src/deviceApiCalls/schemas/setIncontextSignupPermanentlyDismissedAt.params.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "SetIncontextSignupPermanentlyDismissedAt",
+    "type": "object",
+    "description": "Sets the time that the in-context Email Protection sign-up message was permanently dismissed",
+    "additionalProperties": false,
+    "properties": {
+        "value": {
+            "type": "number"
+        }
+    },
+    "required": []
+}

--- a/src/deviceApiCalls/transports/extension.transport.js
+++ b/src/deviceApiCalls/transports/extension.transport.js
@@ -3,7 +3,8 @@ import {
     GetAvailableInputTypesCall,
     GetRuntimeConfigurationCall,
     SendJSPixelCall,
-    SetIncontextSignupDismissedAtCall,
+    SetIncontextSignupInitiallyDismissedAtCall,
+    SetIncontextSignupPermanentlyDismissedAtCall,
     GetIncontextSignupDismissedAtCall
 } from '../__generated__/deviceApiCalls.js'
 import {isAutofillEnabledFromProcessedConfig, isIncontextSignupEnabledFromProcessedConfig} from '../../autofill-utils.js'
@@ -25,8 +26,12 @@ export class ExtensionTransport extends DeviceApiTransport {
             return deviceApiCall.result(await extensionSpecificGetAvailableInputTypes())
         }
 
-        if (deviceApiCall instanceof SetIncontextSignupDismissedAtCall) {
-            return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params))
+        if (deviceApiCall instanceof SetIncontextSignupInitiallyDismissedAtCall) {
+            return deviceApiCall.result(await extensionSpecificSetIncontextSignupInitiallyDismissedAtCall(deviceApiCall.params))
+        }
+
+        if (deviceApiCall instanceof SetIncontextSignupPermanentlyDismissedAtCall) {
+            return deviceApiCall.result(await extensionSpecificSetIncontextSignupPermanentlyDismissedAtCall(deviceApiCall.params))
         }
 
         if (deviceApiCall instanceof GetIncontextSignupDismissedAtCall) {
@@ -70,7 +75,8 @@ async function extensionSpecificRuntimeConfiguration (deviceApi) {
                     },
                     incontextSignup: {
                         settings: {
-                            dismissedAt: incontextSignupDismissedAt.success.value
+                            initiallyDismissedAt: incontextSignupDismissedAt.success.initiallyDismissedAt,
+                            permanentlyDismissedAt: incontextSignupDismissedAt.success.permanentlyDismissedAt
                         }
                     }
                 }
@@ -140,13 +146,30 @@ async function extensionSpecificGetIncontextSignupDismissedAt () {
 }
 
 /**
- * @param {import('../__generated__/validators-ts').SetIncontextSignupDismissedAt} params
+ * @param {import('../__generated__/validators-ts').SetIncontextSignupInitiallyDismissedAt} params
  */
-async function extensionSpecificSetIncontextSignupDismissedAt (params) {
+async function extensionSpecificSetIncontextSignupInitiallyDismissedAtCall (params) {
     return new Promise(resolve => {
         chrome.runtime.sendMessage(
             {
-                messageType: 'setIncontextSignupDismissedAt',
+                messageType: 'setIncontextSignupInitiallyDismissedAt',
+                options: params
+            },
+            () => {
+                resolve(true)
+            }
+        )
+    })
+}
+
+/**
+ * @param {import('../__generated__/validators-ts').SetIncontextSignupPermanentlyDismissedAt} params
+ */
+async function extensionSpecificSetIncontextSignupPermanentlyDismissedAtCall (params) {
+    return new Promise(resolve => {
+        chrome.runtime.sendMessage(
+            {
+                messageType: 'setIncontextSignupPermanentlyDismissedAt',
                 options: params
             },
             () => {

--- a/src/deviceApiCalls/transports/extension.transport.js
+++ b/src/deviceApiCalls/transports/extension.transport.js
@@ -26,7 +26,7 @@ export class ExtensionTransport extends DeviceApiTransport {
         }
 
         if (deviceApiCall instanceof SetIncontextSignupDismissedAtCall) {
-            return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params.value))
+            return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params))
         }
 
         if (deviceApiCall instanceof GetIncontextSignupDismissedAtCall) {
@@ -35,7 +35,7 @@ export class ExtensionTransport extends DeviceApiTransport {
 
         // TODO: unify all calls to use deviceApiCall.method instead of all these if blocks
         if (deviceApiCall instanceof SendJSPixelCall) {
-            return deviceApiCall.result(await extensionSpecificSendPixel(deviceApiCall.params.pixelName))
+            return deviceApiCall.result(await extensionSpecificSendPixel(deviceApiCall.params))
         }
 
         throw new Error('not implemented yet for ' + deviceApiCall.method)
@@ -110,16 +110,14 @@ async function getContentScopeConfig () {
 }
 
 /**
- * @param {import('../__generated__/validators-ts').SendJSPixelParams['pixelName']} pixelName
+ * @param {import('../__generated__/validators-ts').SendJSPixelParams} params
  */
-async function extensionSpecificSendPixel (pixelName) {
+async function extensionSpecificSendPixel (params) {
     return new Promise(resolve => {
         chrome.runtime.sendMessage(
             {
                 messageType: 'sendJSPixel',
-                options: {
-                    pixelName
-                }
+                options: params
             },
             () => {
                 resolve(true)
@@ -141,12 +139,15 @@ async function extensionSpecificGetIncontextSignupDismissedAt () {
     })
 }
 
-async function extensionSpecificSetIncontextSignupDismissedAt (value) {
+/**
+ * @param {import('../__generated__/validators-ts').SetIncontextSignupDismissedAt} params
+ */
+async function extensionSpecificSetIncontextSignupDismissedAt (params) {
     return new Promise(resolve => {
         chrome.runtime.sendMessage(
             {
                 messageType: 'setIncontextSignupDismissedAt',
-                options: { value }
+                options: params
             },
             () => {
                 resolve(true)

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8036,7 +8036,7 @@ var _HTMLTooltip = require("../UI/HTMLTooltip.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const POPUP_TYPES = {
+const TOOLTIP_TYPES = {
   EmailProtection: 'EmailProtection',
   EmailSignup: 'EmailSignup'
 };
@@ -8052,31 +8052,41 @@ class ExtensionInterface extends _InterfacePrototype.default {
       testMode: this.isTestMode()
     };
     const tooltipKinds = {
-      [POPUP_TYPES.EmailProtection]: 'legacy',
-      [POPUP_TYPES.EmailSignup]: 'emailsignup'
+      [TOOLTIP_TYPES.EmailProtection]: 'legacy',
+      [TOOLTIP_TYPES.EmailSignup]: 'emailsignup'
     };
-    const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[POPUP_TYPES.EmailProtection];
+    const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
     return new _HTMLTooltipUIController.HTMLTooltipUIController({
       tooltipKind,
       device: this
     }, htmlTooltipOptions);
   }
 
-  get hasDismissedEmailSignup() {
-    // TODO -- implement peristed dismissed timestamp
-    return false;
-  }
-
   getShowingTooltip() {
     if (this.hasLocalAddresses) {
-      return POPUP_TYPES.EmailProtection;
+      return TOOLTIP_TYPES.EmailProtection;
     }
 
-    if (this.settings.featureToggles.emailProtection_incontext_signup && !this.hasDismissedEmailSignup) {
-      return POPUP_TYPES.EmailSignup;
+    if (this.settings.featureToggles.emailProtection_incontext_signup && this.settings.incontextSignupDismissed === false) {
+      return TOOLTIP_TYPES.EmailSignup;
     }
 
     return null;
+  }
+
+  onIncontextSignupDismissed() {
+    this.settings.setIncontextSignupDismissed(true);
+    chrome.runtime.sendMessage({
+      messageType: 'setIncontextSignupDismissedAt',
+      options: {
+        value: new Date().getTime()
+      }
+    });
+    this.removeAutofillFromUI();
+  }
+
+  removeAutofillFromUI() {
+    this._scannerCleanup && this._scannerCleanup();
   }
 
   async isEnabled() {
@@ -8102,21 +8112,24 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
   postInit() {
     switch (this.getShowingTooltip()) {
-      case POPUP_TYPES.EmailProtection:
+      case TOOLTIP_TYPES.EmailProtection:
         {
-          const cleanup = this.scanner.init();
-          this.addLogoutListener(cleanup);
+          this._scannerCleanup = this.scanner.init();
+          this.addLogoutListener(() => {
+            this.removeAutofillFromUI();
+          });
           break;
         }
 
-      case POPUP_TYPES.EmailSignup:
+      case TOOLTIP_TYPES.EmailSignup:
         {
-          this.scanner.init();
+          this._scannerCleanup = this.scanner.init();
           break;
         }
 
       default:
         {
+          // Don't do anyhing if we don't have a tooltip to show
           break;
         }
     }
@@ -8425,9 +8438,12 @@ class InterfacePrototype {
   /** @type { PMData } */
 
 
+  onIncontextSignupDismissed() {}
   /**
    * @returns {import('../Form/matching').SupportedTypes}
    */
+
+
   getCurrentInputType() {
     throw new Error('Not implemented');
   }
@@ -14342,6 +14358,8 @@ class Settings {
 
   /** @type {boolean | null} */
 
+  /** @type {boolean | null} */
+
   /**
    * @param {GlobalConfig} config
    * @param {DeviceApi} deviceApi
@@ -14358,6 +14376,8 @@ class Settings {
     _defineProperty(this, "_runtimeConfiguration", null);
 
     _defineProperty(this, "_enabled", null);
+
+    _defineProperty(this, "_incontextSignupDismissed", null);
 
     this.deviceApi = deviceApi;
     this.globalConfig = config;
@@ -14411,6 +14431,22 @@ class Settings {
         console.log('isDDGTestMode: getFeatureToggles: ❌', e);
       }
 
+      return null;
+    }
+  }
+  /**
+   * @returns {Promise<boolean|null>}
+   */
+
+
+  async getIncontextSignupDismissed() {
+    try {
+      var _runtimeConfig$userPr4, _runtimeConfig$userPr5, _runtimeConfig$userPr6;
+
+      const runtimeConfig = await this._getRuntimeConfiguration();
+      const incontextSignupSettings = (0, _index.validate)((_runtimeConfig$userPr4 = runtimeConfig.userPreferences) === null || _runtimeConfig$userPr4 === void 0 ? void 0 : (_runtimeConfig$userPr5 = _runtimeConfig$userPr4.features) === null || _runtimeConfig$userPr5 === void 0 ? void 0 : (_runtimeConfig$userPr6 = _runtimeConfig$userPr5.incontextSignup) === null || _runtimeConfig$userPr6 === void 0 ? void 0 : _runtimeConfig$userPr6.settings, _validatorsZod.incontextSignupSettingsSchema);
+      return Boolean(incontextSignupSettings.dismissedAt);
+    } catch (e) {
       return null;
     }
   }
@@ -14469,7 +14505,8 @@ class Settings {
   async refresh() {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
-    this.setAvailableInputTypes(await this.getAvailableInputTypes()); // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
+    this.setAvailableInputTypes(await this.getAvailableInputTypes());
+    this.setIncontextSignupDismissed(await this.getIncontextSignupDismissed()); // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
 
     if (typeof this.enabled === 'boolean') {
       if (!this.enabled) {
@@ -14572,6 +14609,20 @@ class Settings {
 
   setEnabled(enabled) {
     this._enabled = enabled;
+  }
+  /** @returns {boolean|null} */
+
+
+  get incontextSignupDismissed() {
+    return this._incontextSignupDismissed;
+  }
+  /**
+   * @param {boolean|null} incontextSignupDismissed
+   */
+
+
+  setIncontextSignupDismissed(incontextSignupDismissed) {
+    this._incontextSignupDismissed = incontextSignupDismissed;
   }
 
 }
@@ -14784,7 +14835,8 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
     this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                Not Now\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
-    this.registerClickableButton(this.dismissEmailSignup, () => {// TODO: Persist dismissal
+    this.registerClickableButton(this.dismissEmailSignup, () => {
+      device.onIncontextSignupDismissed();
     });
     this.init();
     return this;
@@ -15872,7 +15924,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.buttonMatchesFormType = exports.autofillEnabled = exports.addInlineStyles = exports.SIGN_IN_MSG = exports.ADDRESS_DOMAIN = void 0;
 exports.escapeXML = escapeXML;
-exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
+exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedConfig = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
 
 var _matching = require("./Form/matching.js");
 
@@ -15948,11 +16000,23 @@ const isAutofillEnabledFromProcessedConfig = processedConfig => {
   }
 
   return true;
+};
+
+exports.isAutofillEnabledFromProcessedConfig = isAutofillEnabledFromProcessedConfig;
+
+const isIncontextSignupEnabledFromProcessedConfig = processedConfig => {
+  const site = processedConfig.site;
+
+  if (site.isBroken || !site.enabledFeatures.includes('incontextSignup')) {
+    return false;
+  }
+
+  return true;
 }; // Access the original setter (needed to bypass React's implementation on mobile)
 // @ts-ignore
 
 
-exports.isAutofillEnabledFromProcessedConfig = isAutofillEnabledFromProcessedConfig;
+exports.isIncontextSignupEnabledFromProcessedConfig = isIncontextSignupEnabledFromProcessedConfig;
 const originalSet = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
 /**
  * Ensures the value is set properly and dispatches events to simulate real user action
@@ -16662,7 +16726,7 @@ exports.SendJSPixelCall = SendJSPixelCall;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
+exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
 
 var _zod = require("zod");
 
@@ -16840,6 +16904,12 @@ const userPreferencesSchema = _zod.z.object({
 });
 
 exports.userPreferencesSchema = userPreferencesSchema;
+
+const incontextSignupSettingsSchema = _zod.z.object({
+  dismissedAt: _zod.z.number().optional()
+});
+
+exports.incontextSignupSettingsSchema = incontextSignupSettingsSchema;
 
 const runtimeConfigurationSchema = _zod.z.object({
   contentScope: contentScopeSchema,
@@ -17257,6 +17327,8 @@ exports.ExtensionTransport = ExtensionTransport;
 async function extensionSpecificRuntimeConfiguration(globalConfig) {
   const contentScope = await getContentScopeConfig();
   const emailProtectionEnabled = (0, _autofillUtils.isAutofillEnabledFromProcessedConfig)(contentScope);
+  const incontextSignupEnabled = (0, _autofillUtils.isIncontextSignupEnabledFromProcessedConfig)(contentScope);
+  const incontextSignupDismissedAt = await getIncontextSignupDismissedAt();
   return {
     success: {
       // @ts-ignore
@@ -17267,8 +17339,14 @@ async function extensionSpecificRuntimeConfiguration(globalConfig) {
           autofill: {
             settings: {
               featureToggles: { ..._Settings.Settings.defaults.featureToggles,
-                emailProtection: emailProtectionEnabled
+                emailProtection: emailProtectionEnabled,
+                emailProtection_incontext_signup: incontextSignupEnabled
               }
+            }
+          },
+          incontextSignup: {
+            settings: {
+              dismissedAt: incontextSignupDismissedAt
             }
           }
         }
@@ -17315,6 +17393,16 @@ async function extensionSpecificSendPixel(pixelName) {
       }
     }, () => {
       resolve(true);
+    });
+  });
+}
+
+async function getIncontextSignupDismissedAt() {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({
+      messageType: 'getIncontextSignupDismissedAt'
+    }, response => {
+      resolve(response);
     });
   });
 }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8120,6 +8120,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
     switch (this.getShowingTooltip()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
+          var _this$activeForm;
+
           this._scannerCleanup = this.scanner.init();
           this.addLogoutListener(() => {
             this.resetAutofillUI();
@@ -8132,6 +8134,13 @@ class ExtensionInterface extends _InterfacePrototype.default {
               });
             }
           });
+
+          if ((_this$activeForm = this.activeForm) !== null && _this$activeForm !== void 0 && _this$activeForm.activeInput) {
+            var _this$activeForm2;
+
+            this.attachTooltip(this.activeForm, (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.activeInput, null, 'postSignup');
+          }
+
           break;
         }
 
@@ -8752,7 +8761,7 @@ class InterfacePrototype {
    * @param {import("../Form/Form").Form} form
    * @param {HTMLInputElement} input
    * @param {{ x: number; y: number; } | null} click
-   * @param {'userInitiated' | 'autoprompt'} trigger
+   * @param {import('../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
    */
 
 
@@ -8761,7 +8770,7 @@ class InterfacePrototype {
 
     let trigger = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'userInitiated';
     // Avoid flashing tooltip from background tabs on macOS
-    if (document.visibilityState !== 'visible') return; // Only autoprompt on mobile devices
+    if (document.visibilityState !== 'visible' && trigger !== 'postSignup') return; // Only autoprompt on mobile devices
 
     if (trigger === 'autoprompt' && !this.globalConfig.isMobileApp) return; // Only fire autoprompt once
 
@@ -15846,7 +15855,7 @@ exports.UIController = void 0;
  * @property {{x: number, y: number}|null} click The click positioning
  * @property {TopContextData} topContextData
  * @property {import("../../DeviceInterface/InterfacePrototype").default} device
- * @property {'userInitiated' | 'autoprompt'} trigger
+ * @property {import('../../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
  */
 
 /**
@@ -17068,7 +17077,7 @@ const getAutofillDataRequestSchema = _zod.z.object({
   inputType: _zod.z.string(),
   mainType: _zod.z.union([_zod.z.literal("credentials"), _zod.z.literal("identities"), _zod.z.literal("creditCards")]),
   subType: _zod.z.string(),
-  trigger: _zod.z.union([_zod.z.literal("userInitiated"), _zod.z.literal("autoprompt")]).optional(),
+  trigger: _zod.z.union([_zod.z.literal("userInitiated"), _zod.z.literal("autoprompt"), _zod.z.literal("postSignup")]).optional(),
   serializedInputContext: _zod.z.string().optional(),
   triggerContext: triggerContextSchema.optional()
 });

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8062,6 +8062,12 @@ class ExtensionInterface extends _InterfacePrototype.default {
     return null;
   }
 
+  onIncontextSignup() {
+    this.firePixel({
+      pixelName: 'incontext_get_email_protection'
+    });
+  }
+
   onIncontextSignupDismissed() {
     // Check if the email signup tooltip has previously been dismissed.
     // If it has, make the dismissal persist and remove it from the page.
@@ -8072,9 +8078,15 @@ class ExtensionInterface extends _InterfacePrototype.default {
         value: new Date().getTime()
       }));
       this.removeAutofillUIFromPage();
+      this.firePixel({
+        pixelName: 'incontext_dismiss_persisted'
+      });
     } else {
       this.emailSignupInitialDismissal = true;
       this.removeTooltip();
+      this.firePixel({
+        pixelName: 'incontext_dismiss_initial'
+      });
     }
   }
 
@@ -8462,6 +8474,8 @@ class InterfacePrototype {
   }
   /** @type { PMData } */
 
+
+  onIncontextSignup() {}
 
   onIncontextSignupDismissed() {}
   /**
@@ -14870,11 +14884,15 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {
       device.onIncontextSignupDismissed();
+    });
+    this.getEmailSignup = this.shadow.querySelector('.js-get-email-signup');
+    this.registerClickableButton(this.getEmailSignup, () => {
+      device.onIncontextSignup();
     });
     this.init();
     return this;
@@ -15294,6 +15312,10 @@ class HTMLTooltipUIController extends _UIController.UIController {
     }
 
     if (this._options.tooltipKind === 'emailsignup') {
+      this._options.device.firePixel({
+        pixelName: 'incontext_show'
+      });
+
       return new _EmailSignupHTMLTooltop.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
     } // collect the data for each item to display
 
@@ -17027,6 +17049,14 @@ const sendJSPixelParamsSchema = _zod.z.union([_zod.z.object({
   pixelName: _zod.z.literal("autofill_personal_address")
 }), _zod.z.object({
   pixelName: _zod.z.literal("autofill_private_address")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_show")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_get_email_protection")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_dismiss_persisted")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_dismiss_initial")
 })]);
 
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8043,14 +8043,14 @@ class ExtensionInterface extends _InterfacePrototype.default {
       [TOOLTIP_TYPES.EmailProtection]: 'legacy',
       [TOOLTIP_TYPES.EmailSignup]: 'emailsignup'
     };
-    const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
+    const tooltipKind = tooltipKinds[this.getActiveTooltipType()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
     return new _HTMLTooltipUIController.HTMLTooltipUIController({
       tooltipKind,
       device: this
     }, htmlTooltipOptions);
   }
 
-  getShowingTooltip() {
+  getActiveTooltipType() {
     if (this.hasLocalAddresses) {
       return TOOLTIP_TYPES.EmailProtection;
     }
@@ -8129,7 +8129,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   postInit() {
-    switch (this.getShowingTooltip()) {
+    switch (this.getActiveTooltipType()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
           var _this$activeForm;
@@ -8270,6 +8270,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   addLogoutListener(handler) {
+    // Make sure there's only one log out listener attached by removing the
+    // previous logout listener first, if it exists.
     if (this._logoutListenerHandler) {
       chrome.runtime.onMessage.removeListener(this._logoutListenerHandler);
     } // Cleanup on logout events
@@ -9711,7 +9713,7 @@ class Form {
 
     this.form = form;
     this.matching = matching || (0, _matching.createMatching)();
-    this.formAnalyzer = new _FormAnalyzer.default(form, input, deviceInterface.globalConfig, matching);
+    this.formAnalyzer = new _FormAnalyzer.default(form, input, matching);
     this.isLogin = this.formAnalyzer.isLogin;
     this.isSignup = this.formAnalyzer.isSignup;
     this.isHybrid = this.formAnalyzer.isHybrid;
@@ -10309,10 +10311,9 @@ class FormAnalyzer {
   /**
    * @param {HTMLElement} form
    * @param {HTMLInputElement|HTMLSelectElement} input
-   * @param {GlobalConfig} config
    * @param {Matching} [matching]
    */
-  constructor(form, input, config, matching) {
+  constructor(form, input, matching) {
     _defineProperty(this, "form", void 0);
 
     _defineProperty(this, "matching", void 0);
@@ -10336,12 +10337,7 @@ class FormAnalyzer {
      * @type {boolean}
      */
 
-    this.isHybrid = false; // Avoid autofill on Email Protection web app
-
-    if (config.isDDGDomain) {
-      return this;
-    }
-
+    this.isHybrid = false;
     this.evaluateElAttributes(input, 3, true);
     form ? this.evaluateForm() : this.evaluatePage();
     return this;

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8034,6 +8034,8 @@ var _HTMLTooltipUIController = require("../UI/controllers/HTMLTooltipUIControlle
 
 var _HTMLTooltip = require("../UI/HTMLTooltip.js");
 
+var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const TOOLTIP_TYPES = {
@@ -8076,17 +8078,15 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
   onIncontextSignupDismissed() {
     this.settings.setIncontextSignupDismissed(true);
-    chrome.runtime.sendMessage({
-      messageType: 'setIncontextSignupDismissedAt',
-      options: {
-        value: new Date().getTime()
-      }
-    });
+    this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+      value: new Date().getTime()
+    }));
     this.removeAutofillUIFromPage();
   }
 
   async resetAutofillUI() {
-    this.removeAutofillUIFromPage(); // Start the setup process again
+    this.removeAutofillUIFromPage(); // TOOD: can we use recategorizeAllInputs here?
+    // Start the setup process again
 
     await this.refreshSettings();
     await this.setupAutofill(); // TODO: Do we need this to be called?
@@ -8265,7 +8265,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
 exports.ExtensionInterface = ExtensionInterface;
 
-},{"../UI/HTMLTooltip.js":53,"../UI/controllers/HTMLTooltipUIController.js":54,"../autofill-utils.js":60,"./InterfacePrototype.js":27}],27:[function(require,module,exports){
+},{"../UI/HTMLTooltip.js":53,"../UI/controllers/HTMLTooltipUIController.js":54,"../autofill-utils.js":60,"../deviceApiCalls/__generated__/deviceApiCalls.js":64,"./InterfacePrototype.js":27}],27:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15224,7 +15224,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   }
 
   destroy() {
-    this.removeTooltip('destroy');
+    this.removeTooltip();
 
     this._removeListeners();
 
@@ -16523,7 +16523,7 @@ exports.constants = constants;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.StoreFormDataCall = exports.SetSizeCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
+exports.StoreFormDataCall = exports.SetSizeCall = exports.SetIncontextSignupDismissedAtCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetIncontextSignupDismissedAtCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
 
 var _validatorsZod = require("./validators.zod.js");
 
@@ -16747,8 +16747,44 @@ class SendJSPixelCall extends _deviceApi.DeviceApiCall {
   }
 
 }
+/**
+ * @extends {DeviceApiCall<setIncontextSignupDismissedAtSchema, any>} 
+ */
+
 
 exports.SendJSPixelCall = SendJSPixelCall;
+
+class SetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "setIncontextSignupDismissedAt");
+
+    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupDismissedAtSchema);
+  }
+
+}
+/**
+ * @extends {DeviceApiCall<any, getIncontextSignupDismissedAtSchema>} 
+ */
+
+
+exports.SetIncontextSignupDismissedAtCall = SetIncontextSignupDismissedAtCall;
+
+class GetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "getIncontextSignupDismissedAt");
+
+    _defineProperty(this, "id", "getIncontextSignupDismissedAt");
+
+    _defineProperty(this, "resultValidator", _validatorsZod.getIncontextSignupDismissedAtSchema);
+  }
+
+}
+
+exports.GetIncontextSignupDismissedAtCall = GetIncontextSignupDismissedAtCall;
 
 },{"../../../packages/device-api":14,"./validators.zod.js":65}],65:[function(require,module,exports){
 "use strict";
@@ -16756,7 +16792,7 @@ exports.SendJSPixelCall = SendJSPixelCall;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
+exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.setIncontextSignupDismissedAtSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getIncontextSignupDismissedAtSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
 
 var _zod = require("zod");
 
@@ -16910,6 +16946,14 @@ const getAvailableInputTypesResultSchema = _zod.z.object({
 
 exports.getAvailableInputTypesResultSchema = getAvailableInputTypesResultSchema;
 
+const getIncontextSignupDismissedAtSchema = _zod.z.object({
+  success: _zod.z.object({
+    value: _zod.z.number().optional()
+  })
+});
+
+exports.getIncontextSignupDismissedAtSchema = getIncontextSignupDismissedAtSchema;
+
 const contentScopeSchema = _zod.z.object({
   features: _zod.z.record(_zod.z.object({
     exceptions: _zod.z.array(_zod.z.unknown()),
@@ -16968,6 +17012,12 @@ const sendJSPixelParamsSchema = _zod.z.union([_zod.z.object({
 })]);
 
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;
+
+const setIncontextSignupDismissedAtSchema = _zod.z.object({
+  value: _zod.z.number().optional()
+});
+
+exports.setIncontextSignupDismissedAtSchema = setIncontextSignupDismissedAtSchema;
 
 const setSizeParamsSchema = _zod.z.object({
   height: _zod.z.number(),
@@ -17330,11 +17380,19 @@ class ExtensionTransport extends _index.DeviceApiTransport {
 
   async send(deviceApiCall) {
     if (deviceApiCall instanceof _deviceApiCalls.GetRuntimeConfigurationCall) {
-      return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this.config));
+      return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this));
     }
 
     if (deviceApiCall instanceof _deviceApiCalls.GetAvailableInputTypesCall) {
       return deviceApiCall.result(await extensionSpecificGetAvailableInputTypes());
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params.value));
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.GetIncontextSignupDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificGetIncontextSignupDismissedAt());
     } // TODO: unify all calls to use deviceApiCall.method instead of all these if blocks
 
 
@@ -17347,18 +17405,20 @@ class ExtensionTransport extends _index.DeviceApiTransport {
 
 }
 /**
- * @param {GlobalConfig} globalConfig
+ * @param {ExtensionTransport} deviceApi
  * @returns {Promise<ReturnType<GetRuntimeConfigurationCall['result']>>}
  */
 
 
 exports.ExtensionTransport = ExtensionTransport;
 
-async function extensionSpecificRuntimeConfiguration(globalConfig) {
+async function extensionSpecificRuntimeConfiguration(deviceApi) {
+  var _deviceApi$config;
+
   const contentScope = await getContentScopeConfig();
   const emailProtectionEnabled = (0, _autofillUtils.isAutofillEnabledFromProcessedConfig)(contentScope);
   const incontextSignupEnabled = (0, _autofillUtils.isIncontextSignupEnabledFromProcessedConfig)(contentScope);
-  const incontextSignupDismissedAt = await getIncontextSignupDismissedAt();
+  const incontextSignupDismissedAt = await deviceApi.send(new _deviceApiCalls.GetIncontextSignupDismissedAtCall(null));
   return {
     success: {
       // @ts-ignore
@@ -17376,13 +17436,13 @@ async function extensionSpecificRuntimeConfiguration(globalConfig) {
           },
           incontextSignup: {
             settings: {
-              dismissedAt: incontextSignupDismissedAt
+              dismissedAt: incontextSignupDismissedAt.success.value
             }
           }
         }
       },
       // @ts-ignore
-      userUnprotectedDomains: globalConfig === null || globalConfig === void 0 ? void 0 : globalConfig.userUnprotectedDomains
+      userUnprotectedDomains: (_deviceApi$config = deviceApi.config) === null || _deviceApi$config === void 0 ? void 0 : _deviceApi$config.userUnprotectedDomains
     }
   };
 }
@@ -17427,12 +17487,25 @@ async function extensionSpecificSendPixel(pixelName) {
   });
 }
 
-async function getIncontextSignupDismissedAt() {
+async function extensionSpecificGetIncontextSignupDismissedAt() {
   return new Promise(resolve => {
     chrome.runtime.sendMessage({
       messageType: 'getIncontextSignupDismissedAt'
     }, response => {
       resolve(response);
+    });
+  });
+}
+
+async function extensionSpecificSetIncontextSignupDismissedAt(value) {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({
+      messageType: 'setIncontextSignupDismissedAt',
+      options: {
+        value
+      }
+    }, () => {
+      resolve(true);
     });
   });
 }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8097,11 +8097,19 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   onIncontextSignupDismissed() {
-    this.settings.setIncontextSignupDismissed(true);
-    this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
-      value: new Date().getTime()
-    }));
-    this.removeAutofillUIFromPage();
+    // Check if the email signup tooltip has previously been dismissed.
+    // If it has, make the dismissal persist and remove it from the page.
+    // If it hasn't, set a flag for next time and just hide the tooltip.
+    if (this.emailSignupInitialDismissal) {
+      this.settings.setIncontextSignupDismissed(true);
+      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+        value: new Date().getTime()
+      }));
+      this.removeAutofillUIFromPage();
+    } else {
+      this.emailSignupInitialDismissal = true;
+      this.removeTooltip();
+    }
   }
 
   async resetAutofillUI(callback) {
@@ -8394,6 +8402,8 @@ class InterfacePrototype {
     _defineProperty(this, "initialSetupDelayMs", 0);
 
     _defineProperty(this, "autopromptFired", false);
+
+    _defineProperty(this, "emailSignupInitialDismissal", false);
 
     _defineProperty(this, "passwordGenerator", new _PasswordGenerator.PasswordGenerator());
 
@@ -14873,7 +14883,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                Not Now\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15252,16 +15252,19 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     _defineProperty(this, "_activeInputType", 'unknown');
 
+    _defineProperty(this, "_activeInput", void 0);
+
+    _defineProperty(this, "_activeInputOriginalAutocomplete", void 0);
+
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
   }
+
   /**
    * Cleans up after this UI controller by removing the tooltip and all
    * listeners.
    */
-
-
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
@@ -15285,6 +15288,9 @@ class HTMLTooltipUIController extends _UIController.UIController {
     const tooltip = this.createTooltip(getPosition, topContextData);
     this.setActiveTooltip(tooltip);
     form.showingTooltip(input);
+    this._activeInput = input;
+    this._activeInputOriginalAutocomplete = input.getAttribute('autocomplete');
+    input.setAttribute('autocomplete', 'off');
   }
   /**
    * Actually create the HTML Tooltip
@@ -15423,6 +15429,17 @@ class HTMLTooltipUIController extends _UIController.UIController {
       this._activeTooltip.remove();
 
       this._activeTooltip = null;
+    }
+
+    if (this._activeInput) {
+      if (this._activeInputOriginalAutocomplete) {
+        this._activeInput.setAttribute('autocomplete', this._activeInputOriginalAutocomplete);
+      } else {
+        this._activeInput.removeAttribute('autocomplete');
+      }
+
+      this._activeInput = null;
+      this._activeInputOriginalAutocomplete = null;
     }
   }
   /**

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4421,11 +4421,19 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   onIncontextSignupDismissed() {
-    this.settings.setIncontextSignupDismissed(true);
-    this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
-      value: new Date().getTime()
-    }));
-    this.removeAutofillUIFromPage();
+    // Check if the email signup tooltip has previously been dismissed.
+    // If it has, make the dismissal persist and remove it from the page.
+    // If it hasn't, set a flag for next time and just hide the tooltip.
+    if (this.emailSignupInitialDismissal) {
+      this.settings.setIncontextSignupDismissed(true);
+      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+        value: new Date().getTime()
+      }));
+      this.removeAutofillUIFromPage();
+    } else {
+      this.emailSignupInitialDismissal = true;
+      this.removeTooltip();
+    }
   }
 
   async resetAutofillUI(callback) {
@@ -4718,6 +4726,8 @@ class InterfacePrototype {
     _defineProperty(this, "initialSetupDelayMs", 0);
 
     _defineProperty(this, "autopromptFired", false);
+
+    _defineProperty(this, "emailSignupInitialDismissal", false);
 
     _defineProperty(this, "passwordGenerator", new _PasswordGenerator.PasswordGenerator());
 
@@ -11197,7 +11207,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                Not Now\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4367,14 +4367,14 @@ class ExtensionInterface extends _InterfacePrototype.default {
       [TOOLTIP_TYPES.EmailProtection]: 'legacy',
       [TOOLTIP_TYPES.EmailSignup]: 'emailsignup'
     };
-    const tooltipKind = tooltipKinds[this.getShowingTooltip()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
+    const tooltipKind = tooltipKinds[this.getActiveTooltipType()] || tooltipKinds[TOOLTIP_TYPES.EmailProtection];
     return new _HTMLTooltipUIController.HTMLTooltipUIController({
       tooltipKind,
       device: this
     }, htmlTooltipOptions);
   }
 
-  getShowingTooltip() {
+  getActiveTooltipType() {
     if (this.hasLocalAddresses) {
       return TOOLTIP_TYPES.EmailProtection;
     }
@@ -4453,7 +4453,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   postInit() {
-    switch (this.getShowingTooltip()) {
+    switch (this.getActiveTooltipType()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
           var _this$activeForm;
@@ -4594,6 +4594,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   addLogoutListener(handler) {
+    // Make sure there's only one log out listener attached by removing the
+    // previous logout listener first, if it exists.
     if (this._logoutListenerHandler) {
       chrome.runtime.onMessage.removeListener(this._logoutListenerHandler);
     } // Cleanup on logout events
@@ -6035,7 +6037,7 @@ class Form {
 
     this.form = form;
     this.matching = matching || (0, _matching.createMatching)();
-    this.formAnalyzer = new _FormAnalyzer.default(form, input, deviceInterface.globalConfig, matching);
+    this.formAnalyzer = new _FormAnalyzer.default(form, input, matching);
     this.isLogin = this.formAnalyzer.isLogin;
     this.isSignup = this.formAnalyzer.isSignup;
     this.isHybrid = this.formAnalyzer.isHybrid;
@@ -6633,10 +6635,9 @@ class FormAnalyzer {
   /**
    * @param {HTMLElement} form
    * @param {HTMLInputElement|HTMLSelectElement} input
-   * @param {GlobalConfig} config
    * @param {Matching} [matching]
    */
-  constructor(form, input, config, matching) {
+  constructor(form, input, matching) {
     _defineProperty(this, "form", void 0);
 
     _defineProperty(this, "matching", void 0);
@@ -6660,12 +6661,7 @@ class FormAnalyzer {
      * @type {boolean}
      */
 
-    this.isHybrid = false; // Avoid autofill on Email Protection web app
-
-    if (config.isDDGDomain) {
-      return this;
-    }
-
+    this.isHybrid = false;
     this.evaluateElAttributes(input, 3, true);
     form ? this.evaluateForm() : this.evaluatePage();
     return this;

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -11576,16 +11576,19 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     _defineProperty(this, "_activeInputType", 'unknown');
 
+    _defineProperty(this, "_activeInput", void 0);
+
+    _defineProperty(this, "_activeInputOriginalAutocomplete", void 0);
+
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
   }
+
   /**
    * Cleans up after this UI controller by removing the tooltip and all
    * listeners.
    */
-
-
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
@@ -11609,6 +11612,9 @@ class HTMLTooltipUIController extends _UIController.UIController {
     const tooltip = this.createTooltip(getPosition, topContextData);
     this.setActiveTooltip(tooltip);
     form.showingTooltip(input);
+    this._activeInput = input;
+    this._activeInputOriginalAutocomplete = input.getAttribute('autocomplete');
+    input.setAttribute('autocomplete', 'off');
   }
   /**
    * Actually create the HTML Tooltip
@@ -11747,6 +11753,17 @@ class HTMLTooltipUIController extends _UIController.UIController {
       this._activeTooltip.remove();
 
       this._activeTooltip = null;
+    }
+
+    if (this._activeInput) {
+      if (this._activeInputOriginalAutocomplete) {
+        this._activeInput.setAttribute('autocomplete', this._activeInputOriginalAutocomplete);
+      } else {
+        this._activeInput.removeAttribute('autocomplete');
+      }
+
+      this._activeInput = null;
+      this._activeInputOriginalAutocomplete = null;
     }
   }
   /**

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4408,14 +4408,13 @@ class ExtensionInterface extends _InterfacePrototype.default {
     this.removeAutofillUIFromPage();
   }
 
-  async resetAutofillUI() {
+  async resetAutofillUI(callback) {
     this.removeAutofillUIFromPage(); // TOOD: can we use recategorizeAllInputs here?
     // Start the setup process again
 
     await this.refreshSettings();
-    await this.setupAutofill(); // TODO: Do we need this to be called?
-    // await this.setupSettingsPage({shouldLog: true})
-
+    await this.setupAutofill();
+    if (callback) await callback();
     this.uiController = this.createUIController();
     await this.postInit();
   }
@@ -4551,7 +4550,9 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
       switch (message.type) {
         case 'ddgUserReady':
-          this.resetAutofillUI();
+          this.resetAutofillUI(() => this.setupSettingsPage({
+            shouldLog: true
+          }));
           break;
 
         case 'contextualAutofill':
@@ -10450,8 +10451,6 @@ class DefaultScanner {
 
 
   init() {
-    var _this = this;
-
     const delay = this.options.initialDelay; // if the delay is zero, (chrome/firefox etc) then use `requestIdleCallback`
 
     if (delay === 0) {
@@ -10461,25 +10460,22 @@ class DefaultScanner {
       setTimeout(() => this.scanAndObserve(), delay);
     }
 
-    return function () {
-      let {
-        silent
-      } = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {
-        silent: false
-      };
-      // remove Dax, listeners, timers, and observers
-      clearTimeout(_this.debounceTimer);
+    return () => {
+      var _this$device$activeFo;
 
-      _this.mutObs.disconnect();
+      const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
 
-      _this.forms.forEach(form => {
+      clearTimeout(this.debounceTimer);
+      this.mutObs.disconnect();
+      this.forms.forEach(form => {
         form.resetAllInputs();
         form.removeAllDecorations();
       });
+      this.forms.clear(); // Bring the user back to the input they were interacting with
 
-      _this.forms.clear();
+      activeInput === null || activeInput === void 0 ? void 0 : activeInput.focus();
 
-      if (_this.device.globalConfig.isDDGDomain && !silent) {
+      if (this.device.globalConfig.isDDGDomain) {
         (0, _autofillUtils.notifyWebApp)({
           deviceSignedIn: {
             value: false

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4379,7 +4379,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
       return TOOLTIP_TYPES.EmailProtection;
     }
 
-    if (this.settings.featureToggles.emailProtection_incontext_signup && this.settings.incontextSignupDismissed === false) {
+    if (this.settings.featureToggles.emailProtection_incontext_signup && this.settings.incontextSignupPermanentlyDismissed === false) {
       return TOOLTIP_TYPES.EmailSignup;
     }
 
@@ -4396,9 +4396,9 @@ class ExtensionInterface extends _InterfacePrototype.default {
     // Check if the email signup tooltip has previously been dismissed.
     // If it has, make the dismissal persist and remove it from the page.
     // If it hasn't, set a flag for next time and just hide the tooltip.
-    if (this.emailSignupInitialDismissal) {
-      this.settings.setIncontextSignupDismissed(true);
-      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+    if (this.settings.incontextSignupInitiallyDismissed) {
+      this.settings.setIncontextSignupPermanentlyDismissed(true);
+      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupPermanentlyDismissedAtCall({
         value: new Date().getTime()
       }));
       this.removeAutofillUIFromPage();
@@ -4406,7 +4406,10 @@ class ExtensionInterface extends _InterfacePrototype.default {
         pixelName: 'incontext_dismiss_persisted'
       });
     } else {
-      this.emailSignupInitialDismissal = true;
+      this.settings.setIncontextSignupInitiallyDismissed(true);
+      this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupInitiallyDismissedAtCall({
+        value: new Date().getTime()
+      }));
       this.removeTooltip();
       this.firePixel({
         pixelName: 'incontext_dismiss_initial'
@@ -4715,8 +4718,6 @@ class InterfacePrototype {
     _defineProperty(this, "initialSetupDelayMs", 0);
 
     _defineProperty(this, "autopromptFired", false);
-
-    _defineProperty(this, "emailSignupInitialDismissal", false);
 
     _defineProperty(this, "passwordGenerator", new _PasswordGenerator.PasswordGenerator());
 
@@ -10732,6 +10733,8 @@ class Settings {
 
   /** @type {boolean | null} */
 
+  /** @type {boolean | null} */
+
   /**
    * @param {GlobalConfig} config
    * @param {DeviceApi} deviceApi
@@ -10749,7 +10752,9 @@ class Settings {
 
     _defineProperty(this, "_enabled", null);
 
-    _defineProperty(this, "_incontextSignupDismissed", null);
+    _defineProperty(this, "_incontextSignupInitiallyDismissed", null);
+
+    _defineProperty(this, "_incontextSignupPermanentlyDismissed", null);
 
     this.deviceApi = deviceApi;
     this.globalConfig = config;
@@ -10811,13 +10816,25 @@ class Settings {
    */
 
 
-  async getIncontextSignupDismissed() {
+  async getIncontextSignupInitiallyDismissed() {
     try {
       var _runtimeConfig$userPr4, _runtimeConfig$userPr5, _runtimeConfig$userPr6;
 
       const runtimeConfig = await this._getRuntimeConfiguration();
       const incontextSignupSettings = (0, _index.validate)((_runtimeConfig$userPr4 = runtimeConfig.userPreferences) === null || _runtimeConfig$userPr4 === void 0 ? void 0 : (_runtimeConfig$userPr5 = _runtimeConfig$userPr4.features) === null || _runtimeConfig$userPr5 === void 0 ? void 0 : (_runtimeConfig$userPr6 = _runtimeConfig$userPr5.incontextSignup) === null || _runtimeConfig$userPr6 === void 0 ? void 0 : _runtimeConfig$userPr6.settings, _validatorsZod.incontextSignupSettingsSchema);
-      return Boolean(incontextSignupSettings.dismissedAt);
+      return Boolean(incontextSignupSettings.initiallyDismissedAt);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  async getIncontextSignupPermanentlyDismissed() {
+    try {
+      var _runtimeConfig$userPr7, _runtimeConfig$userPr8, _runtimeConfig$userPr9;
+
+      const runtimeConfig = await this._getRuntimeConfiguration();
+      const incontextSignupSettings = (0, _index.validate)((_runtimeConfig$userPr7 = runtimeConfig.userPreferences) === null || _runtimeConfig$userPr7 === void 0 ? void 0 : (_runtimeConfig$userPr8 = _runtimeConfig$userPr7.features) === null || _runtimeConfig$userPr8 === void 0 ? void 0 : (_runtimeConfig$userPr9 = _runtimeConfig$userPr8.incontextSignup) === null || _runtimeConfig$userPr9 === void 0 ? void 0 : _runtimeConfig$userPr9.settings, _validatorsZod.incontextSignupSettingsSchema);
+      return Boolean(incontextSignupSettings.permanentlyDismissedAt);
     } catch (e) {
       return null;
     }
@@ -10878,7 +10895,8 @@ class Settings {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
     this.setAvailableInputTypes(await this.getAvailableInputTypes());
-    this.setIncontextSignupDismissed(await this.getIncontextSignupDismissed()); // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
+    this.setIncontextSignupInitiallyDismissed(await this.getIncontextSignupInitiallyDismissed());
+    this.setIncontextSignupPermanentlyDismissed(await this.getIncontextSignupPermanentlyDismissed()); // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
 
     if (typeof this.enabled === 'boolean') {
       if (!this.enabled) {
@@ -10985,16 +11003,30 @@ class Settings {
   /** @returns {boolean|null} */
 
 
-  get incontextSignupDismissed() {
-    return this._incontextSignupDismissed;
+  get incontextSignupInitiallyDismissed() {
+    return this._incontextSignupInitiallyDismissed;
   }
   /**
-   * @param {boolean|null} incontextSignupDismissed
+   * @param {boolean|null} incontextSignupInitiallyDismissed
    */
 
 
-  setIncontextSignupDismissed(incontextSignupDismissed) {
-    this._incontextSignupDismissed = incontextSignupDismissed;
+  setIncontextSignupInitiallyDismissed(incontextSignupInitiallyDismissed) {
+    this._incontextSignupInitiallyDismissed = incontextSignupInitiallyDismissed;
+  }
+  /** @returns {boolean|null} */
+
+
+  get incontextSignupPermanentlyDismissed() {
+    return this._incontextSignupPermanentlyDismissed;
+  }
+  /**
+   * @param {boolean|null} incontextSignupPermanentlyDismissed
+   */
+
+
+  setIncontextSignupPermanentlyDismissed(incontextSignupPermanentlyDismissed) {
+    this._incontextSignupPermanentlyDismissed = incontextSignupPermanentlyDismissed;
   }
 
 }
@@ -11204,7 +11236,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.settings.incontextSignupInitiallyDismissed ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {
@@ -12900,7 +12932,7 @@ exports.constants = constants;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.StoreFormDataCall = exports.SetSizeCall = exports.SetIncontextSignupDismissedAtCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetIncontextSignupDismissedAtCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
+exports.StoreFormDataCall = exports.SetSizeCall = exports.SetIncontextSignupPermanentlyDismissedAtCall = exports.SetIncontextSignupInitiallyDismissedAtCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetIncontextSignupDismissedAtCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
 
 var _validatorsZod = require("./validators.zod.js");
 
@@ -13125,19 +13157,36 @@ class SendJSPixelCall extends _deviceApi.DeviceApiCall {
 
 }
 /**
- * @extends {DeviceApiCall<setIncontextSignupDismissedAtSchema, any>} 
+ * @extends {DeviceApiCall<setIncontextSignupInitiallyDismissedAtSchema, any>} 
  */
 
 
 exports.SendJSPixelCall = SendJSPixelCall;
 
-class SetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+class SetIncontextSignupInitiallyDismissedAtCall extends _deviceApi.DeviceApiCall {
   constructor() {
     super(...arguments);
 
-    _defineProperty(this, "method", "setIncontextSignupDismissedAt");
+    _defineProperty(this, "method", "setIncontextSignupInitiallyDismissedAt");
 
-    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupDismissedAtSchema);
+    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupInitiallyDismissedAtSchema);
+  }
+
+}
+/**
+ * @extends {DeviceApiCall<setIncontextSignupPermanentlyDismissedAtSchema, any>} 
+ */
+
+
+exports.SetIncontextSignupInitiallyDismissedAtCall = SetIncontextSignupInitiallyDismissedAtCall;
+
+class SetIncontextSignupPermanentlyDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "setIncontextSignupPermanentlyDismissedAt");
+
+    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupPermanentlyDismissedAtSchema);
   }
 
 }
@@ -13146,7 +13195,7 @@ class SetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
  */
 
 
-exports.SetIncontextSignupDismissedAtCall = SetIncontextSignupDismissedAtCall;
+exports.SetIncontextSignupPermanentlyDismissedAtCall = SetIncontextSignupPermanentlyDismissedAtCall;
 
 class GetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
   constructor() {
@@ -13169,7 +13218,7 @@ exports.GetIncontextSignupDismissedAtCall = GetIncontextSignupDismissedAtCall;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.setIncontextSignupDismissedAtSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getIncontextSignupDismissedAtSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
+exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.setIncontextSignupPermanentlyDismissedAtSchema = exports.setIncontextSignupInitiallyDismissedAtSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getIncontextSignupDismissedAtSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
 const credentialsSchema = null;
 exports.credentialsSchema = credentialsSchema;
 const availableInputTypesSchema = null;
@@ -13210,8 +13259,10 @@ const selectedDetailParamsSchema = null;
 exports.selectedDetailParamsSchema = selectedDetailParamsSchema;
 const sendJSPixelParamsSchema = null;
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;
-const setIncontextSignupDismissedAtSchema = null;
-exports.setIncontextSignupDismissedAtSchema = setIncontextSignupDismissedAtSchema;
+const setIncontextSignupInitiallyDismissedAtSchema = null;
+exports.setIncontextSignupInitiallyDismissedAtSchema = setIncontextSignupInitiallyDismissedAtSchema;
+const setIncontextSignupPermanentlyDismissedAtSchema = null;
+exports.setIncontextSignupPermanentlyDismissedAtSchema = setIncontextSignupPermanentlyDismissedAtSchema;
 const setSizeParamsSchema = null;
 exports.setSizeParamsSchema = setSizeParamsSchema;
 const outgoingCredentialsSchema = null;
@@ -13536,8 +13587,12 @@ class ExtensionTransport extends _index.DeviceApiTransport {
       return deviceApiCall.result(await extensionSpecificGetAvailableInputTypes());
     }
 
-    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupDismissedAtCall) {
-      return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params));
+    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupInitiallyDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificSetIncontextSignupInitiallyDismissedAtCall(deviceApiCall.params));
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupPermanentlyDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificSetIncontextSignupPermanentlyDismissedAtCall(deviceApiCall.params));
     }
 
     if (deviceApiCall instanceof _deviceApiCalls.GetIncontextSignupDismissedAtCall) {
@@ -13585,7 +13640,8 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
           },
           incontextSignup: {
             settings: {
-              dismissedAt: incontextSignupDismissedAt.success.value
+              initiallyDismissedAt: incontextSignupDismissedAt.success.initiallyDismissedAt,
+              permanentlyDismissedAt: incontextSignupDismissedAt.success.permanentlyDismissedAt
             }
           }
         }
@@ -13644,14 +13700,29 @@ async function extensionSpecificGetIncontextSignupDismissedAt() {
   });
 }
 /**
- * @param {import('../__generated__/validators-ts').SetIncontextSignupDismissedAt} params
+ * @param {import('../__generated__/validators-ts').SetIncontextSignupInitiallyDismissedAt} params
  */
 
 
-async function extensionSpecificSetIncontextSignupDismissedAt(params) {
+async function extensionSpecificSetIncontextSignupInitiallyDismissedAtCall(params) {
   return new Promise(resolve => {
     chrome.runtime.sendMessage({
-      messageType: 'setIncontextSignupDismissedAt',
+      messageType: 'setIncontextSignupInitiallyDismissedAt',
+      options: params
+    }, () => {
+      resolve(true);
+    });
+  });
+}
+/**
+ * @param {import('../__generated__/validators-ts').SetIncontextSignupPermanentlyDismissedAt} params
+ */
+
+
+async function extensionSpecificSetIncontextSignupPermanentlyDismissedAtCall(params) {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({
+      messageType: 'setIncontextSignupPermanentlyDismissedAt',
       options: params
     }, () => {
       resolve(true);

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4386,6 +4386,12 @@ class ExtensionInterface extends _InterfacePrototype.default {
     return null;
   }
 
+  onIncontextSignup() {
+    this.firePixel({
+      pixelName: 'incontext_get_email_protection'
+    });
+  }
+
   onIncontextSignupDismissed() {
     // Check if the email signup tooltip has previously been dismissed.
     // If it has, make the dismissal persist and remove it from the page.
@@ -4396,9 +4402,15 @@ class ExtensionInterface extends _InterfacePrototype.default {
         value: new Date().getTime()
       }));
       this.removeAutofillUIFromPage();
+      this.firePixel({
+        pixelName: 'incontext_dismiss_persisted'
+      });
     } else {
       this.emailSignupInitialDismissal = true;
       this.removeTooltip();
+      this.firePixel({
+        pixelName: 'incontext_dismiss_initial'
+      });
     }
   }
 
@@ -4786,6 +4798,8 @@ class InterfacePrototype {
   }
   /** @type { PMData } */
 
+
+  onIncontextSignup() {}
 
   onIncontextSignupDismissed() {}
   /**
@@ -11194,11 +11208,15 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat(device.emailSignupInitialDismissal ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {
       device.onIncontextSignupDismissed();
+    });
+    this.getEmailSignup = this.shadow.querySelector('.js-get-email-signup');
+    this.registerClickableButton(this.getEmailSignup, () => {
+      device.onIncontextSignup();
     });
     this.init();
     return this;
@@ -11618,6 +11636,10 @@ class HTMLTooltipUIController extends _UIController.UIController {
     }
 
     if (this._options.tooltipKind === 'emailsignup') {
+      this._options.device.firePixel({
+        pixelName: 'incontext_show'
+      });
+
       return new _EmailSignupHTMLTooltop.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
     } // collect the data for each item to display
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4406,11 +4406,25 @@ class ExtensionInterface extends _InterfacePrototype.default {
         value: new Date().getTime()
       }
     });
-    this.removeAutofillFromUI();
+    this.removeAutofillUIFromPage();
   }
 
-  removeAutofillFromUI() {
-    this._scannerCleanup && this._scannerCleanup();
+  async resetAutofillUI() {
+    this.removeAutofillUIFromPage(); // Start the setup process again
+
+    await this.refreshSettings();
+    await this.setupAutofill(); // TODO: Do we need this to be called?
+    // await this.setupSettingsPage({shouldLog: true})
+
+    this.uiController = this.createUIController();
+    await this.postInit();
+  }
+
+  removeAutofillUIFromPage() {
+    var _this$uiController, _this$_scannerCleanup;
+
+    (_this$uiController = this.uiController) === null || _this$uiController === void 0 ? void 0 : _this$uiController.destroy();
+    (_this$_scannerCleanup = this._scannerCleanup) === null || _this$_scannerCleanup === void 0 ? void 0 : _this$_scannerCleanup.call(this);
   }
 
   async isEnabled() {
@@ -4440,7 +4454,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
         {
           this._scannerCleanup = this.scanner.init();
           this.addLogoutListener(() => {
-            this.removeAutofillFromUI();
+            this.resetAutofillUI();
           });
           break;
         }
@@ -4537,15 +4551,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
       switch (message.type) {
         case 'ddgUserReady':
-          this.setupAutofill().then(() => {
-            this.refreshSettings().then(() => {
-              this.setupSettingsPage({
-                shouldLog: true
-              }).then(() => {
-                return this.postInit();
-              });
-            });
-          });
+          this.resetAutofillUI();
           break;
 
         case 'contextualAutofill':
@@ -4565,12 +4571,18 @@ class ExtensionInterface extends _InterfacePrototype.default {
   }
 
   addLogoutListener(handler) {
-    // Cleanup on logout events
-    chrome.runtime.onMessage.addListener((message, sender) => {
+    if (this._logoutListenerHandler) {
+      chrome.runtime.onMessage.removeListener(this._logoutListenerHandler);
+    } // Cleanup on logout events
+
+
+    this._logoutListenerHandler = (message, sender) => {
       if (sender.id === chrome.runtime.id && message.type === 'logout') {
         handler();
       }
-    });
+    };
+
+    chrome.runtime.onMessage.addListener(this._logoutListenerHandler);
   }
 
 }
@@ -10438,6 +10450,8 @@ class DefaultScanner {
 
 
   init() {
+    var _this = this;
+
     const delay = this.options.initialDelay; // if the delay is zero, (chrome/firefox etc) then use `requestIdleCallback`
 
     if (delay === 0) {
@@ -10447,17 +10461,25 @@ class DefaultScanner {
       setTimeout(() => this.scanAndObserve(), delay);
     }
 
-    return () => {
+    return function () {
+      let {
+        silent
+      } = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {
+        silent: false
+      };
       // remove Dax, listeners, timers, and observers
-      clearTimeout(this.debounceTimer);
-      this.mutObs.disconnect();
-      this.forms.forEach(form => {
+      clearTimeout(_this.debounceTimer);
+
+      _this.mutObs.disconnect();
+
+      _this.forms.forEach(form => {
         form.resetAllInputs();
         form.removeAllDecorations();
       });
-      this.forms.clear();
 
-      if (this.device.globalConfig.isDDGDomain) {
+      _this.forms.clear();
+
+      if (_this.device.globalConfig.isDDGDomain && !silent) {
         (0, _autofillUtils.notifyWebApp)({
           deviceSignedIn: {
             value: false
@@ -11523,6 +11545,14 @@ class HTMLTooltipUIController extends _UIController.UIController {
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
+  }
+
+  destroy() {
+    this.removeTooltip('destroy');
+
+    this._removeListeners();
+
+    window.removeEventListener('pointerdown', this, true);
   }
   /**
    * @param {import('./UIController').AttachArgs} args

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4444,6 +4444,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
     switch (this.getShowingTooltip()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
+          var _this$activeForm;
+
           this._scannerCleanup = this.scanner.init();
           this.addLogoutListener(() => {
             this.resetAutofillUI();
@@ -4456,6 +4458,13 @@ class ExtensionInterface extends _InterfacePrototype.default {
               });
             }
           });
+
+          if ((_this$activeForm = this.activeForm) !== null && _this$activeForm !== void 0 && _this$activeForm.activeInput) {
+            var _this$activeForm2;
+
+            this.attachTooltip(this.activeForm, (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.activeInput, null, 'postSignup');
+          }
+
           break;
         }
 
@@ -5076,7 +5085,7 @@ class InterfacePrototype {
    * @param {import("../Form/Form").Form} form
    * @param {HTMLInputElement} input
    * @param {{ x: number; y: number; } | null} click
-   * @param {'userInitiated' | 'autoprompt'} trigger
+   * @param {import('../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
    */
 
 
@@ -5085,7 +5094,7 @@ class InterfacePrototype {
 
     let trigger = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'userInitiated';
     // Avoid flashing tooltip from background tabs on macOS
-    if (document.visibilityState !== 'visible') return; // Only autoprompt on mobile devices
+    if (document.visibilityState !== 'visible' && trigger !== 'postSignup') return; // Only autoprompt on mobile devices
 
     if (trigger === 'autoprompt' && !this.globalConfig.isMobileApp) return; // Only fire autoprompt once
 
@@ -12170,7 +12179,7 @@ exports.UIController = void 0;
  * @property {{x: number, y: number}|null} click The click positioning
  * @property {TopContextData} topContextData
  * @property {import("../../DeviceInterface/InterfacePrototype").default} device
- * @property {'userInitiated' | 'autoprompt'} trigger
+ * @property {import('../../deviceApiCalls/__generated__/validators-ts').GetAutofillDataRequest['trigger']} trigger
  */
 
 /**

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4358,6 +4358,8 @@ var _HTMLTooltipUIController = require("../UI/controllers/HTMLTooltipUIControlle
 
 var _HTMLTooltip = require("../UI/HTMLTooltip.js");
 
+var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const TOOLTIP_TYPES = {
@@ -4400,17 +4402,15 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
   onIncontextSignupDismissed() {
     this.settings.setIncontextSignupDismissed(true);
-    chrome.runtime.sendMessage({
-      messageType: 'setIncontextSignupDismissedAt',
-      options: {
-        value: new Date().getTime()
-      }
-    });
+    this.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupDismissedAtCall({
+      value: new Date().getTime()
+    }));
     this.removeAutofillUIFromPage();
   }
 
   async resetAutofillUI() {
-    this.removeAutofillUIFromPage(); // Start the setup process again
+    this.removeAutofillUIFromPage(); // TOOD: can we use recategorizeAllInputs here?
+    // Start the setup process again
 
     await this.refreshSettings();
     await this.setupAutofill(); // TODO: Do we need this to be called?
@@ -4589,7 +4589,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
 exports.ExtensionInterface = ExtensionInterface;
 
-},{"../UI/HTMLTooltip.js":45,"../UI/controllers/HTMLTooltipUIController.js":46,"../autofill-utils.js":52,"./InterfacePrototype.js":19}],19:[function(require,module,exports){
+},{"../UI/HTMLTooltip.js":45,"../UI/controllers/HTMLTooltipUIController.js":46,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"./InterfacePrototype.js":19}],19:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11548,7 +11548,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   }
 
   destroy() {
-    this.removeTooltip('destroy');
+    this.removeTooltip();
 
     this._removeListeners();
 
@@ -12847,7 +12847,7 @@ exports.constants = constants;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.StoreFormDataCall = exports.SetSizeCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
+exports.StoreFormDataCall = exports.SetSizeCall = exports.SetIncontextSignupDismissedAtCall = exports.SendJSPixelCall = exports.SelectedDetailCall = exports.GetRuntimeConfigurationCall = exports.GetIncontextSignupDismissedAtCall = exports.GetAvailableInputTypesCall = exports.GetAutofillInitDataCall = exports.GetAutofillDataCall = exports.GetAutofillCredentialsCall = exports.CloseAutofillParentCall = exports.CheckCredentialsProviderStatusCall = exports.AskToUnlockProviderCall = void 0;
 
 var _validatorsZod = require("./validators.zod.js");
 
@@ -13071,8 +13071,44 @@ class SendJSPixelCall extends _deviceApi.DeviceApiCall {
   }
 
 }
+/**
+ * @extends {DeviceApiCall<setIncontextSignupDismissedAtSchema, any>} 
+ */
+
 
 exports.SendJSPixelCall = SendJSPixelCall;
+
+class SetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "setIncontextSignupDismissedAt");
+
+    _defineProperty(this, "paramsValidator", _validatorsZod.setIncontextSignupDismissedAtSchema);
+  }
+
+}
+/**
+ * @extends {DeviceApiCall<any, getIncontextSignupDismissedAtSchema>} 
+ */
+
+
+exports.SetIncontextSignupDismissedAtCall = SetIncontextSignupDismissedAtCall;
+
+class GetIncontextSignupDismissedAtCall extends _deviceApi.DeviceApiCall {
+  constructor() {
+    super(...arguments);
+
+    _defineProperty(this, "method", "getIncontextSignupDismissedAt");
+
+    _defineProperty(this, "id", "getIncontextSignupDismissedAt");
+
+    _defineProperty(this, "resultValidator", _validatorsZod.getIncontextSignupDismissedAtSchema);
+  }
+
+}
+
+exports.GetIncontextSignupDismissedAtCall = GetIncontextSignupDismissedAtCall;
 
 },{"../../../packages/device-api":6,"./validators.zod.js":57}],57:[function(require,module,exports){
 "use strict";
@@ -13080,7 +13116,7 @@ exports.SendJSPixelCall = SendJSPixelCall;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
+exports.userPreferencesSchema = exports.triggerContextSchema = exports.storeFormDataSchema = exports.setSizeParamsSchema = exports.setIncontextSignupDismissedAtSchema = exports.sendJSPixelParamsSchema = exports.selectedDetailParamsSchema = exports.runtimeConfigurationSchema = exports.providerStatusUpdatedSchema = exports.outgoingCredentialsSchema = exports.incontextSignupSettingsSchema = exports.getRuntimeConfigurationResponseSchema = exports.getIncontextSignupDismissedAtSchema = exports.getAvailableInputTypesResultSchema = exports.getAutofillInitDataResponseSchema = exports.getAutofillDataResponseSchema = exports.getAutofillDataRequestSchema = exports.getAutofillCredentialsResultSchema = exports.getAutofillCredentialsParamsSchema = exports.getAliasResultSchema = exports.getAliasParamsSchema = exports.genericErrorSchema = exports.credentialsSchema = exports.contentScopeSchema = exports.checkCredentialsProviderStatusResultSchema = exports.availableInputTypesSchema = exports.autofillSettingsSchema = exports.autofillFeatureTogglesSchema = exports.askToUnlockProviderResultSchema = void 0;
 const credentialsSchema = null;
 exports.credentialsSchema = credentialsSchema;
 const availableInputTypesSchema = null;
@@ -13107,6 +13143,8 @@ const getAutofillInitDataResponseSchema = null;
 exports.getAutofillInitDataResponseSchema = getAutofillInitDataResponseSchema;
 const getAvailableInputTypesResultSchema = null;
 exports.getAvailableInputTypesResultSchema = getAvailableInputTypesResultSchema;
+const getIncontextSignupDismissedAtSchema = null;
+exports.getIncontextSignupDismissedAtSchema = getIncontextSignupDismissedAtSchema;
 const contentScopeSchema = null;
 exports.contentScopeSchema = contentScopeSchema;
 const userPreferencesSchema = null;
@@ -13119,6 +13157,8 @@ const selectedDetailParamsSchema = null;
 exports.selectedDetailParamsSchema = selectedDetailParamsSchema;
 const sendJSPixelParamsSchema = null;
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;
+const setIncontextSignupDismissedAtSchema = null;
+exports.setIncontextSignupDismissedAtSchema = setIncontextSignupDismissedAtSchema;
 const setSizeParamsSchema = null;
 exports.setSizeParamsSchema = setSizeParamsSchema;
 const outgoingCredentialsSchema = null;
@@ -13436,11 +13476,19 @@ class ExtensionTransport extends _index.DeviceApiTransport {
 
   async send(deviceApiCall) {
     if (deviceApiCall instanceof _deviceApiCalls.GetRuntimeConfigurationCall) {
-      return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this.config));
+      return deviceApiCall.result(await extensionSpecificRuntimeConfiguration(this));
     }
 
     if (deviceApiCall instanceof _deviceApiCalls.GetAvailableInputTypesCall) {
       return deviceApiCall.result(await extensionSpecificGetAvailableInputTypes());
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.SetIncontextSignupDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificSetIncontextSignupDismissedAt(deviceApiCall.params.value));
+    }
+
+    if (deviceApiCall instanceof _deviceApiCalls.GetIncontextSignupDismissedAtCall) {
+      return deviceApiCall.result(await extensionSpecificGetIncontextSignupDismissedAt());
     } // TODO: unify all calls to use deviceApiCall.method instead of all these if blocks
 
 
@@ -13453,18 +13501,20 @@ class ExtensionTransport extends _index.DeviceApiTransport {
 
 }
 /**
- * @param {GlobalConfig} globalConfig
+ * @param {ExtensionTransport} deviceApi
  * @returns {Promise<ReturnType<GetRuntimeConfigurationCall['result']>>}
  */
 
 
 exports.ExtensionTransport = ExtensionTransport;
 
-async function extensionSpecificRuntimeConfiguration(globalConfig) {
+async function extensionSpecificRuntimeConfiguration(deviceApi) {
+  var _deviceApi$config;
+
   const contentScope = await getContentScopeConfig();
   const emailProtectionEnabled = (0, _autofillUtils.isAutofillEnabledFromProcessedConfig)(contentScope);
   const incontextSignupEnabled = (0, _autofillUtils.isIncontextSignupEnabledFromProcessedConfig)(contentScope);
-  const incontextSignupDismissedAt = await getIncontextSignupDismissedAt();
+  const incontextSignupDismissedAt = await deviceApi.send(new _deviceApiCalls.GetIncontextSignupDismissedAtCall(null));
   return {
     success: {
       // @ts-ignore
@@ -13482,13 +13532,13 @@ async function extensionSpecificRuntimeConfiguration(globalConfig) {
           },
           incontextSignup: {
             settings: {
-              dismissedAt: incontextSignupDismissedAt
+              dismissedAt: incontextSignupDismissedAt.success.value
             }
           }
         }
       },
       // @ts-ignore
-      userUnprotectedDomains: globalConfig === null || globalConfig === void 0 ? void 0 : globalConfig.userUnprotectedDomains
+      userUnprotectedDomains: (_deviceApi$config = deviceApi.config) === null || _deviceApi$config === void 0 ? void 0 : _deviceApi$config.userUnprotectedDomains
     }
   };
 }
@@ -13533,12 +13583,25 @@ async function extensionSpecificSendPixel(pixelName) {
   });
 }
 
-async function getIncontextSignupDismissedAt() {
+async function extensionSpecificGetIncontextSignupDismissedAt() {
   return new Promise(resolve => {
     chrome.runtime.sendMessage({
       messageType: 'getIncontextSignupDismissedAt'
     }, response => {
       resolve(response);
+    });
+  });
+}
+
+async function extensionSpecificSetIncontextSignupDismissedAt(value) {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage({
+      messageType: 'setIncontextSignupDismissedAt',
+      options: {
+        value
+      }
+    }, () => {
+      resolve(true);
     });
   });
 }


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/0/1203490723369676/f

## Description
1. Persist dismissal — only show if the user hasn't clicked "Not now"
2. Make sure the notice disappears after login (without needing refresh) and appears after log out (assuming not dismissed previously)

## Steps to test

<details>
  <summary>Apply this diff to the extension</summary>

```diff
diff --git a/shared/js/background/email-utils.es6.js b/shared/js/background/email-utils.es6.js
index 54eb78e1..c52378f6 100644
--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -121,6 +121,13 @@ const fireAddressUsedPixel = (pixel) => {
     updateSetting('lastAddressUsedAt', currentDate())
 }
 
+const fireIncontextSignupPixel = (pixel) => {
+    const browserName = utils.getBrowserName() ?? 'unknown'
+    if (!pixelsEnabled) return
+
+    sendPixelRequest(getFullPixelName(pixel, browserName))
+}
+
 /**
  * Config type definition
  * @typedef {Object} FirePixelOptions
@@ -140,6 +147,18 @@ export const sendJSPixel = (options) => {
     case 'autofill_personal_address':
         fireAddressUsedPixel('email_filled_main_extension')
         break
+    case 'incontext_show':
+        fireIncontextSignupPixel('incontext_show_extension')
+        break
+    case 'incontext_get_email_protection':
+        fireIncontextSignupPixel('incontext_get_email_protection_extension')
+        break
+    case 'incontext_dismiss_persisted':
+        fireIncontextSignupPixel('incontext_dismiss_persisted_extension')
+        break
+    case 'incontext_dismiss_initial':
+        fireIncontextSignupPixel('incontext_dismiss_initial_extension')
+        break
     default:
         console.error('Unknown pixel name', pixelName)
     }
diff --git a/shared/js/background/message-handlers.js b/shared/js/background/message-handlers.js
index 7719a298..556cf9af 100644
--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -301,6 +301,22 @@ export function getEmailProtectionCapabilities (_, sender) {
     }
 }
 
+export function getIncontextSignupDismissedAt() {
+    // setIncontextSignupInitiallyDismissedAt({ value: undefined })
+    // setIncontextSignupPermanentlyDismissedAt({ value: undefined })
+    const initiallyDismissedAt = settings.getSetting('incontextSignupInitiallyDismissedAt')
+    const permanentlyDismissedAt = settings.getSetting('incontextSignupPermanentlyDismissedAt')
+    return { success: { initiallyDismissedAt, permanentlyDismissedAt } }
+}
+
+export function setIncontextSignupInitiallyDismissedAt ({ value }) {
+    settings.updateSetting('incontextSignupInitiallyDismissedAt', value)
+}
+
+export function setIncontextSignupPermanentlyDismissedAt ({ value }) {
+    settings.updateSetting('incontextSignupPermanentlyDismissedAt', value)
+}
+
 // Get user data to be used by the email web app settings page. This includes
 // username, last alias, and a token for generating additional aliases.
 export async function getUserData (_, sender) {
diff --git a/shared/js/background/utils.es6.js b/shared/js/background/utils.es6.js
index e65c53f7..31cbf005 100644
--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -237,7 +237,7 @@ export function getEnabledFeaturesAboutBlank (url) {
 
 export function getEnabledFeatures (url) {
     if (!tdsStorage.config.features) return []
-    const enabledFeatures = []
+    const enabledFeatures = ['incontextSignup']
     for (const feature in tdsStorage.config.features) {
         if (isFeatureEnabled(feature) && brokenListIndex(url, tdsStorage.config.features[feature].exceptions || []) === -1) {
             enabledFeatures.push(feature)
```

</details>

1. Go to https://duckduckgo.com/newsletter while logged out -- the notice should show
2. Sign in to Email Protection -- the notice should be replaced with the expected Email Protection autofill
3. Sign out of Email Protection -- Email Protection autofill should be replaced with the notice
4. Click "Not now" -- this should hide the notice completely
5. Refresh the page -- this notice should not show


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203759246039568