### PR TITLE
fix(perf): avoid checking for CC if we don't need to

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10024,7 +10024,8 @@ class Form {
       isLogin: this.isLogin,
       isHybrid: this.isHybrid,
       hasCredentials: Boolean((_this$device$settings = this.device.settings.availableInputTypes.credentials) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.username),
-      supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
+      supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities,
+      supportsCreditCardsAutofill: this.device.settings.featureToggles.inputType_creditCards
     };
     this.matching.setInputType(input, this.form, opts);
     const mainInputType = (0, _matching.getInputMainType)(input);
@@ -12819,10 +12820,10 @@ class Matching {
       return presetType;
     }
 
-    this.setActiveElementStrings(input, formEl); // // For CC forms we run aggressive matches, so we want to make sure we only
-    // // run them on actual CC forms to avoid false positives and expensive loops
+    this.setActiveElementStrings(input, formEl); // For CC forms we run aggressive matches, so we want to make sure we only
+    // run them on actual CC forms to avoid false positives and expensive loops
 
-    if (this.isCCForm(formEl)) {
+    if (opts.supportsCreditCardsAutofill && this.isCCForm(formEl)) {
       const subtype = this.subtypeFromMatchers('cc', input);
 
       if (subtype && isValidCreditCardSubtype(subtype)) {
@@ -12866,7 +12867,8 @@ class Matching {
    *   isLogin?: boolean,
    *   isHybrid?: boolean,
    *   hasCredentials?: boolean,
-   *   supportsIdentitiesAutofill?: boolean
+   *   supportsIdentitiesAutofill?: boolean,
+   *   supportsCreditCardsAutofill?: boolean,
    * }} SetInputTypeOpts
    */
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6348,7 +6348,8 @@ class Form {
       isLogin: this.isLogin,
       isHybrid: this.isHybrid,
       hasCredentials: Boolean((_this$device$settings = this.device.settings.availableInputTypes.credentials) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.username),
-      supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
+      supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities,
+      supportsCreditCardsAutofill: this.device.settings.featureToggles.inputType_creditCards
     };
     this.matching.setInputType(input, this.form, opts);
     const mainInputType = (0, _matching.getInputMainType)(input);
@@ -9143,10 +9144,10 @@ class Matching {
       return presetType;
     }
 
-    this.setActiveElementStrings(input, formEl); // // For CC forms we run aggressive matches, so we want to make sure we only
-    // // run them on actual CC forms to avoid false positives and expensive loops
+    this.setActiveElementStrings(input, formEl); // For CC forms we run aggressive matches, so we want to make sure we only
+    // run them on actual CC forms to avoid false positives and expensive loops
 
-    if (this.isCCForm(formEl)) {
+    if (opts.supportsCreditCardsAutofill && this.isCCForm(formEl)) {
       const subtype = this.subtypeFromMatchers('cc', input);
 
       if (subtype && isValidCreditCardSubtype(subtype)) {
@@ -9190,7 +9191,8 @@ class Matching {
    *   isLogin?: boolean,
    *   isHybrid?: boolean,
    *   hasCredentials?: boolean,
-   *   supportsIdentitiesAutofill?: boolean
+   *   supportsIdentitiesAutofill?: boolean,
+   *   supportsCreditCardsAutofill?: boolean,
    * }} SetInputTypeOpts
    */
 

--- a/integration-test/helpers/harness.js
+++ b/integration-test/helpers/harness.js
@@ -325,6 +325,8 @@ export function withWindowsContext (test) {
  * @return {Promise<PerformanceEntryList>}
  */
 export async function performanceEntries (page, measureName) {
+    // don't measure until the entries exist
+    await page.waitForFunction((measureName) => window.performance.getEntriesByName(measureName).length === 1, `${measureName}:end`)
     const result = await page.evaluate((measureName) => {
         window.performance?.measure?.(measureName, `${measureName}:start`, `${measureName}:end`)
         const entries = window.performance?.getEntriesByName(measureName)

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -5,6 +5,7 @@ export const constants = {
     pages: {
         'overlay': 'overlay.html',
         'email-autofill': 'email-autofill.html',
+        'scanner-perf': 'scanner-perf.html',
         'signup': 'signup.html',
         'login': 'login.html',
         'loginWithPoorForm': 'login-poor-form.html',

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -669,6 +669,19 @@ export function overlayPage (page, server) {
         }
     }
 }
+/**
+ * A wrapper around interactions for `integration-test/pages/scanner-perf.html`
+ *
+ * @param {import("playwright").Page} page
+ * @param {ServerWrapper} server
+ */
+export function scannerPerf (page, server) {
+    return /** @type {const} */({
+        async navigate () {
+            await page.goto(server.urlForPath(constants.pages['scanner-perf']), {waitUntil: 'networkidle'})
+        }
+    })
+}
 
 /**
  * A wrapper around interactions for `integration-test/pages/signup.html`

--- a/integration-test/pages/scanner-perf.html
+++ b/integration-test/pages/scanner-perf.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Scanner Perf Test</title>
+    <style>
+        label { display: block }
+    </style>
+</head>
+<body>
+<div>
+    <form action="" id="demo" name="demo">
+        <button type="submit">Sign in</button>
+    </form>
+</div>
+<script>
+    const form = document.forms.demo;
+    for (let i = 0; i < 1000; i += 1) {
+        const f = document.createElement('div');
+        f.innerHTML = `<label>Input: ${i}<input name="input-${i}" /></label>`
+        form.appendChild(f)
+    }
+
+</script>
+</body>
+</html>

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -335,7 +335,8 @@ class Form {
             isLogin: this.isLogin,
             isHybrid: this.isHybrid,
             hasCredentials: Boolean(this.device.settings.availableInputTypes.credentials?.username),
-            supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
+            supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities,
+            supportsCreditCardsAutofill: this.device.settings.featureToggles.inputType_creditCards
         }
         this.matching.setInputType(input, this.form, opts)
 

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -294,7 +294,13 @@ describe('Test the form class reading values correctly', () => {
             expValues
         }) => {
         const formEl = attachAndReturnGenericForm(form)
-        const scanner = createScanner(InterfacePrototype.default()).findEligibleInputs(document)
+        const device = InterfacePrototype.default()
+        jest.spyOn(device.settings, 'featureToggles', 'get')
+            .mockReturnValue({
+                inputType_identities: true,
+                inputType_creditCards: true
+            })
+        const scanner = createScanner(device).findEligibleInputs(document)
         const formClass = scanner.forms.get(formEl)
         const hasValues = formClass?.hasValues()
         const formValues = formClass?.getValues()

--- a/src/Form/input-classifiers.test.js
+++ b/src/Form/input-classifiers.test.js
@@ -164,6 +164,10 @@ describe.each(testCases)('Test $html fields', (testCase) => {
         const deviceInterface = InterfacePrototype.default()
         const availableInputTypes = createAvailableInputTypes({credentials: {username: true, password: true}})
         deviceInterface.settings.setAvailableInputTypes(availableInputTypes)
+        deviceInterface.settings.setFeatureToggles({
+            inputType_creditCards: true,
+            inputType_identities: true
+        })
         const scanner = createScanner(deviceInterface)
         scanner.findEligibleInputs(document)
 

--- a/src/Form/matching.js
+++ b/src/Form/matching.js
@@ -219,9 +219,9 @@ class Matching {
 
         this.setActiveElementStrings(input, formEl)
 
-        // // For CC forms we run aggressive matches, so we want to make sure we only
-        // // run them on actual CC forms to avoid false positives and expensive loops
-        if (this.isCCForm(formEl)) {
+        // For CC forms we run aggressive matches, so we want to make sure we only
+        // run them on actual CC forms to avoid false positives and expensive loops
+        if (opts.supportsCreditCardsAutofill && this.isCCForm(formEl)) {
             const subtype = this.subtypeFromMatchers('cc', input)
             if (subtype && isValidCreditCardSubtype(subtype)) {
                 return `creditCards.${subtype}`
@@ -265,7 +265,8 @@ class Matching {
      *   isLogin?: boolean,
      *   isHybrid?: boolean,
      *   hasCredentials?: boolean,
-     *   supportsIdentitiesAutofill?: boolean
+     *   supportsIdentitiesAutofill?: boolean,
+     *   supportsCreditCardsAutofill?: boolean,
      * }} SetInputTypeOpts
      */
 

--- a/src/Form/matching.test.js
+++ b/src/Form/matching.test.js
@@ -150,7 +150,10 @@ describe('matching', () => {
         const { formElement, inputs } = setFormHtml(html)
 
         const matching = createMatching()
-        const inferred = matching.inferInputType(inputs[0], formElement, opts)
+        const inferred = matching.inferInputType(inputs[0], formElement, {
+            ...opts,
+            supportsCreditCardsAutofill: true
+        })
         expect(inferred).toBe(subtype)
     })
     it('should not continue past a ddg-matcher that has a "not" regex', () => {

--- a/src/Scanner.debug.js
+++ b/src/Scanner.debug.js
@@ -13,12 +13,16 @@ const mockInterface = {
     settings: {
         availableInputTypes: {
             credentials: true,
-            identities: true
+            identities: false
         },
         featureToggles: {
             inputType_credentials: true,
-            inputType_identities: true,
-            inputType_creditCards: true
+            inputType_identities: false,
+            inputType_creditCards: false
+        },
+        canAutofillType: (type) => {
+            if (type === 'credentials') return true
+            return false
         }
     },
     globalConfig: {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10024,7 +10024,8 @@ class Form {
       isLogin: this.isLogin,
       isHybrid: this.isHybrid,
       hasCredentials: Boolean((_this$device$settings = this.device.settings.availableInputTypes.credentials) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.username),
-      supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
+      supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities,
+      supportsCreditCardsAutofill: this.device.settings.featureToggles.inputType_creditCards
     };
     this.matching.setInputType(input, this.form, opts);
     const mainInputType = (0, _matching.getInputMainType)(input);
@@ -12819,10 +12820,10 @@ class Matching {
       return presetType;
     }
 
-    this.setActiveElementStrings(input, formEl); // // For CC forms we run aggressive matches, so we want to make sure we only
-    // // run them on actual CC forms to avoid false positives and expensive loops
+    this.setActiveElementStrings(input, formEl); // For CC forms we run aggressive matches, so we want to make sure we only
+    // run them on actual CC forms to avoid false positives and expensive loops
 
-    if (this.isCCForm(formEl)) {
+    if (opts.supportsCreditCardsAutofill && this.isCCForm(formEl)) {
       const subtype = this.subtypeFromMatchers('cc', input);
 
       if (subtype && isValidCreditCardSubtype(subtype)) {
@@ -12866,7 +12867,8 @@ class Matching {
    *   isLogin?: boolean,
    *   isHybrid?: boolean,
    *   hasCredentials?: boolean,
-   *   supportsIdentitiesAutofill?: boolean
+   *   supportsIdentitiesAutofill?: boolean,
+   *   supportsCreditCardsAutofill?: boolean,
    * }} SetInputTypeOpts
    */
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6348,7 +6348,8 @@ class Form {
       isLogin: this.isLogin,
       isHybrid: this.isHybrid,
       hasCredentials: Boolean((_this$device$settings = this.device.settings.availableInputTypes.credentials) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.username),
-      supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
+      supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities,
+      supportsCreditCardsAutofill: this.device.settings.featureToggles.inputType_creditCards
     };
     this.matching.setInputType(input, this.form, opts);
     const mainInputType = (0, _matching.getInputMainType)(input);
@@ -9143,10 +9144,10 @@ class Matching {
       return presetType;
     }
 
-    this.setActiveElementStrings(input, formEl); // // For CC forms we run aggressive matches, so we want to make sure we only
-    // // run them on actual CC forms to avoid false positives and expensive loops
+    this.setActiveElementStrings(input, formEl); // For CC forms we run aggressive matches, so we want to make sure we only
+    // run them on actual CC forms to avoid false positives and expensive loops
 
-    if (this.isCCForm(formEl)) {
+    if (opts.supportsCreditCardsAutofill && this.isCCForm(formEl)) {
       const subtype = this.subtypeFromMatchers('cc', input);
 
       if (subtype && isValidCreditCardSubtype(subtype)) {
@@ -9190,7 +9191,8 @@ class Matching {
    *   isLogin?: boolean,
    *   isHybrid?: boolean,
    *   hasCredentials?: boolean,
-   *   supportsIdentitiesAutofill?: boolean
+   *   supportsIdentitiesAutofill?: boolean,
+   *   supportsCreditCardsAutofill?: boolean,
    * }} SetInputTypeOpts
    */
 


### PR DESCRIPTION
**Reviewer:**  @GioSensation  @sammacbeth 
**Asana:** https://app.asana.com/0/1198964220583541/1204184574937875/f

## Description

Directly solves: https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1792

Platforms that don't support Credit Cards (yet) should not incur the cost of checking for them

I created a test page with 1000 input elements as a stress-test. Note: these times are un-throttled on a M1 Macbook, so the real-world impact is likely much larger 💪

- before: `1.2seconds`
- after: `69ms`

The Credit Card checking happens in an extremely performance-sensitive area of the codebase. Until we have lazy-evalutation of forms/fields the best we can do is try to prevent work from happening in the first place.

--- 

**Before, with 1000 input elements** 

<img width="1672" alt="Screenshot 2023-02-18 at 20 42 36" src="https://user-images.githubusercontent.com/1643522/219899808-ff4c26e3-d909-446d-81ff-ddb09c0911f4.png">


**After, with 1000 input elements** 

<img width="1257" alt="Screenshot 2023-02-18 at 20 41 02" src="https://user-images.githubusercontent.com/1643522/219899882-6d81b1a0-8086-4677-a04c-68141ddafef6.png">


## Steps to test

- I've added an integration test to help prevent us regressing in this area again :)
