### PR TITLE
Update test extension to load host styles

### DIFF
--- a/integration-test/extension/.gitignore
+++ b/integration-test/extension/.gitignore
@@ -1,3 +1,4 @@
 /autofill.js
 /autofill-debug.js
 /public/css/autofill.css
+/public/css/autofill-host-styles_chrome.css

--- a/integration-test/extension/manifest.json
+++ b/integration-test/extension/manifest.json
@@ -17,13 +17,13 @@
       "matches": ["<all_urls>"],
       "run_at": "document_start",
       "js": ["autofill.js"],
+      "css": ["public/css/autofill-host-styles_chrome.css"],
       "all_frames": true,
       "match_about_blank": true
     }
   ],
   "web_accessible_resources": [
       "public/css/autofill.css",
-      "img/logo-small.svg",
-      "autofill.js"
+      "img/logo-small.svg"
   ]
 }

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -19,6 +19,7 @@ function copyAutofillCSS () {
     const hostStylesPath = filepath(srcPath, 'UI', 'styles', 'autofill-host-styles.css')
     copyFileSync(hostStylesPath, filepath(distPath, 'autofill-host-styles_chrome.css'))
     copyFirefoxCSSFile(hostStylesPath, filepath(distPath, 'autofill-host-styles_firefox.css'))
+    copyFileSync(hostStylesPath, filepath('integration-test', 'extension', 'public', 'css', 'autofill-host-styles_chrome.css'))
 }
 
 function copyAutofillHTML () {


### PR DESCRIPTION
**Reviewer:** 
**Asana:** https://app.asana.com/0/1198964220583541/1203966930123203/f

## Description
The Dax icon is missing from the in-context signup integration tests. This icon is added by injected styles rather than from autofill injecting directly into the input.
This PR updates the test extension to inbject the `autofill-host-styles_chrome.css` file which adds these styles.

## Steps to test

1. Update `incontext-signup.extension.spec.js` to pause in one of the tests
2. Run the test `npm run test:integration:showui -- integration-test/tests/incontext-signup.extension.spec.js`
3. Confirm the icon shows as expected