### PR TITLE
Ignore small email inputs

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12539,6 +12539,13 @@ const {
   TEXT_LENGTH_CUTOFF,
   ATTR_INPUT_TYPE
 } = _constants.constants;
+/** @type {{[K in keyof MatcherLists]?: { minWidth: number }} } */
+
+const dimensionBounds = {
+  email: {
+    minWidth: 40
+  }
+};
 /**
  * An abstraction around the concept of classifying input fields.
  *
@@ -12777,6 +12784,24 @@ class Matching {
     return selectors.join(', ');
   }
   /**
+   * Returns true if the field is visible and large enough
+   * @param {keyof MatcherLists} matchedType
+   * @param {HTMLInputElement} input
+   * @returns {boolean}
+   */
+
+
+  isInputLargeEnough(matchedType, input) {
+    const expectedDimensionBounds = dimensionBounds[matchedType];
+    if (!expectedDimensionBounds) return true;
+    const width = input.offsetWidth;
+    const height = input.offsetHeight; // Ignore hidden elements as we can't determine their dimensions
+
+    const isHidden = height === 0 && width === 0;
+    if (isHidden) return true;
+    return width >= expectedDimensionBounds.minWidth;
+  }
+  /**
    * Tries to infer the input type for an input
    *
    * @param {HTMLInputElement|HTMLSelectElement} input
@@ -12810,7 +12835,7 @@ class Matching {
         return 'credentials.password';
       }
 
-      if (this.subtypeFromMatchers('email', input)) {
+      if (this.subtypeFromMatchers('email', input) && this.isInputLargeEnough('email', input)) {
         if (opts.isLogin || opts.isHybrid) {
           // Show identities when supported and there are no credentials
           if (opts.supportsIdentitiesAutofill && !opts.hasCredentials) {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8863,6 +8863,13 @@ const {
   TEXT_LENGTH_CUTOFF,
   ATTR_INPUT_TYPE
 } = _constants.constants;
+/** @type {{[K in keyof MatcherLists]?: { minWidth: number }} } */
+
+const dimensionBounds = {
+  email: {
+    minWidth: 40
+  }
+};
 /**
  * An abstraction around the concept of classifying input fields.
  *
@@ -9101,6 +9108,24 @@ class Matching {
     return selectors.join(', ');
   }
   /**
+   * Returns true if the field is visible and large enough
+   * @param {keyof MatcherLists} matchedType
+   * @param {HTMLInputElement} input
+   * @returns {boolean}
+   */
+
+
+  isInputLargeEnough(matchedType, input) {
+    const expectedDimensionBounds = dimensionBounds[matchedType];
+    if (!expectedDimensionBounds) return true;
+    const width = input.offsetWidth;
+    const height = input.offsetHeight; // Ignore hidden elements as we can't determine their dimensions
+
+    const isHidden = height === 0 && width === 0;
+    if (isHidden) return true;
+    return width >= expectedDimensionBounds.minWidth;
+  }
+  /**
    * Tries to infer the input type for an input
    *
    * @param {HTMLInputElement|HTMLSelectElement} input
@@ -9134,7 +9159,7 @@ class Matching {
         return 'credentials.password';
       }
 
-      if (this.subtypeFromMatchers('email', input)) {
+      if (this.subtypeFromMatchers('email', input) && this.isInputLargeEnough('email', input)) {
         if (opts.isLogin || opts.isHybrid) {
           // Show identities when supported and there are no credentials
           if (opts.supportsIdentitiesAutofill && !opts.hasCredentials) {

--- a/integration-test/pages/email-autofill.html
+++ b/integration-test/pages/email-autofill.html
@@ -13,6 +13,10 @@
 
 <p id="demo"></p>
 
+<div>
+  Small inputs should be ignored: <input id="email" type="email" style="width: 30px;">
+</div>
+
 <div class="dialog">
   <form action="/signup">
     <h2>Sign up for our newsletter</h2>

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -12539,6 +12539,13 @@ const {
   TEXT_LENGTH_CUTOFF,
   ATTR_INPUT_TYPE
 } = _constants.constants;
+/** @type {{[K in keyof MatcherLists]?: { minWidth: number }} } */
+
+const dimensionBounds = {
+  email: {
+    minWidth: 40
+  }
+};
 /**
  * An abstraction around the concept of classifying input fields.
  *
@@ -12777,6 +12784,24 @@ class Matching {
     return selectors.join(', ');
   }
   /**
+   * Returns true if the field is visible and large enough
+   * @param {keyof MatcherLists} matchedType
+   * @param {HTMLInputElement} input
+   * @returns {boolean}
+   */
+
+
+  isInputLargeEnough(matchedType, input) {
+    const expectedDimensionBounds = dimensionBounds[matchedType];
+    if (!expectedDimensionBounds) return true;
+    const width = input.offsetWidth;
+    const height = input.offsetHeight; // Ignore hidden elements as we can't determine their dimensions
+
+    const isHidden = height === 0 && width === 0;
+    if (isHidden) return true;
+    return width >= expectedDimensionBounds.minWidth;
+  }
+  /**
    * Tries to infer the input type for an input
    *
    * @param {HTMLInputElement|HTMLSelectElement} input
@@ -12810,7 +12835,7 @@ class Matching {
         return 'credentials.password';
       }
 
-      if (this.subtypeFromMatchers('email', input)) {
+      if (this.subtypeFromMatchers('email', input) && this.isInputLargeEnough('email', input)) {
         if (opts.isLogin || opts.isHybrid) {
           // Show identities when supported and there are no credentials
           if (opts.supportsIdentitiesAutofill && !opts.hasCredentials) {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -8863,6 +8863,13 @@ const {
   TEXT_LENGTH_CUTOFF,
   ATTR_INPUT_TYPE
 } = _constants.constants;
+/** @type {{[K in keyof MatcherLists]?: { minWidth: number }} } */
+
+const dimensionBounds = {
+  email: {
+    minWidth: 40
+  }
+};
 /**
  * An abstraction around the concept of classifying input fields.
  *
@@ -9101,6 +9108,24 @@ class Matching {
     return selectors.join(', ');
   }
   /**
+   * Returns true if the field is visible and large enough
+   * @param {keyof MatcherLists} matchedType
+   * @param {HTMLInputElement} input
+   * @returns {boolean}
+   */
+
+
+  isInputLargeEnough(matchedType, input) {
+    const expectedDimensionBounds = dimensionBounds[matchedType];
+    if (!expectedDimensionBounds) return true;
+    const width = input.offsetWidth;
+    const height = input.offsetHeight; // Ignore hidden elements as we can't determine their dimensions
+
+    const isHidden = height === 0 && width === 0;
+    if (isHidden) return true;
+    return width >= expectedDimensionBounds.minWidth;
+  }
+  /**
    * Tries to infer the input type for an input
    *
    * @param {HTMLInputElement|HTMLSelectElement} input
@@ -9134,7 +9159,7 @@ class Matching {
         return 'credentials.password';
       }
 
-      if (this.subtypeFromMatchers('email', input)) {
+      if (this.subtypeFromMatchers('email', input) && this.isInputLargeEnough('email', input)) {
         if (opts.isLogin || opts.isHybrid) {
           // Show identities when supported and there are no credentials
           if (opts.supportsIdentitiesAutofill && !opts.hasCredentials) {


### PR DESCRIPTION
**Reviewer:** @shakyShane @GioSensation 
**Asana:** https://app.asana.com/0/0/1204054800859607/f

## Description
When email inputs are very small we should ignore them, they're likely to be false positives.

## Steps to test
1. Add to extension
2. Go to https://codepen.io/alistairjcbrown/pen/RwYPEmE and confirm inputs are not populated