### PR TITLE
Stop scanning pages with a large number of inputs

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -14114,6 +14114,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  *     initialDelay: number,
  *     bufferSize: number,
  *     debounceTimePeriod: number,
+ *     maxInputsOnPage: number,
  * }} ScannerOptions
  */
 
@@ -14126,7 +14127,11 @@ const defaultScannerOptions = {
   // wait for a 500ms window of event silence before performing the scan
   debounceTimePeriod: 500,
   // how long to wait when performing the initial scan
-  initialDelay: 0
+  initialDelay: 0,
+  // How many inputs is too many on the page. If we detect that there's above
+  // this maximum, then we don't scan the page. This will prevent slowdowns on
+  // large pages which are unlikely to require autofill anyway.
+  maxInputsOnPage: 250
 };
 /**
  * This allows:
@@ -14270,7 +14275,13 @@ class DefaultScanner {
     if ('matches' in context && (_context$matches = context.matches) !== null && _context$matches !== void 0 && _context$matches.call(context, _selectorsCss.FORM_INPUTS_SELECTOR)) {
       this.addInput(context);
     } else {
-      context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR).forEach(input => this.addInput(input));
+      const inputs = context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR);
+
+      if (inputs.length > this.options.maxInputsOnPage) {
+        return this;
+      }
+
+      inputs.forEach(input => this.addInput(input));
     }
 
     return this;

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -10438,6 +10438,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  *     initialDelay: number,
  *     bufferSize: number,
  *     debounceTimePeriod: number,
+ *     maxInputsOnPage: number,
  * }} ScannerOptions
  */
 
@@ -10450,7 +10451,11 @@ const defaultScannerOptions = {
   // wait for a 500ms window of event silence before performing the scan
   debounceTimePeriod: 500,
   // how long to wait when performing the initial scan
-  initialDelay: 0
+  initialDelay: 0,
+  // How many inputs is too many on the page. If we detect that there's above
+  // this maximum, then we don't scan the page. This will prevent slowdowns on
+  // large pages which are unlikely to require autofill anyway.
+  maxInputsOnPage: 250
 };
 /**
  * This allows:
@@ -10594,7 +10599,13 @@ class DefaultScanner {
     if ('matches' in context && (_context$matches = context.matches) !== null && _context$matches !== void 0 && _context$matches.call(context, _selectorsCss.FORM_INPUTS_SELECTOR)) {
       this.addInput(context);
     } else {
-      context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR).forEach(input => this.addInput(input));
+      const inputs = context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR);
+
+      if (inputs.length > this.options.maxInputsOnPage) {
+        return this;
+      }
+
+      inputs.forEach(input => this.addInput(input));
     }
 
     return this;

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -14,6 +14,7 @@ import { createMatching } from './Form/matching.js'
  *     initialDelay: number,
  *     bufferSize: number,
  *     debounceTimePeriod: number,
+ *     maxInputsOnPage: number,
  * }} ScannerOptions
  */
 
@@ -26,7 +27,11 @@ const defaultScannerOptions = {
     // wait for a 500ms window of event silence before performing the scan
     debounceTimePeriod: 500,
     // how long to wait when performing the initial scan
-    initialDelay: 0
+    initialDelay: 0,
+    // How many inputs is too many on the page. If we detect that there's above
+    // this maximum, then we don't scan the page. This will prevent slowdowns on
+    // large pages which are unlikely to require autofill anyway.
+    maxInputsOnPage: 250
 }
 
 /**
@@ -124,7 +129,11 @@ class DefaultScanner {
         if ('matches' in context && context.matches?.(FORM_INPUTS_SELECTOR)) {
             this.addInput(context)
         } else {
-            context.querySelectorAll(FORM_INPUTS_SELECTOR).forEach((input) => this.addInput(input))
+            const inputs = context.querySelectorAll(FORM_INPUTS_SELECTOR)
+            if (inputs.length > this.options.maxInputsOnPage) {
+                return this
+            }
+            inputs.forEach((input) => this.addInput(input))
         }
         return this
     }

--- a/src/Scanner.test.js
+++ b/src/Scanner.test.js
@@ -27,6 +27,7 @@ describe('performance', () => {
         scanner.enqueue([document])
         jest.advanceTimersByTime(1000)
         expect(spy).toHaveBeenCalledTimes(1)
+        expect(document.body).toMatchSnapshot()
     })
     it('should constrain the buffer size', () => {
         const scanner = createScanner(InterfacePrototype.default(), {
@@ -43,5 +44,16 @@ describe('performance', () => {
 
         jest.advanceTimersByTime(1000)
         expect(spy).toHaveBeenCalledTimes(1)
+        expect(document.body).toMatchSnapshot()
+    })
+    it('should not scan if above maximum inputs', () => {
+        const scanner = createScanner(InterfacePrototype.default(), {
+            maxInputsOnPage: 3
+        })
+
+        scanner.findEligibleInputs(document)
+
+        jest.advanceTimersByTime(1000)
+        expect(document.body).toMatchSnapshot()
     })
 })

--- a/src/__snapshots__/Scanner.test.js.snap
+++ b/src/__snapshots__/Scanner.test.js.snap
@@ -1,0 +1,200 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`performance should constrain the buffer size 1`] = `
+<body>
+  
+            
+  <form
+    action=""
+  >
+    
+                
+    <label
+      for="input-01"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-01"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-02"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-02"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-03"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-03"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-04"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-04"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-05"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-05"
+        type="text"
+      />
+    </label>
+    
+            
+  </form>
+</body>
+`;
+
+exports[`performance should debounce dom lookups 1`] = `
+<body>
+  
+            
+  <form
+    action=""
+  >
+    
+                
+    <label
+      for="input-01"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-01"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-02"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-02"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-03"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-03"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-04"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-04"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-05"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-05"
+        type="text"
+      />
+    </label>
+    
+            
+  </form>
+</body>
+`;
+
+exports[`performance should not scan if above maximum inputs 1`] = `
+<body>
+  
+            
+  <form
+    action=""
+  >
+    
+                
+    <label
+      for="input-01"
+    >
+      <input
+        id="input-01"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-02"
+    >
+      <input
+        id="input-02"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-03"
+    >
+      <input
+        id="input-03"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-04"
+    >
+      <input
+        id="input-04"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-05"
+    >
+      <input
+        id="input-05"
+        type="text"
+      />
+    </label>
+    
+            
+  </form>
+</body>
+`;

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -14114,6 +14114,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  *     initialDelay: number,
  *     bufferSize: number,
  *     debounceTimePeriod: number,
+ *     maxInputsOnPage: number,
  * }} ScannerOptions
  */
 
@@ -14126,7 +14127,11 @@ const defaultScannerOptions = {
   // wait for a 500ms window of event silence before performing the scan
   debounceTimePeriod: 500,
   // how long to wait when performing the initial scan
-  initialDelay: 0
+  initialDelay: 0,
+  // How many inputs is too many on the page. If we detect that there's above
+  // this maximum, then we don't scan the page. This will prevent slowdowns on
+  // large pages which are unlikely to require autofill anyway.
+  maxInputsOnPage: 250
 };
 /**
  * This allows:
@@ -14270,7 +14275,13 @@ class DefaultScanner {
     if ('matches' in context && (_context$matches = context.matches) !== null && _context$matches !== void 0 && _context$matches.call(context, _selectorsCss.FORM_INPUTS_SELECTOR)) {
       this.addInput(context);
     } else {
-      context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR).forEach(input => this.addInput(input));
+      const inputs = context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR);
+
+      if (inputs.length > this.options.maxInputsOnPage) {
+        return this;
+      }
+
+      inputs.forEach(input => this.addInput(input));
     }
 
     return this;

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -10438,6 +10438,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  *     initialDelay: number,
  *     bufferSize: number,
  *     debounceTimePeriod: number,
+ *     maxInputsOnPage: number,
  * }} ScannerOptions
  */
 
@@ -10450,7 +10451,11 @@ const defaultScannerOptions = {
   // wait for a 500ms window of event silence before performing the scan
   debounceTimePeriod: 500,
   // how long to wait when performing the initial scan
-  initialDelay: 0
+  initialDelay: 0,
+  // How many inputs is too many on the page. If we detect that there's above
+  // this maximum, then we don't scan the page. This will prevent slowdowns on
+  // large pages which are unlikely to require autofill anyway.
+  maxInputsOnPage: 250
 };
 /**
  * This allows:
@@ -10594,7 +10599,13 @@ class DefaultScanner {
     if ('matches' in context && (_context$matches = context.matches) !== null && _context$matches !== void 0 && _context$matches.call(context, _selectorsCss.FORM_INPUTS_SELECTOR)) {
       this.addInput(context);
     } else {
-      context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR).forEach(input => this.addInput(input));
+      const inputs = context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR);
+
+      if (inputs.length > this.options.maxInputsOnPage) {
+        return this;
+      }
+
+      inputs.forEach(input => this.addInput(input));
     }
 
     return this;


### PR DESCRIPTION
**Reviewer:** @GioSensation @shakyShane 
**Asana:** https://app.asana.com/0/1198964220583541/1203995347288602/f

## Description
Stop scanning pages with a large number of inputs

## Steps to test
1. Add to extension
1. Go to site with a large number of inputs (e.g. testing page - https://jsfiddle.net/alistairjcbrown/es506ubm/)
1. Confirm that Dax does not show in the inputs2. 

Large number of inputs | Small number of inputs
--- | ---
<img width="2160" alt="Screenshot 2023-02-17 at 19 31 39" src="https://user-images.githubusercontent.com/635903/219770077-f820e617-c71c-4d5c-a9af-90bff7ece994.png"> | <img width="2160" alt="Screenshot 2023-02-17 at 19 31 54" src="https://user-images.githubusercontent.com/635903/219770034-dc31204a-f87b-4a5d-b686-8dfa5cd1a03a.png">

