### PR TITLE
Reduce maximum input limit

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -13520,7 +13520,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.__secret_do_not_use = exports.SUBMIT_BUTTON_SELECTOR = exports.FORM_INPUTS_SELECTOR = void 0;
-const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\nselect";
+const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\n[autocomplete=username],\nselect";
 exports.FORM_INPUTS_SELECTOR = FORM_INPUTS_SELECTOR;
 const SUBMIT_BUTTON_SELECTOR = "\ninput[type=submit],\ninput[type=button],\nbutton:not([role=switch]):not([role=link]),\n[role=button],\na[href=\"#\"][id*=button i],\na[href=\"#\"][id*=btn i]";
 exports.SUBMIT_BUTTON_SELECTOR = SUBMIT_BUTTON_SELECTOR;
@@ -14131,7 +14131,7 @@ const defaultScannerOptions = {
   // How many inputs is too many on the page. If we detect that there's above
   // this maximum, then we don't scan the page. This will prevent slowdowns on
   // large pages which are unlikely to require autofill anyway.
-  maxInputsOnPage: 250
+  maxInputsOnPage: 100
 };
 /**
  * This allows:

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -9844,7 +9844,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.__secret_do_not_use = exports.SUBMIT_BUTTON_SELECTOR = exports.FORM_INPUTS_SELECTOR = void 0;
-const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\nselect";
+const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\n[autocomplete=username],\nselect";
 exports.FORM_INPUTS_SELECTOR = FORM_INPUTS_SELECTOR;
 const SUBMIT_BUTTON_SELECTOR = "\ninput[type=submit],\ninput[type=button],\nbutton:not([role=switch]):not([role=link]),\n[role=button],\na[href=\"#\"][id*=button i],\na[href=\"#\"][id*=btn i]";
 exports.SUBMIT_BUTTON_SELECTOR = SUBMIT_BUTTON_SELECTOR;
@@ -10455,7 +10455,7 @@ const defaultScannerOptions = {
   // How many inputs is too many on the page. If we detect that there's above
   // this maximum, then we don't scan the page. This will prevent slowdowns on
   // large pages which are unlikely to require autofill anyway.
-  maxInputsOnPage: 250
+  maxInputsOnPage: 100
 };
 /**
  * This allows:

--- a/src/Form/selectors-css.js
+++ b/src/Form/selectors-css.js
@@ -1,5 +1,6 @@
 const FORM_INPUTS_SELECTOR = `
 input:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),
+[autocomplete=username],
 select`
 
 const SUBMIT_BUTTON_SELECTOR = `

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -31,7 +31,7 @@ const defaultScannerOptions = {
     // How many inputs is too many on the page. If we detect that there's above
     // this maximum, then we don't scan the page. This will prevent slowdowns on
     // large pages which are unlikely to require autofill anyway.
-    maxInputsOnPage: 250
+    maxInputsOnPage: 100
 }
 
 /**

--- a/src/Scanner.test.js
+++ b/src/Scanner.test.js
@@ -52,8 +52,32 @@ describe('performance', () => {
         })
 
         scanner.findEligibleInputs(document)
-
         jest.advanceTimersByTime(1000)
+
+        // Confirm that no elements on the page are scanned
+        expect(document.body).toMatchSnapshot()
+    })
+    it('should stop scanning if page grows above maximum inputs', () => {
+        const scanner = createScanner(InterfacePrototype.default(), {
+            maxInputsOnPage: 5,
+            bufferSize: 2
+        })
+
+        scanner.findEligibleInputs(document)
+        jest.advanceTimersByTime(1000)
+
+        // Add more new inputs than the buffer size allows
+        const form = document.querySelector('form')
+        const inputs = Array.from(Array(3)).map(() => {
+            const input = document.createElement('input')
+            input.setAttribute('type', 'text')
+            return input
+        })
+        inputs.forEach(input => form?.appendChild(input))
+        inputs.forEach(input => scanner.enqueue([input]))
+        jest.advanceTimersByTime(1000)
+
+        // Confirm that newly added inputs are not scanned
         expect(document.body).toMatchSnapshot()
     })
 })

--- a/src/__snapshots__/Scanner.test.js.snap
+++ b/src/__snapshots__/Scanner.test.js.snap
@@ -198,3 +198,80 @@ exports[`performance should not scan if above maximum inputs 1`] = `
   </form>
 </body>
 `;
+
+exports[`performance should stop scanning if page grows above maximum inputs 1`] = `
+<body>
+  
+            
+  <form
+    action=""
+  >
+    
+                
+    <label
+      for="input-01"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-01"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-02"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-02"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-03"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-03"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-04"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-04"
+        type="text"
+      />
+    </label>
+    
+                
+    <label
+      for="input-05"
+    >
+      <input
+        data-ddg-inputtype="unknown"
+        id="input-05"
+        type="text"
+      />
+    </label>
+    
+            
+    <input
+      type="text"
+    />
+    <input
+      type="text"
+    />
+    <input
+      type="text"
+    />
+  </form>
+</body>
+`;

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -13520,7 +13520,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.__secret_do_not_use = exports.SUBMIT_BUTTON_SELECTOR = exports.FORM_INPUTS_SELECTOR = void 0;
-const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\nselect";
+const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\n[autocomplete=username],\nselect";
 exports.FORM_INPUTS_SELECTOR = FORM_INPUTS_SELECTOR;
 const SUBMIT_BUTTON_SELECTOR = "\ninput[type=submit],\ninput[type=button],\nbutton:not([role=switch]):not([role=link]),\n[role=button],\na[href=\"#\"][id*=button i],\na[href=\"#\"][id*=btn i]";
 exports.SUBMIT_BUTTON_SELECTOR = SUBMIT_BUTTON_SELECTOR;
@@ -14131,7 +14131,7 @@ const defaultScannerOptions = {
   // How many inputs is too many on the page. If we detect that there's above
   // this maximum, then we don't scan the page. This will prevent slowdowns on
   // large pages which are unlikely to require autofill anyway.
-  maxInputsOnPage: 250
+  maxInputsOnPage: 100
 };
 /**
  * This allows:

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -9844,7 +9844,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.__secret_do_not_use = exports.SUBMIT_BUTTON_SELECTOR = exports.FORM_INPUTS_SELECTOR = void 0;
-const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\nselect";
+const FORM_INPUTS_SELECTOR = "\ninput:not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]):not([type=hidden]):not([type=file]):not([type=search]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]),\n[autocomplete=username],\nselect";
 exports.FORM_INPUTS_SELECTOR = FORM_INPUTS_SELECTOR;
 const SUBMIT_BUTTON_SELECTOR = "\ninput[type=submit],\ninput[type=button],\nbutton:not([role=switch]):not([role=link]),\n[role=button],\na[href=\"#\"][id*=button i],\na[href=\"#\"][id*=btn i]";
 exports.SUBMIT_BUTTON_SELECTOR = SUBMIT_BUTTON_SELECTOR;
@@ -10455,7 +10455,7 @@ const defaultScannerOptions = {
   // How many inputs is too many on the page. If we detect that there's above
   // this maximum, then we don't scan the page. This will prevent slowdowns on
   // large pages which are unlikely to require autofill anyway.
-  maxInputsOnPage: 250
+  maxInputsOnPage: 100
 };
 /**
  * This allows:


### PR DESCRIPTION
**Reviewer:** @shakyShane @GioSensation 
**Asana:** https://app.asana.com/0/1198964220583541/1203995347288602/f

## Description
Reduce the maximum number of inputs on page to 100

## Steps to test
Same instructions as https://github.com/duckduckgo/duckduckgo-autofill/pull/257