### PR TITLE
Don't open in-context signup on input click

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10142,9 +10142,13 @@ class Form {
   }
 
   shouldOpenTooltip(e, input) {
+    var _this$device$inContex;
+
     if (this.device.globalConfig.isApp) return true;
     if (this.device.globalConfig.isWindows) return true;
-    return !this.touched.has(input) && !input.classList.contains('ddg-autofilled') || (0, _autofillUtils.isEventWithinDax)(e, input);
+    if ((0, _autofillUtils.isEventWithinDax)(e, input)) return true;
+    if ((_this$device$inContex = this.device.inContextSignup) !== null && _this$device$inContex !== void 0 && _this$device$inContex.isAvailable()) return false;
+    return !this.touched.has(input) && !input.classList.contains('ddg-autofilled');
   }
 
   autofillInput(input, string, dataType) {
@@ -13719,7 +13723,8 @@ class InContextSignup {
     var _this$device$settings;
 
     const isEnabled = (_this$device$settings = this.device.settings) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.featureToggles.emailProtection_incontext_signup;
-    return isEnabled && !this.isPermanentlyDismissed() && this.isOnValidDomain();
+    const isLoggedIn = this.device.isDeviceSignedIn();
+    return isEnabled && !isLoggedIn && !this.isPermanentlyDismissed() && this.isOnValidDomain();
   }
 
   onIncontextSignup() {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6466,9 +6466,13 @@ class Form {
   }
 
   shouldOpenTooltip(e, input) {
+    var _this$device$inContex;
+
     if (this.device.globalConfig.isApp) return true;
     if (this.device.globalConfig.isWindows) return true;
-    return !this.touched.has(input) && !input.classList.contains('ddg-autofilled') || (0, _autofillUtils.isEventWithinDax)(e, input);
+    if ((0, _autofillUtils.isEventWithinDax)(e, input)) return true;
+    if ((_this$device$inContex = this.device.inContextSignup) !== null && _this$device$inContex !== void 0 && _this$device$inContex.isAvailable()) return false;
+    return !this.touched.has(input) && !input.classList.contains('ddg-autofilled');
   }
 
   autofillInput(input, string, dataType) {
@@ -10043,7 +10047,8 @@ class InContextSignup {
     var _this$device$settings;
 
     const isEnabled = (_this$device$settings = this.device.settings) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.featureToggles.emailProtection_incontext_signup;
-    return isEnabled && !this.isPermanentlyDismissed() && this.isOnValidDomain();
+    const isLoggedIn = this.device.isDeviceSignedIn();
+    return isEnabled && !isLoggedIn && !this.isPermanentlyDismissed() && this.isOnValidDomain();
   }
 
   onIncontextSignup() {

--- a/integration-test/tests/incontext-signup.extension.spec.js
+++ b/integration-test/tests/incontext-signup.extension.spec.js
@@ -19,7 +19,12 @@ test.describe('chrome extension', () => {
         await emailPage.navigate('https://example.com')
         const newPageOpening = new Promise(resolve => context.once('page', resolve))
 
+        // Confirm tooltip hidden after clicking the input
         await emailPage.clickIntoInput()
+        await incontextSignup.assertIsHidden()
+
+        // Confirm tooltip shows after clicking the Dax icon
+        await emailPage.clickDirectlyOnDax()
         await incontextSignup.assertIsShowing()
         await incontextSignup.getEmailProtection()
 
@@ -41,7 +46,7 @@ test.describe('chrome extension', () => {
         await emailPage.navigate('https://example.com')
 
         // Hide tooltip
-        await emailPage.clickIntoInput()
+        await emailPage.clickDirectlyOnDax()
         await incontextSignup.assertIsShowing()
         await incontextSignup.dismissTooltipWith('Maybe Later')
 

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -457,8 +457,10 @@ class Form {
     shouldOpenTooltip (e, input) {
         if (this.device.globalConfig.isApp) return true
         if (this.device.globalConfig.isWindows) return true
+        if (isEventWithinDax(e, input)) return true
+        if (this.device.inContextSignup?.isAvailable()) return false
 
-        return (!this.touched.has(input) && !input.classList.contains('ddg-autofilled')) || isEventWithinDax(e, input)
+        return (!this.touched.has(input) && !input.classList.contains('ddg-autofilled'))
     }
 
     autofillInput (input, string, dataType) {

--- a/src/InContextSignup.js
+++ b/src/InContextSignup.js
@@ -39,7 +39,8 @@ export class InContextSignup {
 
     isAvailable () {
         const isEnabled = this.device.settings?.featureToggles.emailProtection_incontext_signup
-        return isEnabled && !this.isPermanentlyDismissed() && this.isOnValidDomain()
+        const isLoggedIn = this.device.isDeviceSignedIn()
+        return isEnabled && !isLoggedIn && !this.isPermanentlyDismissed() && this.isOnValidDomain()
     }
 
     onIncontextSignup () {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10142,9 +10142,13 @@ class Form {
   }
 
   shouldOpenTooltip(e, input) {
+    var _this$device$inContex;
+
     if (this.device.globalConfig.isApp) return true;
     if (this.device.globalConfig.isWindows) return true;
-    return !this.touched.has(input) && !input.classList.contains('ddg-autofilled') || (0, _autofillUtils.isEventWithinDax)(e, input);
+    if ((0, _autofillUtils.isEventWithinDax)(e, input)) return true;
+    if ((_this$device$inContex = this.device.inContextSignup) !== null && _this$device$inContex !== void 0 && _this$device$inContex.isAvailable()) return false;
+    return !this.touched.has(input) && !input.classList.contains('ddg-autofilled');
   }
 
   autofillInput(input, string, dataType) {
@@ -13719,7 +13723,8 @@ class InContextSignup {
     var _this$device$settings;
 
     const isEnabled = (_this$device$settings = this.device.settings) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.featureToggles.emailProtection_incontext_signup;
-    return isEnabled && !this.isPermanentlyDismissed() && this.isOnValidDomain();
+    const isLoggedIn = this.device.isDeviceSignedIn();
+    return isEnabled && !isLoggedIn && !this.isPermanentlyDismissed() && this.isOnValidDomain();
   }
 
   onIncontextSignup() {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6466,9 +6466,13 @@ class Form {
   }
 
   shouldOpenTooltip(e, input) {
+    var _this$device$inContex;
+
     if (this.device.globalConfig.isApp) return true;
     if (this.device.globalConfig.isWindows) return true;
-    return !this.touched.has(input) && !input.classList.contains('ddg-autofilled') || (0, _autofillUtils.isEventWithinDax)(e, input);
+    if ((0, _autofillUtils.isEventWithinDax)(e, input)) return true;
+    if ((_this$device$inContex = this.device.inContextSignup) !== null && _this$device$inContex !== void 0 && _this$device$inContex.isAvailable()) return false;
+    return !this.touched.has(input) && !input.classList.contains('ddg-autofilled');
   }
 
   autofillInput(input, string, dataType) {
@@ -10043,7 +10047,8 @@ class InContextSignup {
     var _this$device$settings;
 
     const isEnabled = (_this$device$settings = this.device.settings) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.featureToggles.emailProtection_incontext_signup;
-    return isEnabled && !this.isPermanentlyDismissed() && this.isOnValidDomain();
+    const isLoggedIn = this.device.isDeviceSignedIn();
+    return isEnabled && !isLoggedIn && !this.isPermanentlyDismissed() && this.isOnValidDomain();
   }
 
   onIncontextSignup() {


### PR DESCRIPTION
**Reviewer:** @shakyShane @GioSensation 
**Asana:** https://app.asana.com/0/0/1204038361216229/f

## Description
Use in-context signup `isAvailable` check to prevent tooltip from opening on input click

## Steps to test
1. Build into extension
2. Go to https://duckduckgo.com/newsletter
3. Click into input -- confirm tooltip does not show
4. Click Dax icon -- confirm tooltip does show