### PR TITLE
add windows release automation

### DIFF
--- a/.github/workflows/asana-release.yml
+++ b/.github/workflows/asana-release.yml
@@ -222,6 +222,44 @@ jobs:
           body: "${{ env.PR_BODY_EXTENSIONS }}"
           token: ${{ secrets.DAXMOBILE_AUTOFILL_AUTOMATION }}
 
+      - name: Checkout Windows
+        uses: actions/checkout@v3
+        with:
+          repository: duckduckgo/windows-browser
+          path: windows/
+          ref: develop
+          token: ${{ secrets.DAXMOBILE_AUTOFILL_AUTOMATION }}
+      - name: Update Windows autofill reference
+        run: |
+          cd windows/submodules/duckduckgo-autofill
+          git checkout ${{ github.event.release.tag_name }}
+          cd ../..
+      - name: Create Windows PR Body
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_NOTES: ${{ github.event.release.body }}
+          ASANA_OUTPUT: ${{ steps.create-asana-tasks.outputs.ASANA_OUTPUT }}
+        run: |
+          TEMPLATE="$(node ./autofill/scripts/release/create-pr-template.js windows)"
+          # Creates a randomised delimiter. See https://app.asana.com/0/1199892415909552/1203243297643584/f
+          DELIMITER=$(echo $RANDOM | md5sum | head -c 20;)
+          echo "PR_BODY_WINDOWS<<$DELIMITER" >> $GITHUB_ENV
+          echo "$TEMPLATE" >> $GITHUB_ENV
+          echo "$DELIMITER" >> $GITHUB_ENV
+      - name: Create PR for Windows
+        uses: peter-evans/create-pull-request@88bf0de51c7487d91e1abbb4899332e602c58bbf
+        id: windows-pr
+        with:
+          path: windows/
+          add-paths: |
+            submodules/duckduckgo-autofill
+          commit-message: Update autofill to ${{ github.event.release.tag_name }}
+          branch: update-autofill-${{ github.event.release.tag_name }}
+          title: Update autofill to ${{ github.event.release.tag_name }}
+          body: "${{ env.PR_BODY_WINDOWS }}"
+          token: ${{ secrets.DAXMOBILE_AUTOFILL_AUTOMATION }}
+
       - name: Update Asana tasks
         env:
           ASANA_ACCESS_TOKEN: ${{ secrets.NATIVE_APPS_WORKFLOW }}
@@ -233,6 +271,7 @@ jobs:
           IOS_PR_URL: ${{ steps.ios-pr.outputs.pull-request-url }}
           MACOS_PR_URL: ${{ steps.macos-pr.outputs.pull-request-url }}
           ANDROID_PR_URL: ${{ steps.android-pr.outputs.pull-request-url }}
+          WINDOWS_PR_URL: ${{ steps.windows-pr.outputs.pull-request-url }}
           EXTENSIONS_PR_URL: ${{ steps.extensions-pr.outputs.pull-request-url }}
         run:  node ./autofill/scripts/release/asana-update-tasks.js
 

--- a/scripts/release/asana-update-tasks.js
+++ b/scripts/release/asana-update-tasks.js
@@ -11,7 +11,8 @@ const prUrls = {
     bsk: process.env.BSK_PR_URL || 'error',
     ios: process.env.IOS_PR_URL || 'error',
     macos: process.env.MACOS_PR_URL || 'error',
-    extensions: process.env.EXTENSIONS_PR_URL || 'error'
+    extensions: process.env.EXTENSIONS_PR_URL || 'error',
+    windows: process.env.WINDOWS_PR_URL || 'error'
 }
 const asanaOutputRaw = process.env.ASANA_OUTPUT || '{}'
 const asanaOutput = JSON.parse(asanaOutputRaw)


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1198964220583541/1203788037949098/f

## Description

Adds windows be part of the release automation.
- Checkout Windows became part of the GH action: bumping the autofill dependency is updating the sub module within the windows repository.
- Create Windows PR Body became part of the GH action
- Create PR for Windows became part of the GH action: scripts/release/asana-update-tasks.js now expects `process.env.WINDOWS_PR_URL` to be present
- Added the [windows release template](https://app.asana.com/0/0/1204153276804943/f) as part of the autofill release template