### PR TITLE
More minor fixes

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -9855,7 +9855,12 @@ class Form {
 
   categorizeInputs() {
     const selector = this.matching.cssSelector('FORM_INPUTS_SELECTOR');
-    this.form.querySelectorAll(selector).forEach(input => this.addInput(input));
+
+    if (this.form.matches(selector)) {
+      this.addInput(this.form);
+    } else {
+      this.form.querySelectorAll(selector).forEach(input => this.addInput(input));
+    }
   }
 
   get submitButtons() {
@@ -13004,7 +13009,7 @@ class Matching {
       return false;
     }
 
-    const hasCCSelectorChild = formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
+    const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
 
     if (hasCCSelectorChild) return true; // Read form attributes to find a signal
 
@@ -13361,7 +13366,7 @@ const email = "\ninput:not([type])[name*=email i]:not([placeholder*=search i]):n
 const GENERIC_TEXT_FIELD = "\ninput:not([type=button]):not([type=checkbox]):not([type=color]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=file]):not([type=hidden]):not([type=month]):not([type=number]):not([type=radio]):not([type=range]):not([type=reset]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week])";
 const password = "input[type=password]:not([autocomplete*=cc]):not([autocomplete=one-time-code]):not([name*=answer i]):not([name*=mfa i]):not([name*=tin i])";
 const cardName = "\ninput[autocomplete=\"cc-name\"],\ninput[autocomplete=\"ccname\"],\ninput[name=\"ccname\"],\ninput[name=\"cc-name\"],\ninput[name=\"ppw-accountHolderName\"],\ninput[id*=cardname i],\ninput[id*=card-name i],\ninput[id*=card_name i]";
-const cardNumber = "\ninput[autocomplete=\"cc-number\"],\ninput[autocomplete=\"ccnumber\"],\ninput[autocomplete=\"cardnumber\"],\ninput[autocomplete=\"card-number\"],\ninput[name=\"ccnumber\"],\ninput[name=\"cc-number\"],\ninput[name*=card i][name*=number i],\ninput[id*=cardnumber i],\ninput[id*=card-number i],\ninput[id*=card_number i]";
+const cardNumber = "\ninput[autocomplete=\"cc-number\"],\ninput[autocomplete=\"ccnumber\"],\ninput[autocomplete=\"cardnumber\"],\ninput[autocomplete=\"card-number\"],\ninput[name=\"ccnumber\"],\ninput[name=\"cc-number\"],\ninput[name*=card i][name*=number i],\ninput[name*=cardnumber i],\ninput[id*=cardnumber i],\ninput[id*=card-number i],\ninput[id*=card_number i]";
 const cardSecurityCode = "\ninput[autocomplete=\"cc-csc\"],\ninput[autocomplete=\"csc\"],\ninput[autocomplete=\"cc-cvc\"],\ninput[autocomplete=\"cvc\"],\ninput[name=\"cvc\"],\ninput[name=\"cc-cvc\"],\ninput[name=\"cc-csc\"],\ninput[name=\"csc\"],\ninput[name*=security i][name*=code i]";
 const expirationMonth = "\n[autocomplete=\"cc-exp-month\"],\n[name=\"ccmonth\"],\n[name=\"ppw-expirationDate_month\"],\n[name=cardExpiryMonth],\n[name*=ExpDate_Month i],\n[name*=expiration i][name*=month i],\n[id*=expiration i][id*=month i]";
 const expirationYear = "\n[autocomplete=\"cc-exp-year\"],\n[name=\"ccyear\"],\n[name=\"ppw-expirationDate_year\"],\n[name=cardExpiryYear],\n[name*=ExpDate_Year i],\n[name*=expiration i][name*=year i],\n[id*=expiration i][id*=year i]";
@@ -14055,7 +14060,7 @@ class DefaultScanner {
 
     let element = input; // traverse the DOM to search for related inputs
 
-    while (element.parentElement && element.parentElement !== document.body) {
+    while (element.parentElement && element.parentElement !== document.documentElement) {
       var _element$parentElemen;
 
       // If parent includes a form return the current element to avoid overlapping forms
@@ -15895,7 +15900,9 @@ const fireEventsOnSelect = el => {
 const setValueForSelect = (el, val) => {
   const subtype = (0, _matching.getInputSubtype)(el);
   const isMonth = subtype.includes('Month');
-  const isZeroBasedNumber = isMonth && el.options[0].value === '0' && el.options.length === 12; // Loop first through all values because they tend to be more precise
+  const isZeroBasedNumber = isMonth && el.options[0].value === '0' && el.options.length === 12;
+  const stringVal = String(val);
+  const numberVal = Number(val); // Loop first through all values because they tend to be more precise
 
   for (const option of el.options) {
     // If values for months are zero-based (Jan === 0), add one to match our data type
@@ -15907,7 +15914,7 @@ const setValueForSelect = (el, val) => {
     // TODO: implement alternative versions of values (abbreviations for States/Provinces or variations like USA, US, United States, etc.)
 
 
-    if (value === String(val)) {
+    if (value === stringVal || Number(value) === numberVal) {
       if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);
@@ -15916,7 +15923,7 @@ const setValueForSelect = (el, val) => {
   }
 
   for (const option of el.options) {
-    if (option.innerText === String(val)) {
+    if (option.innerText === stringVal || Number(option.innerText) === numberVal) {
       if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -6586,6 +6586,9 @@ module.exports={
   "claro.com.br": {
     "password-rules": "minlength: 8; required: lower; allowed: upper, digit, [-!@#$%&*_+=<>];"
   },
+  "classmates.com": {
+    "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit, [!@#$%^&*];"
+  },
   "clien.net": {
     "password-rules": "minlength: 5; required: lower, upper; required: digit;"
   },
@@ -6898,9 +6901,6 @@ module.exports={
   "microsoft.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
   },
-  "minecraft.com": {
-    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: ascii-printable;"
-  },
   "mintmobile.com": {
     "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
   },
@@ -6924,6 +6924,9 @@ module.exports={
   },
   "myhealthrecord.com": {
     "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
+  },
+  "mysedgwick.com": {
+    "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#%^&+=!]; allowed: [-~_$.,;]"
   },
   "mysubaru.com": {
     "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6179,7 +6179,12 @@ class Form {
 
   categorizeInputs() {
     const selector = this.matching.cssSelector('FORM_INPUTS_SELECTOR');
-    this.form.querySelectorAll(selector).forEach(input => this.addInput(input));
+
+    if (this.form.matches(selector)) {
+      this.addInput(this.form);
+    } else {
+      this.form.querySelectorAll(selector).forEach(input => this.addInput(input));
+    }
   }
 
   get submitButtons() {
@@ -9328,7 +9333,7 @@ class Matching {
       return false;
     }
 
-    const hasCCSelectorChild = formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
+    const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
 
     if (hasCCSelectorChild) return true; // Read form attributes to find a signal
 
@@ -9685,7 +9690,7 @@ const email = "\ninput:not([type])[name*=email i]:not([placeholder*=search i]):n
 const GENERIC_TEXT_FIELD = "\ninput:not([type=button]):not([type=checkbox]):not([type=color]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=file]):not([type=hidden]):not([type=month]):not([type=number]):not([type=radio]):not([type=range]):not([type=reset]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week])";
 const password = "input[type=password]:not([autocomplete*=cc]):not([autocomplete=one-time-code]):not([name*=answer i]):not([name*=mfa i]):not([name*=tin i])";
 const cardName = "\ninput[autocomplete=\"cc-name\"],\ninput[autocomplete=\"ccname\"],\ninput[name=\"ccname\"],\ninput[name=\"cc-name\"],\ninput[name=\"ppw-accountHolderName\"],\ninput[id*=cardname i],\ninput[id*=card-name i],\ninput[id*=card_name i]";
-const cardNumber = "\ninput[autocomplete=\"cc-number\"],\ninput[autocomplete=\"ccnumber\"],\ninput[autocomplete=\"cardnumber\"],\ninput[autocomplete=\"card-number\"],\ninput[name=\"ccnumber\"],\ninput[name=\"cc-number\"],\ninput[name*=card i][name*=number i],\ninput[id*=cardnumber i],\ninput[id*=card-number i],\ninput[id*=card_number i]";
+const cardNumber = "\ninput[autocomplete=\"cc-number\"],\ninput[autocomplete=\"ccnumber\"],\ninput[autocomplete=\"cardnumber\"],\ninput[autocomplete=\"card-number\"],\ninput[name=\"ccnumber\"],\ninput[name=\"cc-number\"],\ninput[name*=card i][name*=number i],\ninput[name*=cardnumber i],\ninput[id*=cardnumber i],\ninput[id*=card-number i],\ninput[id*=card_number i]";
 const cardSecurityCode = "\ninput[autocomplete=\"cc-csc\"],\ninput[autocomplete=\"csc\"],\ninput[autocomplete=\"cc-cvc\"],\ninput[autocomplete=\"cvc\"],\ninput[name=\"cvc\"],\ninput[name=\"cc-cvc\"],\ninput[name=\"cc-csc\"],\ninput[name=\"csc\"],\ninput[name*=security i][name*=code i]";
 const expirationMonth = "\n[autocomplete=\"cc-exp-month\"],\n[name=\"ccmonth\"],\n[name=\"ppw-expirationDate_month\"],\n[name=cardExpiryMonth],\n[name*=ExpDate_Month i],\n[name*=expiration i][name*=month i],\n[id*=expiration i][id*=month i]";
 const expirationYear = "\n[autocomplete=\"cc-exp-year\"],\n[name=\"ccyear\"],\n[name=\"ppw-expirationDate_year\"],\n[name=cardExpiryYear],\n[name*=ExpDate_Year i],\n[name*=expiration i][name*=year i],\n[id*=expiration i][id*=year i]";
@@ -10379,7 +10384,7 @@ class DefaultScanner {
 
     let element = input; // traverse the DOM to search for related inputs
 
-    while (element.parentElement && element.parentElement !== document.body) {
+    while (element.parentElement && element.parentElement !== document.documentElement) {
       var _element$parentElemen;
 
       // If parent includes a form return the current element to avoid overlapping forms
@@ -12219,7 +12224,9 @@ const fireEventsOnSelect = el => {
 const setValueForSelect = (el, val) => {
   const subtype = (0, _matching.getInputSubtype)(el);
   const isMonth = subtype.includes('Month');
-  const isZeroBasedNumber = isMonth && el.options[0].value === '0' && el.options.length === 12; // Loop first through all values because they tend to be more precise
+  const isZeroBasedNumber = isMonth && el.options[0].value === '0' && el.options.length === 12;
+  const stringVal = String(val);
+  const numberVal = Number(val); // Loop first through all values because they tend to be more precise
 
   for (const option of el.options) {
     // If values for months are zero-based (Jan === 0), add one to match our data type
@@ -12231,7 +12238,7 @@ const setValueForSelect = (el, val) => {
     // TODO: implement alternative versions of values (abbreviations for States/Provinces or variations like USA, US, United States, etc.)
 
 
-    if (value === String(val)) {
+    if (value === stringVal || Number(value) === numberVal) {
       if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);
@@ -12240,7 +12247,7 @@ const setValueForSelect = (el, val) => {
   }
 
   for (const option of el.options) {
-    if (option.innerText === String(val)) {
+    if (option.innerText === stringVal || Number(option.innerText) === numberVal) {
       if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -2910,6 +2910,9 @@ module.exports={
   "claro.com.br": {
     "password-rules": "minlength: 8; required: lower; allowed: upper, digit, [-!@#$%&*_+=<>];"
   },
+  "classmates.com": {
+    "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit, [!@#$%^&*];"
+  },
   "clien.net": {
     "password-rules": "minlength: 5; required: lower, upper; required: digit;"
   },
@@ -3222,9 +3225,6 @@ module.exports={
   "microsoft.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
   },
-  "minecraft.com": {
-    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: ascii-printable;"
-  },
   "mintmobile.com": {
     "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
   },
@@ -3248,6 +3248,9 @@ module.exports={
   },
   "myhealthrecord.com": {
     "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
+  },
+  "mysedgwick.com": {
+    "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#%^&+=!]; allowed: [-~_$.,;]"
   },
   "mysubaru.com": {
     "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/packages/password/rules.json
+++ b/packages/password/rules.json
@@ -170,6 +170,9 @@
   "claro.com.br": {
     "password-rules": "minlength: 8; required: lower; allowed: upper, digit, [-!@#$%&*_+=<>];"
   },
+  "classmates.com": {
+    "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit, [!@#$%^&*];"
+  },
   "clien.net": {
     "password-rules": "minlength: 5; required: lower, upper; required: digit;"
   },
@@ -482,9 +485,6 @@
   "microsoft.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
   },
-  "minecraft.com": {
-    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: ascii-printable;"
-  },
   "mintmobile.com": {
     "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
   },
@@ -508,6 +508,9 @@
   },
   "myhealthrecord.com": {
     "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
+  },
+  "mysedgwick.com": {
+    "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#%^&+=!]; allowed: [-~_$.,;]"
   },
   "mysubaru.com": {
     "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -265,7 +265,11 @@ class Form {
 
     categorizeInputs () {
         const selector = this.matching.cssSelector('FORM_INPUTS_SELECTOR')
-        this.form.querySelectorAll(selector).forEach(input => this.addInput(input))
+        if (this.form.matches(selector)) {
+            this.addInput(this.form)
+        } else {
+            this.form.querySelectorAll(selector).forEach(input => this.addInput(input))
+        }
     }
 
     get submitButtons () {

--- a/src/Form/matching.js
+++ b/src/Form/matching.js
@@ -485,7 +485,7 @@ class Matching {
         if (!ccFieldSelector) {
             return false
         }
-        const hasCCSelectorChild = formEl.querySelector(ccFieldSelector)
+        const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector)
         // If the form contains one of the specific selectors, we have high confidence
         if (hasCCSelectorChild) return true
 

--- a/src/Form/selectors-css.js
+++ b/src/Form/selectors-css.js
@@ -49,6 +49,7 @@ input[autocomplete="card-number"],
 input[name="ccnumber"],
 input[name="cc-number"],
 input[name*=card i][name*=number i],
+input[name*=cardnumber i],
 input[id*=cardnumber i],
 input[id*=card-number i],
 input[id*=card_number i]`

--- a/src/Form/test-cases/index.js
+++ b/src/Form/test-cases/index.js
@@ -253,5 +253,6 @@ export default [
     // Issues with buttons here is due to lots of hidden forms and weird markup, they don't affect the actual UX
     { html: 'boardgamearena_signup.html', expectedFailures: ['birthday'], expectedSubmitFalsePositives: 2, expectedSubmitFalseNegatives: 5 },
     { html: 'eventbrite_checkout-signup.html' },
-    { html: 'eventbrite_fake-signup.html' }
+    { html: 'eventbrite_fake-signup.html' },
+    { html: 'ryanair_cc-card-name.html' }
 ]

--- a/src/Form/test-cases/ryanair_cc-card-name.html
+++ b/src/Form/test-cases/ryanair_cc-card-name.html
@@ -1,0 +1,13 @@
+<!-- https://pi.ryanairpi.com/mt/en?platform=desktop&basketId=277542e9-b913-4843-8682-cda6eb8d8712 -->
+<!-- This is loaded in an iframe and it's the sole content of that iframe -->
+<app-root _nghost-flv-c18="" ng-version="13.3.11">
+    <div _ngcontent-flv-c18="" class="credit-card-iframe ng-untouched ng-pristine ng-invalid">
+        <ry-input-d _ngcontent-flv-c18="" name="cardNumber" pattern="[0-9 ]*" type="tel" formcontrolname="cardNumber"
+                    _nghost-flv-c15="" class="ng-untouched ng-pristine ng-invalid">
+            <div _ngcontent-flv-c15="" class="_input-container" data-ref="ry-input-label">
+                <div _ngcontent-flv-c15="" class="_icon"></div>
+                <input _ngcontent-flv-c15="" class="b2 date-placeholder" type="tel" name="cardNumber" autocomplete=""
+                       min="undefined" max="undefined" pattern="[0-9 ]*" data-hj-suppress="true" data-manual-scoring="cardNumber"></div>
+            <label _ngcontent-flv-c15="" class="b2">Card number *</label><!----><!----><!----><span
+                _ngcontent-flv-c15="" class="_helper b2"></span></ry-input-d><!----><!----></div>
+</app-root>

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -133,7 +133,7 @@ class DefaultScanner {
 
         let element = input
         // traverse the DOM to search for related inputs
-        while (element.parentElement && element.parentElement !== document.body) {
+        while (element.parentElement && element.parentElement !== document.documentElement) {
             // If parent includes a form return the current element to avoid overlapping forms
             if (element.parentElement?.querySelector('form')) {
                 return element

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -126,6 +126,8 @@ const setValueForSelect = (el, val) => {
     const isMonth = subtype.includes('Month')
     const isZeroBasedNumber = isMonth &&
         el.options[0].value === '0' && el.options.length === 12
+    const stringVal = String(val)
+    const numberVal = Number(val)
 
     // Loop first through all values because they tend to be more precise
     for (const option of el.options) {
@@ -136,7 +138,7 @@ const setValueForSelect = (el, val) => {
         }
         // TODO: try to match localised month names
         // TODO: implement alternative versions of values (abbreviations for States/Provinces or variations like USA, US, United States, etc.)
-        if (value === String(val)) {
+        if (value === stringVal || Number(value) === numberVal) {
             if (option.selected) return false
             option.selected = true
             fireEventsOnSelect(el)
@@ -145,7 +147,7 @@ const setValueForSelect = (el, val) => {
     }
 
     for (const option of el.options) {
-        if (option.innerText === String(val)) {
+        if (option.innerText === stringVal || Number(option.innerText) === numberVal) {
             if (option.selected) return false
             option.selected = true
             fireEventsOnSelect(el)

--- a/src/autofill-utils.test.js
+++ b/src/autofill-utils.test.js
@@ -46,6 +46,8 @@ const renderInputWithSelect = () => {
     <select name="country">
         <option value="GB">Great Britain</option>
         <option value="US">USA</option>
+        <option value="02">February</option>
+        <option value="march">03</option>
     </select>
     `
 
@@ -58,23 +60,40 @@ const renderInputWithSelect = () => {
     select.addEventListener('click', () => events.push('click'))
     select.addEventListener('change', () => events.push('change'))
 
+    // Needed to bypass the fact that jsdom has innerText = undefined
+    for (const option of select.options) {
+        option.innerText = option.textContent || ''
+    }
+
     return {select, events}
 }
 
 describe('value setting on selects', function () {
+    const eventsToFireOnSelect = [
+        'mousedown',
+        'mouseup',
+        'click',
+        'change',
+        'mousedown',
+        'mouseup',
+        'click',
+        'change'
+    ]
+
     it('should set value & dispatch events when value has changed', () => {
         const {select, events} = renderInputWithSelect()
         setValue(select, 'US')
-        expect(events).toStrictEqual([
-            'mousedown',
-            'mouseup',
-            'click',
-            'change',
-            'mousedown',
-            'mouseup',
-            'click',
-            'change'
-        ])
+        expect(events).toStrictEqual(eventsToFireOnSelect)
+    })
+    it('should set value when the value is expressed with a leading 0 like 02 for February', () => {
+        const {select, events} = renderInputWithSelect()
+        setValue(select, '2')
+        expect(select.value).toBe('02')
+        expect(events).toStrictEqual(eventsToFireOnSelect)
+
+        setValue(select, '3')
+        expect(select.value).toBe('march')
+        expect(events).toStrictEqual([...eventsToFireOnSelect, ...eventsToFireOnSelect])
     })
     it('should not fire any events when the value has not changed', () => {
         const {select, events} = renderInputWithSelect()

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -9855,7 +9855,12 @@ class Form {
 
   categorizeInputs() {
     const selector = this.matching.cssSelector('FORM_INPUTS_SELECTOR');
-    this.form.querySelectorAll(selector).forEach(input => this.addInput(input));
+
+    if (this.form.matches(selector)) {
+      this.addInput(this.form);
+    } else {
+      this.form.querySelectorAll(selector).forEach(input => this.addInput(input));
+    }
   }
 
   get submitButtons() {
@@ -13004,7 +13009,7 @@ class Matching {
       return false;
     }
 
-    const hasCCSelectorChild = formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
+    const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
 
     if (hasCCSelectorChild) return true; // Read form attributes to find a signal
 
@@ -13361,7 +13366,7 @@ const email = "\ninput:not([type])[name*=email i]:not([placeholder*=search i]):n
 const GENERIC_TEXT_FIELD = "\ninput:not([type=button]):not([type=checkbox]):not([type=color]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=file]):not([type=hidden]):not([type=month]):not([type=number]):not([type=radio]):not([type=range]):not([type=reset]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week])";
 const password = "input[type=password]:not([autocomplete*=cc]):not([autocomplete=one-time-code]):not([name*=answer i]):not([name*=mfa i]):not([name*=tin i])";
 const cardName = "\ninput[autocomplete=\"cc-name\"],\ninput[autocomplete=\"ccname\"],\ninput[name=\"ccname\"],\ninput[name=\"cc-name\"],\ninput[name=\"ppw-accountHolderName\"],\ninput[id*=cardname i],\ninput[id*=card-name i],\ninput[id*=card_name i]";
-const cardNumber = "\ninput[autocomplete=\"cc-number\"],\ninput[autocomplete=\"ccnumber\"],\ninput[autocomplete=\"cardnumber\"],\ninput[autocomplete=\"card-number\"],\ninput[name=\"ccnumber\"],\ninput[name=\"cc-number\"],\ninput[name*=card i][name*=number i],\ninput[id*=cardnumber i],\ninput[id*=card-number i],\ninput[id*=card_number i]";
+const cardNumber = "\ninput[autocomplete=\"cc-number\"],\ninput[autocomplete=\"ccnumber\"],\ninput[autocomplete=\"cardnumber\"],\ninput[autocomplete=\"card-number\"],\ninput[name=\"ccnumber\"],\ninput[name=\"cc-number\"],\ninput[name*=card i][name*=number i],\ninput[name*=cardnumber i],\ninput[id*=cardnumber i],\ninput[id*=card-number i],\ninput[id*=card_number i]";
 const cardSecurityCode = "\ninput[autocomplete=\"cc-csc\"],\ninput[autocomplete=\"csc\"],\ninput[autocomplete=\"cc-cvc\"],\ninput[autocomplete=\"cvc\"],\ninput[name=\"cvc\"],\ninput[name=\"cc-cvc\"],\ninput[name=\"cc-csc\"],\ninput[name=\"csc\"],\ninput[name*=security i][name*=code i]";
 const expirationMonth = "\n[autocomplete=\"cc-exp-month\"],\n[name=\"ccmonth\"],\n[name=\"ppw-expirationDate_month\"],\n[name=cardExpiryMonth],\n[name*=ExpDate_Month i],\n[name*=expiration i][name*=month i],\n[id*=expiration i][id*=month i]";
 const expirationYear = "\n[autocomplete=\"cc-exp-year\"],\n[name=\"ccyear\"],\n[name=\"ppw-expirationDate_year\"],\n[name=cardExpiryYear],\n[name*=ExpDate_Year i],\n[name*=expiration i][name*=year i],\n[id*=expiration i][id*=year i]";
@@ -14055,7 +14060,7 @@ class DefaultScanner {
 
     let element = input; // traverse the DOM to search for related inputs
 
-    while (element.parentElement && element.parentElement !== document.body) {
+    while (element.parentElement && element.parentElement !== document.documentElement) {
       var _element$parentElemen;
 
       // If parent includes a form return the current element to avoid overlapping forms
@@ -15895,7 +15900,9 @@ const fireEventsOnSelect = el => {
 const setValueForSelect = (el, val) => {
   const subtype = (0, _matching.getInputSubtype)(el);
   const isMonth = subtype.includes('Month');
-  const isZeroBasedNumber = isMonth && el.options[0].value === '0' && el.options.length === 12; // Loop first through all values because they tend to be more precise
+  const isZeroBasedNumber = isMonth && el.options[0].value === '0' && el.options.length === 12;
+  const stringVal = String(val);
+  const numberVal = Number(val); // Loop first through all values because they tend to be more precise
 
   for (const option of el.options) {
     // If values for months are zero-based (Jan === 0), add one to match our data type
@@ -15907,7 +15914,7 @@ const setValueForSelect = (el, val) => {
     // TODO: implement alternative versions of values (abbreviations for States/Provinces or variations like USA, US, United States, etc.)
 
 
-    if (value === String(val)) {
+    if (value === stringVal || Number(value) === numberVal) {
       if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);
@@ -15916,7 +15923,7 @@ const setValueForSelect = (el, val) => {
   }
 
   for (const option of el.options) {
-    if (option.innerText === String(val)) {
+    if (option.innerText === stringVal || Number(option.innerText) === numberVal) {
       if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -6586,6 +6586,9 @@ module.exports={
   "claro.com.br": {
     "password-rules": "minlength: 8; required: lower; allowed: upper, digit, [-!@#$%&*_+=<>];"
   },
+  "classmates.com": {
+    "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit, [!@#$%^&*];"
+  },
   "clien.net": {
     "password-rules": "minlength: 5; required: lower, upper; required: digit;"
   },
@@ -6898,9 +6901,6 @@ module.exports={
   "microsoft.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
   },
-  "minecraft.com": {
-    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: ascii-printable;"
-  },
   "mintmobile.com": {
     "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
   },
@@ -6924,6 +6924,9 @@ module.exports={
   },
   "myhealthrecord.com": {
     "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
+  },
+  "mysedgwick.com": {
+    "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#%^&+=!]; allowed: [-~_$.,;]"
   },
   "mysubaru.com": {
     "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6179,7 +6179,12 @@ class Form {
 
   categorizeInputs() {
     const selector = this.matching.cssSelector('FORM_INPUTS_SELECTOR');
-    this.form.querySelectorAll(selector).forEach(input => this.addInput(input));
+
+    if (this.form.matches(selector)) {
+      this.addInput(this.form);
+    } else {
+      this.form.querySelectorAll(selector).forEach(input => this.addInput(input));
+    }
   }
 
   get submitButtons() {
@@ -9328,7 +9333,7 @@ class Matching {
       return false;
     }
 
-    const hasCCSelectorChild = formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
+    const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
 
     if (hasCCSelectorChild) return true; // Read form attributes to find a signal
 
@@ -9685,7 +9690,7 @@ const email = "\ninput:not([type])[name*=email i]:not([placeholder*=search i]):n
 const GENERIC_TEXT_FIELD = "\ninput:not([type=button]):not([type=checkbox]):not([type=color]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=file]):not([type=hidden]):not([type=month]):not([type=number]):not([type=radio]):not([type=range]):not([type=reset]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week])";
 const password = "input[type=password]:not([autocomplete*=cc]):not([autocomplete=one-time-code]):not([name*=answer i]):not([name*=mfa i]):not([name*=tin i])";
 const cardName = "\ninput[autocomplete=\"cc-name\"],\ninput[autocomplete=\"ccname\"],\ninput[name=\"ccname\"],\ninput[name=\"cc-name\"],\ninput[name=\"ppw-accountHolderName\"],\ninput[id*=cardname i],\ninput[id*=card-name i],\ninput[id*=card_name i]";
-const cardNumber = "\ninput[autocomplete=\"cc-number\"],\ninput[autocomplete=\"ccnumber\"],\ninput[autocomplete=\"cardnumber\"],\ninput[autocomplete=\"card-number\"],\ninput[name=\"ccnumber\"],\ninput[name=\"cc-number\"],\ninput[name*=card i][name*=number i],\ninput[id*=cardnumber i],\ninput[id*=card-number i],\ninput[id*=card_number i]";
+const cardNumber = "\ninput[autocomplete=\"cc-number\"],\ninput[autocomplete=\"ccnumber\"],\ninput[autocomplete=\"cardnumber\"],\ninput[autocomplete=\"card-number\"],\ninput[name=\"ccnumber\"],\ninput[name=\"cc-number\"],\ninput[name*=card i][name*=number i],\ninput[name*=cardnumber i],\ninput[id*=cardnumber i],\ninput[id*=card-number i],\ninput[id*=card_number i]";
 const cardSecurityCode = "\ninput[autocomplete=\"cc-csc\"],\ninput[autocomplete=\"csc\"],\ninput[autocomplete=\"cc-cvc\"],\ninput[autocomplete=\"cvc\"],\ninput[name=\"cvc\"],\ninput[name=\"cc-cvc\"],\ninput[name=\"cc-csc\"],\ninput[name=\"csc\"],\ninput[name*=security i][name*=code i]";
 const expirationMonth = "\n[autocomplete=\"cc-exp-month\"],\n[name=\"ccmonth\"],\n[name=\"ppw-expirationDate_month\"],\n[name=cardExpiryMonth],\n[name*=ExpDate_Month i],\n[name*=expiration i][name*=month i],\n[id*=expiration i][id*=month i]";
 const expirationYear = "\n[autocomplete=\"cc-exp-year\"],\n[name=\"ccyear\"],\n[name=\"ppw-expirationDate_year\"],\n[name=cardExpiryYear],\n[name*=ExpDate_Year i],\n[name*=expiration i][name*=year i],\n[id*=expiration i][id*=year i]";
@@ -10379,7 +10384,7 @@ class DefaultScanner {
 
     let element = input; // traverse the DOM to search for related inputs
 
-    while (element.parentElement && element.parentElement !== document.body) {
+    while (element.parentElement && element.parentElement !== document.documentElement) {
       var _element$parentElemen;
 
       // If parent includes a form return the current element to avoid overlapping forms
@@ -12219,7 +12224,9 @@ const fireEventsOnSelect = el => {
 const setValueForSelect = (el, val) => {
   const subtype = (0, _matching.getInputSubtype)(el);
   const isMonth = subtype.includes('Month');
-  const isZeroBasedNumber = isMonth && el.options[0].value === '0' && el.options.length === 12; // Loop first through all values because they tend to be more precise
+  const isZeroBasedNumber = isMonth && el.options[0].value === '0' && el.options.length === 12;
+  const stringVal = String(val);
+  const numberVal = Number(val); // Loop first through all values because they tend to be more precise
 
   for (const option of el.options) {
     // If values for months are zero-based (Jan === 0), add one to match our data type
@@ -12231,7 +12238,7 @@ const setValueForSelect = (el, val) => {
     // TODO: implement alternative versions of values (abbreviations for States/Provinces or variations like USA, US, United States, etc.)
 
 
-    if (value === String(val)) {
+    if (value === stringVal || Number(value) === numberVal) {
       if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);
@@ -12240,7 +12247,7 @@ const setValueForSelect = (el, val) => {
   }
 
   for (const option of el.options) {
-    if (option.innerText === String(val)) {
+    if (option.innerText === stringVal || Number(option.innerText) === numberVal) {
       if (option.selected) return false;
       option.selected = true;
       fireEventsOnSelect(el);

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -2910,6 +2910,9 @@ module.exports={
   "claro.com.br": {
     "password-rules": "minlength: 8; required: lower; allowed: upper, digit, [-!@#$%&*_+=<>];"
   },
+  "classmates.com": {
+    "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit, [!@#$%^&*];"
+  },
   "clien.net": {
     "password-rules": "minlength: 5; required: lower, upper; required: digit;"
   },
@@ -3222,9 +3225,6 @@ module.exports={
   "microsoft.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
   },
-  "minecraft.com": {
-    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: ascii-printable;"
-  },
   "mintmobile.com": {
     "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
   },
@@ -3248,6 +3248,9 @@ module.exports={
   },
   "myhealthrecord.com": {
     "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
+  },
+  "mysedgwick.com": {
+    "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#%^&+=!]; allowed: [-~_$.,;]"
   },
   "mysubaru.com": {
     "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"


### PR DESCRIPTION
**Reviewer:** 
**Asana:** https://app.asana.com/0/1198964220583541/1203648188543062/f

## Description
A bunch of minor fixes:

- Improve setting value on `select` when a numeric value is expressed with a leading zero, like `02` for `february`.
- Fix failure when an isolated input field is detected as its own form container (there's no identifiable form).
- Fix failure when an input field is a direct child of `body`.

## Steps to test
Automated tests added + verified on real websites. I couldn't find a simple way with our current setup for the last point above, and the tradeoff of adding a more complex test just for this edge case didn't make much sense.