### PR TITLE
Prevent in-context signup showing on local or invalid domain pages

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8068,7 +8068,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
       return TOOLTIP_TYPES.EmailProtection;
     }
 
-    if (this.settings.featureToggles.emailProtection_incontext_signup && ((_this$inContextSignup = this.inContextSignup) === null || _this$inContextSignup === void 0 ? void 0 : _this$inContextSignup.permanentlyDismissed) === false) {
+    if ((_this$inContextSignup = this.inContextSignup) !== null && _this$inContextSignup !== void 0 && _this$inContextSignup.isAvailable()) {
       return TOOLTIP_TYPES.EmailSignup;
     }
 
@@ -13656,24 +13656,45 @@ exports.InContextSignup = void 0;
 
 var _deviceApiCalls = require("./deviceApiCalls/__generated__/deviceApiCalls.js");
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+var _autofillUtils = require("./autofill-utils.js");
 
 class InContextSignup {
   /**
    * @param {import("./DeviceInterface/InterfacePrototype").default} device
    */
   constructor(device) {
-    _defineProperty(this, "permanentlyDismissed", false);
-
-    _defineProperty(this, "initiallyDismissed", false);
-
     this.device = device;
   }
 
   async init() {
+    await this.refreshData();
+  }
+
+  async refreshData() {
     const incontextSignupDismissedAt = await this.device.deviceApi.request(new _deviceApiCalls.GetIncontextSignupDismissedAtCall(null));
-    this.permanentlyDismissed = Boolean(incontextSignupDismissedAt.permanentlyDismissedAt);
-    this.initiallyDismissed = Boolean(incontextSignupDismissedAt.initiallyDismissedAt);
+    this.permanentlyDismissedAt = incontextSignupDismissedAt.permanentlyDismissedAt;
+    this.initiallyDismissedAt = incontextSignupDismissedAt.initiallyDismissedAt;
+  }
+
+  isPermanentlyDismissed() {
+    return Boolean(this.permanentlyDismissedAt);
+  }
+
+  isInitiallyDismissed() {
+    return Boolean(this.initiallyDismissedAt);
+  }
+
+  isOnValidDomain() {
+    // Only show in-context signup if we've high confidence that the page is
+    // not internally hosted or an intranet
+    return (0, _autofillUtils.isValidTLD)() && !(0, _autofillUtils.isLocalNetwork)();
+  }
+
+  isAvailable() {
+    var _this$device$settings;
+
+    const isEnabled = (_this$device$settings = this.device.settings) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.featureToggles.emailProtection_incontext_signup;
+    return isEnabled && !this.isPermanentlyDismissed() && this.isOnValidDomain();
   }
 
   onIncontextSignup() {
@@ -13686,19 +13707,19 @@ class InContextSignup {
     // Check if the email signup tooltip has previously been dismissed.
     // If it has, make the dismissal persist and remove it from the page.
     // If it hasn't, set a flag for next time and just hide the tooltip.
-    if (this.initiallyDismissed) {
-      this.permanentlyDismissed = true;
+    if (this.isInitiallyDismissed()) {
+      this.permanentlyDismissedAt = new Date().getTime();
       this.device.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupPermanentlyDismissedAtCall({
-        value: new Date().getTime()
+        value: this.permanentlyDismissedAt
       }));
       this.device.removeAutofillUIFromPage();
       this.device.firePixel({
         pixelName: 'incontext_dismiss_persisted'
       });
     } else {
-      this.initiallyDismissed = true;
+      this.initiallyDismissedAt = new Date().getTime();
       this.device.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupInitiallyDismissedAtCall({
-        value: new Date().getTime()
+        value: this.initiallyDismissedAt
       }));
       this.device.removeTooltip();
       this.device.firePixel({
@@ -13711,7 +13732,7 @@ class InContextSignup {
 
 exports.InContextSignup = InContextSignup;
 
-},{"./deviceApiCalls/__generated__/deviceApiCalls.js":65}],45:[function(require,module,exports){
+},{"./autofill-utils.js":61,"./deviceApiCalls/__generated__/deviceApiCalls.js":65}],45:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14911,7 +14932,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
     var _device$inContextSign;
 
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat((_device$inContextSign = device.inContextSignup) !== null && _device$inContextSign !== void 0 && _device$inContextSign.initiallyDismissed ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat((_device$inContextSign = device.inContextSignup) !== null && _device$inContextSign !== void 0 && _device$inContextSign.isInitiallyDismissed() ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {
@@ -16044,7 +16065,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.buttonMatchesFormType = exports.autofillEnabled = exports.addInlineStyles = exports.SIGN_IN_MSG = exports.ADDRESS_DOMAIN = void 0;
 exports.escapeXML = escapeXML;
-exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedConfig = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
+exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedConfig = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
+exports.isLocalNetwork = isLocalNetwork;
+exports.isValidTLD = isValidTLD;
+exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = void 0;
 
 var _matching = require("./Form/matching.js");
 
@@ -16475,8 +16499,32 @@ const getText = el => {
   if (el instanceof HTMLInputElement && ['submit', 'button'].includes(el.type)) return el.value;
   return (0, _matching.removeExcessWhitespace)(Array.from(el.childNodes).reduce((text, child) => child instanceof Text ? text + ' ' + child.textContent : text, ''));
 };
+/**
+ * Check if hostname is a local address
+ * @param {string} [hostname]
+ * @returns {boolean}
+ */
+
 
 exports.getText = getText;
+
+function isLocalNetwork() {
+  let hostname = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : window.location.hostname;
+  return ['localhost', '', '::1'].includes(hostname) || hostname.includes('127.0.0.1') || hostname.includes('192.168.') || hostname.startsWith('10.0.') || hostname.endsWith('.local') || hostname.endsWith('.internal');
+} // Extracted from lib/DDG/Util/Constants.pm
+
+
+const tldrs = /\.(?:c(?:o(?:m|op)?|at?|[iykgdmnxruhcfzvl])|o(?:rg|m)|n(?:et?|a(?:me)?|[ucgozrfpil])|e(?:d?u|[gechstr])|i(?:n(?:t|fo)?|[stqldroem])|m(?:o(?:bi)?|u(?:seum)?|i?l|[mcyvtsqhaerngxzfpwkd])|g(?:ov|[glqeriabtshdfmuywnp])|b(?:iz?|[drovfhtaywmzjsgbenl])|t(?:r(?:avel)?|[ncmfzdvkopthjwg]|e?l)|k[iemygznhwrp]|s[jtvberindlucygkhaozm]|u[gymszka]|h[nmutkr]|r[owesu]|d[kmzoej]|a(?:e(?:ro)?|r(?:pa)?|[qofiumsgzlwcnxdt])|p(?:ro?|[sgnthfymakwle])|v[aegiucn]|l[sayuvikcbrt]|j(?:o(?:bs)?|[mep])|w[fs]|z[amw]|f[rijkom]|y[eut]|qa)$/i;
+/**
+ * Check if hostname is a valid top-level domain
+ * @param {string} [hostname]
+ * @returns {boolean}
+ */
+
+function isValidTLD() {
+  let hostname = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : window.location.hostname;
+  return tldrs.test(hostname);
+}
 
 },{"./Form/matching.js":41}],62:[function(require,module,exports){
 "use strict";

--- a/integration-test/helpers/harness.js
+++ b/integration-test/helpers/harness.js
@@ -57,6 +57,20 @@ export function setupServer (port) {
 }
 
 /**
+ * @param {import("playwright").Page} page
+ * @param {string} domain
+ */
+export async function setupMockedDomain (page, domain) {
+    await page.route(`${domain}/**/*`, (route, request) => {
+        const { pathname } = new URL(request.url())
+        return route.fulfill({
+            status: 200,
+            body: readFileSync(join('.', pathname), 'utf8')
+        })
+    })
+}
+
+/**
  * Launch a chromium browser with the test extension pre-loaded.
  *
  * @param {typeof import("@playwright/test").test} test

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -578,13 +578,19 @@ export function loginPageMultistep (page, server, opts) {
  * A wrapper around interactions for `integration-test/pages/email-autofill.html`
  *
  * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {ServerWrapper} [server]
  */
 export function emailAutofillPage (page, server) {
     const {selectors} = constants.fields.email
     return {
-        async navigate () {
-            await page.goto(server.urlForPath(constants.pages['email-autofill']))
+        async navigate (domain) {
+            const emailAutofillPageName = constants.pages['email-autofill']
+            if (domain) {
+                const pagePath = `integration-test/pages/${emailAutofillPageName}`
+                await page.goto(new URL(pagePath, domain).href)
+            } else {
+                await page.goto(server.urlForPath(emailAutofillPageName))
+            }
         },
         async clickIntoInput () {
             const input = page.locator(selectors.identity)

--- a/integration-test/tests/incontext-signup.extension.spec.js
+++ b/integration-test/tests/incontext-signup.extension.spec.js
@@ -1,4 +1,4 @@
-import {forwardConsoleMessages, setupServer, withChromeExtensionContext} from '../helpers/harness.js'
+import {forwardConsoleMessages, withChromeExtensionContext, setupMockedDomain} from '../helpers/harness.js'
 import { test as base, expect } from '@playwright/test'
 import {emailAutofillPage, incontextSignupPage} from '../helpers/pages.js'
 
@@ -10,19 +10,13 @@ import {emailAutofillPage, incontextSignupPage} from '../helpers/pages.js'
 const test = withChromeExtensionContext(base)
 
 test.describe('chrome extension', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test('should allow user to sign up for Email Protection', async ({page, context}) => {
         forwardConsoleMessages(page)
+        await setupMockedDomain(page, 'https://example.com')
 
         const incontextSignup = incontextSignupPage(page)
-        const emailPage = emailAutofillPage(page, server)
-        await emailPage.navigate()
+        const emailPage = emailAutofillPage(page)
+        await emailPage.navigate('https://example.com')
         const newPageOpening = new Promise(resolve => context.once('page', resolve))
 
         await emailPage.clickIntoInput()
@@ -40,10 +34,11 @@ test.describe('chrome extension', () => {
 
     test('should allow tooptip to be dismissed', async ({page}) => {
         forwardConsoleMessages(page)
+        await setupMockedDomain(page, 'https://example.com')
 
         const incontextSignup = incontextSignupPage(page)
-        const emailPage = emailAutofillPage(page, server)
-        await emailPage.navigate()
+        const emailPage = emailAutofillPage(page)
+        await emailPage.navigate('https://example.com')
 
         // Hide tooltip
         await emailPage.clickIntoInput()

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -47,7 +47,7 @@ class ExtensionInterface extends InterfacePrototype {
             return TOOLTIP_TYPES.EmailProtection
         }
 
-        if (this.settings.featureToggles.emailProtection_incontext_signup && this.inContextSignup?.permanentlyDismissed === false) {
+        if (this.inContextSignup?.isAvailable()) {
             return TOOLTIP_TYPES.EmailSignup
         }
 

--- a/src/InContextSignup.js
+++ b/src/InContextSignup.js
@@ -3,11 +3,9 @@ import {
     SetIncontextSignupInitiallyDismissedAtCall,
     SetIncontextSignupPermanentlyDismissedAtCall
 } from './deviceApiCalls/__generated__/deviceApiCalls.js'
+import { isLocalNetwork, isValidTLD } from './autofill-utils.js'
 
 export class InContextSignup {
-    permanentlyDismissed = false
-    initiallyDismissed = false
-
     /**
      * @param {import("./DeviceInterface/InterfacePrototype").default} device
      */
@@ -16,9 +14,32 @@ export class InContextSignup {
     }
 
     async init () {
+        await this.refreshData()
+    }
+
+    async refreshData () {
         const incontextSignupDismissedAt = await this.device.deviceApi.request(new GetIncontextSignupDismissedAtCall(null))
-        this.permanentlyDismissed = Boolean(incontextSignupDismissedAt.permanentlyDismissedAt)
-        this.initiallyDismissed = Boolean(incontextSignupDismissedAt.initiallyDismissedAt)
+        this.permanentlyDismissedAt = incontextSignupDismissedAt.permanentlyDismissedAt
+        this.initiallyDismissedAt = incontextSignupDismissedAt.initiallyDismissedAt
+    }
+
+    isPermanentlyDismissed () {
+        return Boolean(this.permanentlyDismissedAt)
+    }
+
+    isInitiallyDismissed () {
+        return Boolean(this.initiallyDismissedAt)
+    }
+
+    isOnValidDomain () {
+        // Only show in-context signup if we've high confidence that the page is
+        // not internally hosted or an intranet
+        return isValidTLD() && !isLocalNetwork()
+    }
+
+    isAvailable () {
+        const isEnabled = this.device.settings?.featureToggles.emailProtection_incontext_signup
+        return isEnabled && !this.isPermanentlyDismissed() && this.isOnValidDomain()
     }
 
     onIncontextSignup () {
@@ -29,14 +50,14 @@ export class InContextSignup {
         // Check if the email signup tooltip has previously been dismissed.
         // If it has, make the dismissal persist and remove it from the page.
         // If it hasn't, set a flag for next time and just hide the tooltip.
-        if (this.initiallyDismissed) {
-            this.permanentlyDismissed = true
-            this.device.deviceApi.notify(new SetIncontextSignupPermanentlyDismissedAtCall({ value: new Date().getTime() }))
+        if (this.isInitiallyDismissed()) {
+            this.permanentlyDismissedAt = new Date().getTime()
+            this.device.deviceApi.notify(new SetIncontextSignupPermanentlyDismissedAtCall({ value: this.permanentlyDismissedAt }))
             this.device.removeAutofillUIFromPage()
             this.device.firePixel({pixelName: 'incontext_dismiss_persisted'})
         } else {
-            this.initiallyDismissed = true
-            this.device.deviceApi.notify(new SetIncontextSignupInitiallyDismissedAtCall({ value: new Date().getTime() }))
+            this.initiallyDismissedAt = new Date().getTime()
+            this.device.deviceApi.notify(new SetIncontextSignupInitiallyDismissedAtCall({ value: this.initiallyDismissedAt }))
             this.device.removeTooltip()
             this.device.firePixel({pixelName: 'incontext_dismiss_initial'})
         }

--- a/src/UI/EmailSignupHTMLTooltop.js
+++ b/src/UI/EmailSignupHTMLTooltop.js
@@ -23,7 +23,7 @@ ${this.options.css}
                 Get Email Protection
             </a>
             <button class="ghost js-dismiss-email-signup">
-                ${device.inContextSignup?.initiallyDismissed ? "Don't Ask Again" : 'Maybe Later'}
+                ${device.inContextSignup?.isInitiallyDismissed() ? "Don't Ask Again" : 'Maybe Later'}
             </button>
         </div>
     </div>

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -351,6 +351,33 @@ const getText = (el) => {
     )
 }
 
+/**
+ * Check if hostname is a local address
+ * @param {string} [hostname]
+ * @returns {boolean}
+ */
+function isLocalNetwork (hostname = window.location.hostname) {
+    return (
+        ['localhost', '', '::1'].includes(hostname) ||
+        hostname.includes('127.0.0.1') ||
+        hostname.includes('192.168.') ||
+        hostname.startsWith('10.0.') ||
+        hostname.endsWith('.local') ||
+        hostname.endsWith('.internal')
+    )
+}
+
+// Extracted from lib/DDG/Util/Constants.pm
+const tldrs = /\.(?:c(?:o(?:m|op)?|at?|[iykgdmnxruhcfzvl])|o(?:rg|m)|n(?:et?|a(?:me)?|[ucgozrfpil])|e(?:d?u|[gechstr])|i(?:n(?:t|fo)?|[stqldroem])|m(?:o(?:bi)?|u(?:seum)?|i?l|[mcyvtsqhaerngxzfpwkd])|g(?:ov|[glqeriabtshdfmuywnp])|b(?:iz?|[drovfhtaywmzjsgbenl])|t(?:r(?:avel)?|[ncmfzdvkopthjwg]|e?l)|k[iemygznhwrp]|s[jtvberindlucygkhaozm]|u[gymszka]|h[nmutkr]|r[owesu]|d[kmzoej]|a(?:e(?:ro)?|r(?:pa)?|[qofiumsgzlwcnxdt])|p(?:ro?|[sgnthfymakwle])|v[aegiucn]|l[sayuvikcbrt]|j(?:o(?:bs)?|[mep])|w[fs]|z[amw]|f[rijkom]|y[eut]|qa)$/i
+/**
+ * Check if hostname is a valid top-level domain
+ * @param {string} [hostname]
+ * @returns {boolean}
+ */
+function isValidTLD (hostname = window.location.hostname) {
+    return tldrs.test(hostname)
+}
+
 export {
     notifyWebApp,
     sendAndWaitForAnswer,
@@ -370,5 +397,7 @@ export {
     escapeXML,
     isLikelyASubmitButton,
     buttonMatchesFormType,
-    getText
+    getText,
+    isLocalNetwork,
+    isValidTLD
 }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8068,7 +8068,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
       return TOOLTIP_TYPES.EmailProtection;
     }
 
-    if (this.settings.featureToggles.emailProtection_incontext_signup && ((_this$inContextSignup = this.inContextSignup) === null || _this$inContextSignup === void 0 ? void 0 : _this$inContextSignup.permanentlyDismissed) === false) {
+    if ((_this$inContextSignup = this.inContextSignup) !== null && _this$inContextSignup !== void 0 && _this$inContextSignup.isAvailable()) {
       return TOOLTIP_TYPES.EmailSignup;
     }
 
@@ -13656,24 +13656,45 @@ exports.InContextSignup = void 0;
 
 var _deviceApiCalls = require("./deviceApiCalls/__generated__/deviceApiCalls.js");
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+var _autofillUtils = require("./autofill-utils.js");
 
 class InContextSignup {
   /**
    * @param {import("./DeviceInterface/InterfacePrototype").default} device
    */
   constructor(device) {
-    _defineProperty(this, "permanentlyDismissed", false);
-
-    _defineProperty(this, "initiallyDismissed", false);
-
     this.device = device;
   }
 
   async init() {
+    await this.refreshData();
+  }
+
+  async refreshData() {
     const incontextSignupDismissedAt = await this.device.deviceApi.request(new _deviceApiCalls.GetIncontextSignupDismissedAtCall(null));
-    this.permanentlyDismissed = Boolean(incontextSignupDismissedAt.permanentlyDismissedAt);
-    this.initiallyDismissed = Boolean(incontextSignupDismissedAt.initiallyDismissedAt);
+    this.permanentlyDismissedAt = incontextSignupDismissedAt.permanentlyDismissedAt;
+    this.initiallyDismissedAt = incontextSignupDismissedAt.initiallyDismissedAt;
+  }
+
+  isPermanentlyDismissed() {
+    return Boolean(this.permanentlyDismissedAt);
+  }
+
+  isInitiallyDismissed() {
+    return Boolean(this.initiallyDismissedAt);
+  }
+
+  isOnValidDomain() {
+    // Only show in-context signup if we've high confidence that the page is
+    // not internally hosted or an intranet
+    return (0, _autofillUtils.isValidTLD)() && !(0, _autofillUtils.isLocalNetwork)();
+  }
+
+  isAvailable() {
+    var _this$device$settings;
+
+    const isEnabled = (_this$device$settings = this.device.settings) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.featureToggles.emailProtection_incontext_signup;
+    return isEnabled && !this.isPermanentlyDismissed() && this.isOnValidDomain();
   }
 
   onIncontextSignup() {
@@ -13686,19 +13707,19 @@ class InContextSignup {
     // Check if the email signup tooltip has previously been dismissed.
     // If it has, make the dismissal persist and remove it from the page.
     // If it hasn't, set a flag for next time and just hide the tooltip.
-    if (this.initiallyDismissed) {
-      this.permanentlyDismissed = true;
+    if (this.isInitiallyDismissed()) {
+      this.permanentlyDismissedAt = new Date().getTime();
       this.device.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupPermanentlyDismissedAtCall({
-        value: new Date().getTime()
+        value: this.permanentlyDismissedAt
       }));
       this.device.removeAutofillUIFromPage();
       this.device.firePixel({
         pixelName: 'incontext_dismiss_persisted'
       });
     } else {
-      this.initiallyDismissed = true;
+      this.initiallyDismissedAt = new Date().getTime();
       this.device.deviceApi.notify(new _deviceApiCalls.SetIncontextSignupInitiallyDismissedAtCall({
-        value: new Date().getTime()
+        value: this.initiallyDismissedAt
       }));
       this.device.removeTooltip();
       this.device.firePixel({
@@ -13711,7 +13732,7 @@ class InContextSignup {
 
 exports.InContextSignup = InContextSignup;
 
-},{"./deviceApiCalls/__generated__/deviceApiCalls.js":65}],45:[function(require,module,exports){
+},{"./autofill-utils.js":61,"./deviceApiCalls/__generated__/deviceApiCalls.js":65}],45:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14911,7 +14932,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
     var _device$inContextSign;
 
     this.device = device;
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat((_device$inContextSign = device.inContextSignup) !== null && _device$inContextSign !== void 0 && _device$inContextSign.initiallyDismissed ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\">\n    <div class=\"tooltip tooltip--email tooltip--email-signup\" hidden>\n        <h1>\n            Protect your inbox \uD83D\uDCAA I've caught trackers hiding in 85% of emails.\n        </h1>\n        <p>\n            Want me to hide your email address and remove hidden trackers before\n            forwarding messages to your inbox?\n        </p>\n        <div class=\"notice-controls\">\n            <a href=\"https://duckduckgo.com/email/start-incontext\" target=\"_blank\" class=\"primary js-get-email-signup\">\n                Get Email Protection\n            </a>\n            <button class=\"ghost js-dismiss-email-signup\">\n                ").concat((_device$inContextSign = device.inContextSignup) !== null && _device$inContextSign !== void 0 && _device$inContextSign.isInitiallyDismissed() ? "Don't Ask Again" : 'Maybe Later', "\n            </button>\n        </div>\n    </div>\n</div>");
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.dismissEmailSignup = this.shadow.querySelector('.js-dismiss-email-signup');
     this.registerClickableButton(this.dismissEmailSignup, () => {
@@ -16044,7 +16065,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.buttonMatchesFormType = exports.autofillEnabled = exports.addInlineStyles = exports.SIGN_IN_MSG = exports.ADDRESS_DOMAIN = void 0;
 exports.escapeXML = escapeXML;
-exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedConfig = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
+exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedConfig = exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = exports.getText = exports.getDaxBoundingBox = exports.formatDuckAddress = void 0;
+exports.isLocalNetwork = isLocalNetwork;
+exports.isValidTLD = isValidTLD;
+exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = exports.isVisible = void 0;
 
 var _matching = require("./Form/matching.js");
 
@@ -16475,8 +16499,32 @@ const getText = el => {
   if (el instanceof HTMLInputElement && ['submit', 'button'].includes(el.type)) return el.value;
   return (0, _matching.removeExcessWhitespace)(Array.from(el.childNodes).reduce((text, child) => child instanceof Text ? text + ' ' + child.textContent : text, ''));
 };
+/**
+ * Check if hostname is a local address
+ * @param {string} [hostname]
+ * @returns {boolean}
+ */
+
 
 exports.getText = getText;
+
+function isLocalNetwork() {
+  let hostname = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : window.location.hostname;
+  return ['localhost', '', '::1'].includes(hostname) || hostname.includes('127.0.0.1') || hostname.includes('192.168.') || hostname.startsWith('10.0.') || hostname.endsWith('.local') || hostname.endsWith('.internal');
+} // Extracted from lib/DDG/Util/Constants.pm
+
+
+const tldrs = /\.(?:c(?:o(?:m|op)?|at?|[iykgdmnxruhcfzvl])|o(?:rg|m)|n(?:et?|a(?:me)?|[ucgozrfpil])|e(?:d?u|[gechstr])|i(?:n(?:t|fo)?|[stqldroem])|m(?:o(?:bi)?|u(?:seum)?|i?l|[mcyvtsqhaerngxzfpwkd])|g(?:ov|[glqeriabtshdfmuywnp])|b(?:iz?|[drovfhtaywmzjsgbenl])|t(?:r(?:avel)?|[ncmfzdvkopthjwg]|e?l)|k[iemygznhwrp]|s[jtvberindlucygkhaozm]|u[gymszka]|h[nmutkr]|r[owesu]|d[kmzoej]|a(?:e(?:ro)?|r(?:pa)?|[qofiumsgzlwcnxdt])|p(?:ro?|[sgnthfymakwle])|v[aegiucn]|l[sayuvikcbrt]|j(?:o(?:bs)?|[mep])|w[fs]|z[amw]|f[rijkom]|y[eut]|qa)$/i;
+/**
+ * Check if hostname is a valid top-level domain
+ * @param {string} [hostname]
+ * @returns {boolean}
+ */
+
+function isValidTLD() {
+  let hostname = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : window.location.hostname;
+  return tldrs.test(hostname);
+}
 
 },{"./Form/matching.js":41}],62:[function(require,module,exports){
 "use strict";


### PR DESCRIPTION
**Reviewer:** @shakyShane @GioSensation 
**Asana:** https://app.asana.com/0/0/1204038361216231/f

## Description
Restrict in-context signup from running on local pages with valid TLD. This branch also updates the in-context signup tests to run on a real domain, mocked in puppeteer.

## Steps to test
1. Build update into extension
2. Run local server and go to `email-autofill.html` integration test file
3. Confirm that in-context signup does not display
4. Go to https://duckduckgo.com/newsletter
5. Confirm that in-context signup does display
