### PR TITLE
Remove form frontend validation

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -6895,6 +6895,9 @@ module.exports={
   "medicare.gov": {
     "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
   },
+  "member.everbridge.net": {
+    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
+  },
   "metlife.com": {
     "password-rules": "minlength: 6; maxlength: 20;"
   },

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -9661,24 +9661,6 @@ class Form {
     /** @type HTMLElement */
     e === null || e === void 0 ? void 0 : e.target);
   }
-  /**
-   * Checks that the form element doesn't contain an invalid field
-   * @return {boolean}
-   */
-
-
-  isValid() {
-    if (this.form instanceof HTMLFormElement) {
-      return this.form.checkValidity();
-    } // If the container is not a valid form, we must check fields individually
-
-
-    let validity = true;
-    this.execOnInputs(input => {
-      if (input.validity && !input.validity.valid) validity = false;
-    }, 'all', false);
-    return validity;
-  }
 
   submitHandler() {
     var _this$device$postSubm, _this$device;
@@ -9690,7 +9672,6 @@ class Form {
     }
 
     if (this.handlerExecuted) return;
-    if (!this.isValid()) return;
     const values = this.getValues();
     (_this$device$postSubm = (_this$device = this.device).postSubmit) === null || _this$device$postSubm === void 0 ? void 0 : _this$device$postSubm.call(_this$device, values, this); // mark this form as being handled
 
@@ -9876,8 +9857,7 @@ class Form {
 
   attemptSubmissionIfNeeded() {
     if (!this.isLogin || // Only submit login forms
-    this.submitButtons.length > 1 || // Do not submit if we're unsure about the submit button
-    !this.isValid() // Do not submit invalid forms
+    this.submitButtons.length > 1 // Do not submit if we're unsure about the submit button
     ) return; // check for visible empty fields before attemtping submission
     // this is to avoid loops where a captcha keeps failing for the user
 
@@ -10185,7 +10165,7 @@ var _autofillUtils = require("../autofill-utils.js");
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 const negativeRegex = new RegExp(/sign(ing)?.?in(?!g)|log.?in|unsubscri|(forgot(ten)?|reset) (your )?password|password (forgotten|lost)/i);
-const positiveRegex = new RegExp(/sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat|reset) password|password confirm?/i);
+const positiveRegex = new RegExp(/sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat) password|password confirm?/i);
 const conservativePositiveRegex = new RegExp(/sign.?up|join|register|enroll|newsletter|subscri(be|ption)|settings|preferences|profile|update/i);
 const strictPositiveRegex = new RegExp(/sign.?up|join|register|enroll|settings|preferences|profile|update/i);
 
@@ -10354,8 +10334,19 @@ class FormAnalyzer {
 
 
     if (el.matches(this.matching.cssSelector('SUBMIT_BUTTON_SELECTOR'))) {
-      // If we're confident this is a submit button, it's a stronger signal
-      const strength = (0, _autofillUtils.isLikelyASubmitButton)(el) ? 20 : 2;
+      // If we're confident this is the submit button, it's a stronger signal
+      let likelyASubmit = (0, _autofillUtils.isLikelyASubmitButton)(el);
+
+      if (likelyASubmit) {
+        this.form.querySelectorAll('input[type=submit], button[type=submit]').forEach(submit => {
+          // If there is another element marked as submit and this is not, flip back to false
+          if (el.type !== 'submit' && el !== submit) {
+            likelyASubmit = false;
+          }
+        });
+      }
+
+      const strength = likelyASubmit ? 20 : 2;
       this.updateSignal({
         string,
         strength,
@@ -13360,7 +13351,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.__secret_do_not_use = exports.SUBMIT_BUTTON_SELECTOR = exports.FORM_INPUTS_SELECTOR = void 0;
-const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]),\nselect";
+const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\nselect";
 exports.FORM_INPUTS_SELECTOR = FORM_INPUTS_SELECTOR;
 const SUBMIT_BUTTON_SELECTOR = "\ninput[type=submit],\ninput[type=button],\nbutton:not([role=switch]):not([role=link]),\n[role=button],\na[href=\"#\"][id*=button i],\na[href=\"#\"][id*=btn i]";
 exports.SUBMIT_BUTTON_SELECTOR = SUBMIT_BUTTON_SELECTOR;

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -5985,24 +5985,6 @@ class Form {
     /** @type HTMLElement */
     e === null || e === void 0 ? void 0 : e.target);
   }
-  /**
-   * Checks that the form element doesn't contain an invalid field
-   * @return {boolean}
-   */
-
-
-  isValid() {
-    if (this.form instanceof HTMLFormElement) {
-      return this.form.checkValidity();
-    } // If the container is not a valid form, we must check fields individually
-
-
-    let validity = true;
-    this.execOnInputs(input => {
-      if (input.validity && !input.validity.valid) validity = false;
-    }, 'all', false);
-    return validity;
-  }
 
   submitHandler() {
     var _this$device$postSubm, _this$device;
@@ -6014,7 +5996,6 @@ class Form {
     }
 
     if (this.handlerExecuted) return;
-    if (!this.isValid()) return;
     const values = this.getValues();
     (_this$device$postSubm = (_this$device = this.device).postSubmit) === null || _this$device$postSubm === void 0 ? void 0 : _this$device$postSubm.call(_this$device, values, this); // mark this form as being handled
 
@@ -6200,8 +6181,7 @@ class Form {
 
   attemptSubmissionIfNeeded() {
     if (!this.isLogin || // Only submit login forms
-    this.submitButtons.length > 1 || // Do not submit if we're unsure about the submit button
-    !this.isValid() // Do not submit invalid forms
+    this.submitButtons.length > 1 // Do not submit if we're unsure about the submit button
     ) return; // check for visible empty fields before attemtping submission
     // this is to avoid loops where a captcha keeps failing for the user
 
@@ -6509,7 +6489,7 @@ var _autofillUtils = require("../autofill-utils.js");
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 const negativeRegex = new RegExp(/sign(ing)?.?in(?!g)|log.?in|unsubscri|(forgot(ten)?|reset) (your )?password|password (forgotten|lost)/i);
-const positiveRegex = new RegExp(/sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat|reset) password|password confirm?/i);
+const positiveRegex = new RegExp(/sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat) password|password confirm?/i);
 const conservativePositiveRegex = new RegExp(/sign.?up|join|register|enroll|newsletter|subscri(be|ption)|settings|preferences|profile|update/i);
 const strictPositiveRegex = new RegExp(/sign.?up|join|register|enroll|settings|preferences|profile|update/i);
 
@@ -6678,8 +6658,19 @@ class FormAnalyzer {
 
 
     if (el.matches(this.matching.cssSelector('SUBMIT_BUTTON_SELECTOR'))) {
-      // If we're confident this is a submit button, it's a stronger signal
-      const strength = (0, _autofillUtils.isLikelyASubmitButton)(el) ? 20 : 2;
+      // If we're confident this is the submit button, it's a stronger signal
+      let likelyASubmit = (0, _autofillUtils.isLikelyASubmitButton)(el);
+
+      if (likelyASubmit) {
+        this.form.querySelectorAll('input[type=submit], button[type=submit]').forEach(submit => {
+          // If there is another element marked as submit and this is not, flip back to false
+          if (el.type !== 'submit' && el !== submit) {
+            likelyASubmit = false;
+          }
+        });
+      }
+
+      const strength = likelyASubmit ? 20 : 2;
       this.updateSignal({
         string,
         strength,
@@ -9684,7 +9675,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.__secret_do_not_use = exports.SUBMIT_BUTTON_SELECTOR = exports.FORM_INPUTS_SELECTOR = void 0;
-const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]),\nselect";
+const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\nselect";
 exports.FORM_INPUTS_SELECTOR = FORM_INPUTS_SELECTOR;
 const SUBMIT_BUTTON_SELECTOR = "\ninput[type=submit],\ninput[type=button],\nbutton:not([role=switch]):not([role=link]),\n[role=button],\na[href=\"#\"][id*=button i],\na[href=\"#\"][id*=btn i]";
 exports.SUBMIT_BUTTON_SELECTOR = SUBMIT_BUTTON_SELECTOR;

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -3219,6 +3219,9 @@ module.exports={
   "medicare.gov": {
     "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
   },
+  "member.everbridge.net": {
+    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
+  },
   "metlife.com": {
     "password-rules": "minlength: 6; maxlength: 20;"
   },

--- a/integration-test/tests/login-form.ios.spec.js
+++ b/integration-test/tests/login-form.ios.spec.js
@@ -136,7 +136,6 @@ test.describe('Auto-fill a login form on iOS', () => {
                 await login.promptWasShown('ios')
                 await login.assertUsernameFilled(personalAddress)
                 await login.assertPasswordEmpty()
-                await login.clickContinue()
                 await login.clickIntoPasswordInput()
                 await login.assertPasswordFilled(password)
                 await login.assertFormSubmitted()

--- a/packages/password/rules.json
+++ b/packages/password/rules.json
@@ -479,6 +479,9 @@
   "medicare.gov": {
     "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
   },
+  "member.everbridge.net": {
+    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
+  },
   "metlife.com": {
     "password-rules": "minlength: 6; maxlength: 20;"
   },

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -99,31 +99,12 @@ class Form {
         return this.form.contains(document.activeElement) || this.form.contains(/** @type HTMLElement */(e?.target))
     }
 
-    /**
-     * Checks that the form element doesn't contain an invalid field
-     * @return {boolean}
-     */
-    isValid () {
-        if (this.form instanceof HTMLFormElement) {
-            return this.form.checkValidity()
-        }
-
-        // If the container is not a valid form, we must check fields individually
-        let validity = true
-        this.execOnInputs((input) => {
-            if (input.validity && !input.validity.valid) validity = false
-        }, 'all', false)
-        return validity
-    }
-
     submitHandler (via = 'unknown') {
         if (this.device.globalConfig.isDDGTestMode) {
             console.log('Form.submitHandler via:', via, this)
         }
 
         if (this.handlerExecuted) return
-
-        if (!this.isValid()) return
 
         const values = this.getValues()
 
@@ -285,8 +266,7 @@ class Form {
     attemptSubmissionIfNeeded () {
         if (
             !this.isLogin || // Only submit login forms
-            this.submitButtons.length > 1 || // Do not submit if we're unsure about the submit button
-            !this.isValid() // Do not submit invalid forms
+            this.submitButtons.length > 1 // Do not submit if we're unsure about the submit button
         ) return
 
         // check for visible empty fields before attemtping submission

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -304,81 +304,6 @@ describe('Test the form class reading values correctly', () => {
     })
 })
 
-describe('Form validity is reported correctly', () => {
-    const testCases = [
-        {
-            testCase: 'valid form with validation',
-            form: `
-<form>
-    <input autocomplete="cc-name" required value="Peppa Pig">
-    <input autocomplete="cc-number" required value="4111111111111111">
-</form>`,
-            expIsValid: true
-        },
-        {
-            testCase: 'valid form because of no validation',
-            form: `
-<form>
-    <input autocomplete="cc-name" value="Peppa Pig">
-    <input autocomplete="cc-number" value="4111111111111111">
-</form>`,
-            expIsValid: true
-        },
-        {
-            testCase: 'valid non-standard form',
-            form: `
-<div id="form">
-    <input autocomplete="cc-name" required value="Peppa Pig">
-    <input autocomplete="cc-number" required value="4111111111111111">
-</div>`,
-            expIsValid: true
-        },
-        {
-            testCase: 'invalid form',
-            form: `
-<form>
-    <input autocomplete="cc-name" required value="">
-    <input autocomplete="cc-number" minlength="10" value="4111">
-</form>`,
-            expIsValid: false
-        },
-        {
-            testCase: 'invalid non-standard form',
-            form: `
-<div id="form">
-    <input autocomplete="cc-name" required value="">
-    <input autocomplete="cc-number" required value="">
-</div>`,
-            expIsValid: false
-        },
-        {
-            testCase: 'invalid non-standard form because of invalid undecorated field',
-            form: `
-<div id="form">
-    <input autocomplete="cc-name" value="">
-    <input autocomplete="cc-number" value="">
-    <input type="text" required value="">
-</div>`,
-            expIsValid: false
-        }
-    ]
-
-    test.each(testCases)('Test $testCase', (
-        {
-            form,
-            expIsValid
-        }) => {
-        const formEl = attachAndReturnGenericForm(form)
-
-        const scanner = createScanner(InterfacePrototype.default()).findEligibleInputs(document)
-
-        const formClass = scanner.forms.get(formEl)
-        const isValid = formClass?.isValid()
-
-        expect(isValid).toBe(expIsValid)
-    })
-})
-
 describe('Check form has focus', () => {
     test('focus detected correctly', () => {
         const formEl = attachAndReturnGenericForm()
@@ -423,20 +348,6 @@ describe('Attempt form submission when needed', () => {
                     <input type="password" value="testPassword" autocomplete="current-password" />
                     <button type="submit">Log in</button>
                     <button type="submit">Other weird login buton that takes you somewhere else</button>
-                </form>`)
-            formEl.addEventListener('submit', submitHandler)
-            const scanner = createScanner(InterfacePrototype.default()).findEligibleInputs(document)
-
-            const formClass = scanner.forms.get(formEl)
-            formClass?.attemptSubmissionIfNeeded()
-            expect(submitHandler).not.toHaveBeenCalled()
-        })
-        test('when the form is invalid', () => {
-            const formEl = attachAndReturnGenericForm(`
-                <form>
-                    <input type="email" value="not_an_email" required autocomplete="username" />
-                    <input type="password" value="" required autocomplete="current-password" />
-                    <button type="submit">Log in</button>
                 </form>`)
             formEl.addEventListener('submit', submitHandler)
             const scanner = createScanner(InterfacePrototype.default()).findEligibleInputs(document)

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -166,8 +166,19 @@ class FormAnalyzer {
 
         // check button contents
         if (el.matches(this.matching.cssSelector('SUBMIT_BUTTON_SELECTOR'))) {
-            // If we're confident this is a submit button, it's a stronger signal
-            const strength = isLikelyASubmitButton(el) ? 20 : 2
+            // If we're confident this is the submit button, it's a stronger signal
+            let likelyASubmit = isLikelyASubmitButton(el)
+            if (likelyASubmit) {
+                this.form.querySelectorAll('input[type=submit], button[type=submit]').forEach(
+                    (submit) => {
+                        // If there is another element marked as submit and this is not, flip back to false
+                        if (el.type !== 'submit' && el !== submit) {
+                            likelyASubmit = false
+                        }
+                    }
+                )
+            }
+            const strength = likelyASubmit ? 20 : 2
             this.updateSignal({string, strength, signalType: `submit: ${string}`})
         }
         // if an external link matches one of the regexes, we assume the match is not pertinent to the current form

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -5,7 +5,7 @@ import { getText, isLikelyASubmitButton } from '../autofill-utils.js'
 
 const negativeRegex = new RegExp(/sign(ing)?.?in(?!g)|log.?in|unsubscri|(forgot(ten)?|reset) (your )?password|password (forgotten|lost)/i)
 const positiveRegex = new RegExp(
-    /sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat|reset) password|password confirm?/i
+    /sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat) password|password confirm?/i
 )
 const conservativePositiveRegex = new RegExp(/sign.?up|join|register|enroll|newsletter|subscri(be|ption)|settings|preferences|profile|update/i)
 const strictPositiveRegex = new RegExp(/sign.?up|join|register|enroll|settings|preferences|profile|update/i)

--- a/src/Form/selectors-css.js
+++ b/src/Form/selectors-css.js
@@ -1,5 +1,5 @@
 const FORM_INPUTS_SELECTOR = `
-input:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]),
+input:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),
 select`
 
 const SUBMIT_BUTTON_SELECTOR = `

--- a/src/Form/test-cases/index.js
+++ b/src/Form/test-cases/index.js
@@ -254,5 +254,7 @@ export default [
     { html: 'boardgamearena_signup.html', expectedFailures: ['birthday'], expectedSubmitFalsePositives: 2, expectedSubmitFalseNegatives: 5 },
     { html: 'eventbrite_checkout-signup.html' },
     { html: 'eventbrite_fake-signup.html' },
-    { html: 'ryanair_cc-card-name.html' }
+    { html: 'ryanair_cc-card-name.html' },
+    { html: 'paypal_otp.html' },
+    { html: 'postnews_login.html' }
 ]

--- a/src/Form/test-cases/paypal_otp.html
+++ b/src/Form/test-cases/paypal_otp.html
@@ -1,0 +1,61 @@
+<form method="post" novalidate="">
+    <div>
+        <div>
+            <div class="codeInput">
+                <div class="codeInput-resend" id="code-resend">
+                    <div class="resend-link"><a class="ppvx_link___3-9-8 ppvx--v2___3-9-8 resend" href="#">Invia di
+                        nuovo</a></div>
+                </div>
+                <div class="ppvx_code-input___1-4-1 codeInput-wrapper" id="otpCode">
+                    <div class="ppvx_code-input__input-wrapper___1-4-1">
+                        <div class="ppvx_text-input___3-14-1 ppvx_text-input--nolabel___3-14-1 ppvx--v2___3-14-1 ppvx_code-input__text-input___1-4-1">
+                            <input aria-describedby="otpCode"
+                                   aria-invalid="false" aria-label="1-6" class="ppvx_text-input__control___3-14-1 ppvx_code-input__input___1-4-1 hasHelp" for="securityCodeInput" id="ci-otpCode-0" name="otpCode-0"
+                                   placeholder=" " role="textbox" type="tel"
+                                   value="" data-manual-scoring="unknown"><label class="ppvx_text-input__label___3-14-1 otpCodeLabel data-nemo" for="ci-otpCode-0"
+                                                                   id="ci-otpCode-0-label"></label>
+                        </div>
+                        <div class="ppvx_text-input___3-14-1 ppvx_text-input--nolabel___3-14-1 ppvx--v2___3-14-1 ppvx_code-input__text-input___1-4-1">
+                            <input aria-describedby="otpCode"
+                                   aria-invalid="false" aria-label="2-6" class="ppvx_text-input__control___3-14-1 ppvx_code-input__input___1-4-1 hasHelp" for="securityCodeInput" id="ci-otpCode-1" name="otpCode-1"
+                                   placeholder=" " role="textbox" type="tel"
+                                   value="" data-manual-scoring="unknown"><label class="ppvx_text-input__label___3-14-1 otpCodeLabel data-nemo" for="ci-otpCode-1"
+                                                                   id="ci-otpCode-1-label"></label>
+                        </div>
+                        <div class="ppvx_text-input___3-14-1 ppvx_text-input--nolabel___3-14-1 ppvx--v2___3-14-1 ppvx_code-input__text-input___1-4-1">
+                            <input aria-describedby="otpCode"
+                                   aria-invalid="false" aria-label="3-6" class="ppvx_text-input__control___3-14-1 ppvx_code-input__input___1-4-1 hasHelp" for="securityCodeInput" id="ci-otpCode-2" name="otpCode-2"
+                                   placeholder=" " role="textbox" type="tel"
+                                   value="" data-manual-scoring="unknown"><label class="ppvx_text-input__label___3-14-1 otpCodeLabel data-nemo" for="ci-otpCode-2"
+                                                                   id="ci-otpCode-2-label"></label>
+                        </div>
+                        <div class="ppvx_text-input___3-14-1 ppvx_text-input--nolabel___3-14-1 ppvx--v2___3-14-1 ppvx_code-input__text-input___1-4-1">
+                            <input aria-describedby="otpCode"
+                                   aria-invalid="false" aria-label="4-6" class="ppvx_text-input__control___3-14-1 ppvx_code-input__input___1-4-1 hasHelp" for="securityCodeInput" id="ci-otpCode-3" name="otpCode-3"
+                                   placeholder=" " role="textbox" type="tel"
+                                   value="" data-manual-scoring="unknown"><label class="ppvx_text-input__label___3-14-1 otpCodeLabel data-nemo" for="ci-otpCode-3"
+                                                                   id="ci-otpCode-3-label"></label>
+                        </div>
+                        <div class="ppvx_text-input___3-14-1 ppvx_text-input--nolabel___3-14-1 ppvx--v2___3-14-1 ppvx_code-input__text-input___1-4-1">
+                            <input aria-describedby="otpCode"
+                                   aria-invalid="false" aria-label="5-6" class="ppvx_text-input__control___3-14-1 ppvx_code-input__input___1-4-1 hasHelp" for="securityCodeInput" id="ci-otpCode-4" name="otpCode-4"
+                                   placeholder=" " role="textbox" type="tel"
+                                   value="" data-manual-scoring="unknown"><label class="ppvx_text-input__label___3-14-1 otpCodeLabel data-nemo" for="ci-otpCode-4"
+                                                                   id="ci-otpCode-4-label"></label>
+                        </div>
+                        <div class="ppvx_text-input___3-14-1 ppvx_text-input--nolabel___3-14-1 ppvx--v2___3-14-1 ppvx_code-input__text-input___1-4-1">
+                            <input aria-describedby="otpCode"
+                                   aria-invalid="false" aria-label="6-6" class="ppvx_text-input__control___3-14-1 ppvx_code-input__input___1-4-1 hasHelp" for="securityCodeInput" id="ci-otpCode-5" name="otpCode-5"
+                                   placeholder=" " role="textbox" type="tel"
+                                   value="" data-manual-scoring="unknown"><label class="ppvx_text-input__label___3-14-1 otpCodeLabel data-nemo" for="ci-otpCode-5"
+                                                                   id="ci-otpCode-5-label"></label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <button class="ppvx_btn___5-11-8 ppvx--v2___5-11-8 submit-form-button" data-nemo="twofactorSubmit" type="submit">
+        Continua
+    </button>
+</form>

--- a/src/Form/test-cases/postnews_login.html
+++ b/src/Form/test-cases/postnews_login.html
@@ -1,0 +1,38 @@
+<!-- https://post.news/auth/signin -->
+<form class="c-PJLV" novalidate=""><label class="c-ehkLfE"><span
+        class="c-dAqCK c-dAqCK-jdhiMW-type-sans300m c-dAqCK-ljnjCj-color-spidertooth800 c-dAqCK-ijknsHb-css">Email</span><span
+        class="c-dAqCK c-dAqCK-cUwCye-type-sans200 c-dAqCK-GjjkV-color-spidertooth600 c-dAqCK-ikQfaPs-css">Enter the email used to sign up</span>
+    <div class="c-bSMcqW"><input autocomplete="on" class="c-eSwFRQ" data-manual-scoring="username" name="email" type="email"
+                                 value=""><span></span></div>
+    <div class="c-frmHud"></div>
+</label><label class="c-ehkLfE"><span
+        class="c-dAqCK c-dAqCK-jdhiMW-type-sans300m c-dAqCK-ljnjCj-color-spidertooth800 c-dAqCK-ijknsHb-css">Password</span><span
+        class="c-dAqCK c-dAqCK-cUwCye-type-sans200 c-dAqCK-GjjkV-color-spidertooth600 c-dAqCK-ikQfaPs-css">Enter the password used to sign up</span>
+    <div class="c-bSMcqW"><input autocomplete="on" class="c-eSwFRQ" data-manual-scoring="password" name="password" type="password"
+                                 value=""><span></span></div>
+    <div class="c-frmHud"></div>
+</label><a aria-label="Reset Password" class=" c-cdQeth" href="/reset-password" target="_self"><span
+        class="c-FHWXc c-FHWXc-hQDKtx-hierarchy-TERTIARY c-FHWXc-lbZpKu-hug-true c-FHWXc-hxSfWK-iconPlacement-LEFT c-FHWXc-igWSLUl-css"><span>Reset Password</span></span></a>
+    <div class="c-bGLbat">
+        <button aria-disabled="false" aria-label="Log In" class=" c-cdQeth" type="submit" data-manual-submit><span
+                class="c-FHWXc c-FHWXc-Pbzoi-hierarchy-PRIMARY c-FHWXc-hxSfWK-iconPlacement-LEFT c-FHWXc-gzqAoS-type-LABEL_ONLY c-FHWXc-ijsODbu-css"><span>Log In</span></span>
+        </button>
+    </div>
+    <div class="c-iZMHBn"><p
+            class="c-dAqCK c-dAqCK-ikeHfo-type-sans400 c-dAqCK-GjjkV-color-spidertooth600 c-dAqCK-icKRwKw-css">Don’t
+        have an account?</p>
+        <button aria-disabled="false" aria-label="Sign Up" class=" c-cdQeth" type="button"><span
+                class="c-FHWXc c-FHWXc-hQDKtx-hierarchy-TERTIARY c-FHWXc-lbZpKu-hug-true c-FHWXc-hxSfWK-iconPlacement-LEFT"><span>Sign Up</span></span>
+        </button>
+    </div>
+    <div class="c-iZMHBn"><h2
+            class="c-dAqCK c-dAqCK-ikeHfo-type-sans400 c-dAqCK-GjjkV-color-spidertooth600 c-dAqCK-icKRwKw-css">Having
+        sign-up issues?</h2><a aria-label="Request a Code" class=" c-cdQeth" href="/auth/request_code"
+                               target="_self"><span
+            class="c-FHWXc c-FHWXc-hQDKtx-hierarchy-TERTIARY c-FHWXc-lbZpKu-hug-true c-FHWXc-hxSfWK-iconPlacement-LEFT"><span>Request a Code</span></span></a>
+    </div>
+    <div class="c-kqvkfk"><a aria-label="Read our FAQ" class=" c-cdQeth" href="https://intercom.help/post-news/en/articles/6787347-troubleshooting-sign-up-and-log-in-issues"
+                             target="_blank"><span
+            class="c-FHWXc c-FHWXc-hQDKtx-hierarchy-TERTIARY c-FHWXc-hxSfWK-iconPlacement-LEFT"><span>Read our FAQ</span></span></a>
+    </div>
+</form>

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -6895,6 +6895,9 @@ module.exports={
   "medicare.gov": {
     "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
   },
+  "member.everbridge.net": {
+    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
+  },
   "metlife.com": {
     "password-rules": "minlength: 6; maxlength: 20;"
   },

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -9661,24 +9661,6 @@ class Form {
     /** @type HTMLElement */
     e === null || e === void 0 ? void 0 : e.target);
   }
-  /**
-   * Checks that the form element doesn't contain an invalid field
-   * @return {boolean}
-   */
-
-
-  isValid() {
-    if (this.form instanceof HTMLFormElement) {
-      return this.form.checkValidity();
-    } // If the container is not a valid form, we must check fields individually
-
-
-    let validity = true;
-    this.execOnInputs(input => {
-      if (input.validity && !input.validity.valid) validity = false;
-    }, 'all', false);
-    return validity;
-  }
 
   submitHandler() {
     var _this$device$postSubm, _this$device;
@@ -9690,7 +9672,6 @@ class Form {
     }
 
     if (this.handlerExecuted) return;
-    if (!this.isValid()) return;
     const values = this.getValues();
     (_this$device$postSubm = (_this$device = this.device).postSubmit) === null || _this$device$postSubm === void 0 ? void 0 : _this$device$postSubm.call(_this$device, values, this); // mark this form as being handled
 
@@ -9876,8 +9857,7 @@ class Form {
 
   attemptSubmissionIfNeeded() {
     if (!this.isLogin || // Only submit login forms
-    this.submitButtons.length > 1 || // Do not submit if we're unsure about the submit button
-    !this.isValid() // Do not submit invalid forms
+    this.submitButtons.length > 1 // Do not submit if we're unsure about the submit button
     ) return; // check for visible empty fields before attemtping submission
     // this is to avoid loops where a captcha keeps failing for the user
 
@@ -10185,7 +10165,7 @@ var _autofillUtils = require("../autofill-utils.js");
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 const negativeRegex = new RegExp(/sign(ing)?.?in(?!g)|log.?in|unsubscri|(forgot(ten)?|reset) (your )?password|password (forgotten|lost)/i);
-const positiveRegex = new RegExp(/sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat|reset) password|password confirm?/i);
+const positiveRegex = new RegExp(/sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat) password|password confirm?/i);
 const conservativePositiveRegex = new RegExp(/sign.?up|join|register|enroll|newsletter|subscri(be|ption)|settings|preferences|profile|update/i);
 const strictPositiveRegex = new RegExp(/sign.?up|join|register|enroll|settings|preferences|profile|update/i);
 
@@ -10354,8 +10334,19 @@ class FormAnalyzer {
 
 
     if (el.matches(this.matching.cssSelector('SUBMIT_BUTTON_SELECTOR'))) {
-      // If we're confident this is a submit button, it's a stronger signal
-      const strength = (0, _autofillUtils.isLikelyASubmitButton)(el) ? 20 : 2;
+      // If we're confident this is the submit button, it's a stronger signal
+      let likelyASubmit = (0, _autofillUtils.isLikelyASubmitButton)(el);
+
+      if (likelyASubmit) {
+        this.form.querySelectorAll('input[type=submit], button[type=submit]').forEach(submit => {
+          // If there is another element marked as submit and this is not, flip back to false
+          if (el.type !== 'submit' && el !== submit) {
+            likelyASubmit = false;
+          }
+        });
+      }
+
+      const strength = likelyASubmit ? 20 : 2;
       this.updateSignal({
         string,
         strength,
@@ -13360,7 +13351,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.__secret_do_not_use = exports.SUBMIT_BUTTON_SELECTOR = exports.FORM_INPUTS_SELECTOR = void 0;
-const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]),\nselect";
+const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\nselect";
 exports.FORM_INPUTS_SELECTOR = FORM_INPUTS_SELECTOR;
 const SUBMIT_BUTTON_SELECTOR = "\ninput[type=submit],\ninput[type=button],\nbutton:not([role=switch]):not([role=link]),\n[role=button],\na[href=\"#\"][id*=button i],\na[href=\"#\"][id*=btn i]";
 exports.SUBMIT_BUTTON_SELECTOR = SUBMIT_BUTTON_SELECTOR;

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -5985,24 +5985,6 @@ class Form {
     /** @type HTMLElement */
     e === null || e === void 0 ? void 0 : e.target);
   }
-  /**
-   * Checks that the form element doesn't contain an invalid field
-   * @return {boolean}
-   */
-
-
-  isValid() {
-    if (this.form instanceof HTMLFormElement) {
-      return this.form.checkValidity();
-    } // If the container is not a valid form, we must check fields individually
-
-
-    let validity = true;
-    this.execOnInputs(input => {
-      if (input.validity && !input.validity.valid) validity = false;
-    }, 'all', false);
-    return validity;
-  }
 
   submitHandler() {
     var _this$device$postSubm, _this$device;
@@ -6014,7 +5996,6 @@ class Form {
     }
 
     if (this.handlerExecuted) return;
-    if (!this.isValid()) return;
     const values = this.getValues();
     (_this$device$postSubm = (_this$device = this.device).postSubmit) === null || _this$device$postSubm === void 0 ? void 0 : _this$device$postSubm.call(_this$device, values, this); // mark this form as being handled
 
@@ -6200,8 +6181,7 @@ class Form {
 
   attemptSubmissionIfNeeded() {
     if (!this.isLogin || // Only submit login forms
-    this.submitButtons.length > 1 || // Do not submit if we're unsure about the submit button
-    !this.isValid() // Do not submit invalid forms
+    this.submitButtons.length > 1 // Do not submit if we're unsure about the submit button
     ) return; // check for visible empty fields before attemtping submission
     // this is to avoid loops where a captcha keeps failing for the user
 
@@ -6509,7 +6489,7 @@ var _autofillUtils = require("../autofill-utils.js");
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 const negativeRegex = new RegExp(/sign(ing)?.?in(?!g)|log.?in|unsubscri|(forgot(ten)?|reset) (your )?password|password (forgotten|lost)/i);
-const positiveRegex = new RegExp(/sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat|reset) password|password confirm?/i);
+const positiveRegex = new RegExp(/sign(ing)?.?up|join|\bregist(er|ration)|newsletter|\bsubscri(be|ption)|contact|create|start|enroll|settings|preferences|profile|update|checkout|guest|purchase|buy|order|schedule|estimate|request|new.?customer|(confirm|retype|repeat) password|password confirm?/i);
 const conservativePositiveRegex = new RegExp(/sign.?up|join|register|enroll|newsletter|subscri(be|ption)|settings|preferences|profile|update/i);
 const strictPositiveRegex = new RegExp(/sign.?up|join|register|enroll|settings|preferences|profile|update/i);
 
@@ -6678,8 +6658,19 @@ class FormAnalyzer {
 
 
     if (el.matches(this.matching.cssSelector('SUBMIT_BUTTON_SELECTOR'))) {
-      // If we're confident this is a submit button, it's a stronger signal
-      const strength = (0, _autofillUtils.isLikelyASubmitButton)(el) ? 20 : 2;
+      // If we're confident this is the submit button, it's a stronger signal
+      let likelyASubmit = (0, _autofillUtils.isLikelyASubmitButton)(el);
+
+      if (likelyASubmit) {
+        this.form.querySelectorAll('input[type=submit], button[type=submit]').forEach(submit => {
+          // If there is another element marked as submit and this is not, flip back to false
+          if (el.type !== 'submit' && el !== submit) {
+            likelyASubmit = false;
+          }
+        });
+      }
+
+      const strength = likelyASubmit ? 20 : 2;
       this.updateSignal({
         string,
         strength,
@@ -9684,7 +9675,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.__secret_do_not_use = exports.SUBMIT_BUTTON_SELECTOR = exports.FORM_INPUTS_SELECTOR = void 0;
-const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]),\nselect";
+const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\nselect";
 exports.FORM_INPUTS_SELECTOR = FORM_INPUTS_SELECTOR;
 const SUBMIT_BUTTON_SELECTOR = "\ninput[type=submit],\ninput[type=button],\nbutton:not([role=switch]):not([role=link]),\n[role=button],\na[href=\"#\"][id*=button i],\na[href=\"#\"][id*=btn i]";
 exports.SUBMIT_BUTTON_SELECTOR = SUBMIT_BUTTON_SELECTOR;

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -3219,6 +3219,9 @@ module.exports={
   "medicare.gov": {
     "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
   },
+  "member.everbridge.net": {
+    "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
+  },
   "metlife.com": {
     "password-rules": "minlength: 6; maxlength: 20;"
   },


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/0/1203662765229908/f

## Description
Back in the day, we introduced a form validity check before prompting to store credentials to minimise prompting when submission fails. We discovered though that form validity is not a valid signal of whether a login event would successfully happen or not. Many sites, including Ryanair and Chase ignore the form validity and just submit the form. This meant users would never see a prompt to save credentials on those sites. This PR removes those frontend checks.

This also includes minor changes to algo accuracy to fix a few recent bug reports. Test cases added for those.

## Steps to test
Visit ryanair.com and try to login. You should see the prompt to store the credentials. I've already checked both there and on chas.com.