### PR TITLE
Fix username not saved

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -9171,7 +9171,7 @@ class InterfacePrototype {
       }
     }
 
-    if (dataType === 'credentials' && this.settings.globalConfig.isMobileApp) {
+    if (dataType === 'credentials' && formObj.shouldAutoSubmit) {
       formObj.attemptSubmissionIfNeeded();
     }
   }
@@ -9722,6 +9722,7 @@ class Form {
     this.isAutofilling = false;
     this.handlerExecuted = false;
     this.shouldPromptToStoreData = true;
+    this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     /**
      * @type {IntersectionObserver | null}
      */
@@ -10219,7 +10220,7 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false; // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+    this.isAutofilling = false; // After autofill we check if form values match the data provided
 
     const formValues = this.getValues();
     const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
@@ -10229,7 +10230,11 @@ class Form {
     });
 
     if (areAllFormValuesKnown) {
+      // If we know all the values do not prompt to store data
       this.shouldPromptToStoreData = false;
+    } else {
+      // Otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      this.shouldAutoSubmit = false;
     }
 
     (_this$device$postAuto = (_this$device2 = this.device).postAutofill) === null || _this$device$postAuto === void 0 ? void 0 : _this$device$postAuto.call(_this$device2, data, dataType, this);

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -9823,7 +9823,9 @@ class Form {
         this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
           var _elText$match;
 
-          const elText = (0, _autofillUtils.getText)(el);
+          const elText = (0, _autofillUtils.getText)(el); // Ignore long texts to avoid false positives
+
+          if (elText.length > 70) return;
           const emailOrUsername = (_elText$match = elText.match( // https://www.emailregex.com/
           /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/)) === null || _elText$match === void 0 ? void 0 : _elText$match[0];
 
@@ -9879,9 +9881,9 @@ class Form {
 
   removeAllHighlights(e, dataType) {
     // This ensures we are not removing the highlight ourselves when autofilling more than once
-    if (e && !e.isTrusted) return; // If the user has changed the value, we prompt to update the stored creds
+    if (e && !e.isTrusted) return; // If the user has changed the value, we prompt to update the stored data
 
-    this.shouldPromptToStoreCredentials = true;
+    this.shouldPromptToStoreData = true;
     this.execOnInputs(input => this.removeInputHighlight(input), dataType);
   }
 
@@ -10198,7 +10200,6 @@ class Form {
   autofillData(data, dataType) {
     var _this$device$postAuto, _this$device2;
 
-    this.shouldPromptToStoreData = false;
     this.isAutofilling = true;
     this.execOnInputs(input => {
       const inputSubtype = (0, _matching.getInputSubtype)(input);
@@ -10218,7 +10219,19 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false;
+    this.isAutofilling = false; // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+
+    const formValues = this.getValues();
+    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
+      var _formValues$dataType;
+
+      return ((_formValues$dataType = formValues[dataType]) === null || _formValues$dataType === void 0 ? void 0 : _formValues$dataType[subtype]) === data[subtype];
+    });
+
+    if (areAllFormValuesKnown) {
+      this.shouldPromptToStoreData = false;
+    }
+
     (_this$device$postAuto = (_this$device2 = this.device).postAutofill) === null || _this$device$postAuto === void 0 ? void 0 : _this$device$postAuto.call(_this$device2, data, dataType, this);
     this.removeTooltip();
   }

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10220,7 +10220,7 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false; // After autofill we check if form values match the data provided
+    this.isAutofilling = false; // After autofill we check if form values match the data provided…
 
     const formValues = this.getValues();
     const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
@@ -10230,10 +10230,10 @@ class Form {
     });
 
     if (areAllFormValuesKnown) {
-      // If we know all the values do not prompt to store data
+      // …if we know all the values do not prompt to store data
       this.shouldPromptToStoreData = false;
     } else {
-      // Otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;
     }
 

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10223,15 +10223,13 @@ class Form {
     this.isAutofilling = false; // After autofill we check if form values match the data provided…
 
     const formValues = this.getValues();
-    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
-      var _formValues$dataType;
-
-      return ((_formValues$dataType = formValues[dataType]) === null || _formValues$dataType === void 0 ? void 0 : _formValues$dataType[subtype]) === data[subtype];
-    });
+    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => formValues[dataType][subtype] === data[subtype]);
 
     if (areAllFormValuesKnown) {
       // …if we know all the values do not prompt to store data
-      this.shouldPromptToStoreData = false;
+      this.shouldPromptToStoreData = false; // reset this to its initial value
+
+      this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     } else {
       // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6147,7 +6147,9 @@ class Form {
         this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
           var _elText$match;
 
-          const elText = (0, _autofillUtils.getText)(el);
+          const elText = (0, _autofillUtils.getText)(el); // Ignore long texts to avoid false positives
+
+          if (elText.length > 70) return;
           const emailOrUsername = (_elText$match = elText.match( // https://www.emailregex.com/
           /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/)) === null || _elText$match === void 0 ? void 0 : _elText$match[0];
 
@@ -6203,9 +6205,9 @@ class Form {
 
   removeAllHighlights(e, dataType) {
     // This ensures we are not removing the highlight ourselves when autofilling more than once
-    if (e && !e.isTrusted) return; // If the user has changed the value, we prompt to update the stored creds
+    if (e && !e.isTrusted) return; // If the user has changed the value, we prompt to update the stored data
 
-    this.shouldPromptToStoreCredentials = true;
+    this.shouldPromptToStoreData = true;
     this.execOnInputs(input => this.removeInputHighlight(input), dataType);
   }
 
@@ -6522,7 +6524,6 @@ class Form {
   autofillData(data, dataType) {
     var _this$device$postAuto, _this$device2;
 
-    this.shouldPromptToStoreData = false;
     this.isAutofilling = true;
     this.execOnInputs(input => {
       const inputSubtype = (0, _matching.getInputSubtype)(input);
@@ -6542,7 +6543,19 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false;
+    this.isAutofilling = false; // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+
+    const formValues = this.getValues();
+    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
+      var _formValues$dataType;
+
+      return ((_formValues$dataType = formValues[dataType]) === null || _formValues$dataType === void 0 ? void 0 : _formValues$dataType[subtype]) === data[subtype];
+    });
+
+    if (areAllFormValuesKnown) {
+      this.shouldPromptToStoreData = false;
+    }
+
     (_this$device$postAuto = (_this$device2 = this.device).postAutofill) === null || _this$device$postAuto === void 0 ? void 0 : _this$device$postAuto.call(_this$device2, data, dataType, this);
     this.removeTooltip();
   }

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6547,15 +6547,13 @@ class Form {
     this.isAutofilling = false; // After autofill we check if form values match the data provided…
 
     const formValues = this.getValues();
-    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
-      var _formValues$dataType;
-
-      return ((_formValues$dataType = formValues[dataType]) === null || _formValues$dataType === void 0 ? void 0 : _formValues$dataType[subtype]) === data[subtype];
-    });
+    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => formValues[dataType][subtype] === data[subtype]);
 
     if (areAllFormValuesKnown) {
       // …if we know all the values do not prompt to store data
-      this.shouldPromptToStoreData = false;
+      this.shouldPromptToStoreData = false; // reset this to its initial value
+
+      this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     } else {
       // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6544,7 +6544,7 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false; // After autofill we check if form values match the data provided
+    this.isAutofilling = false; // After autofill we check if form values match the data provided…
 
     const formValues = this.getValues();
     const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
@@ -6554,10 +6554,10 @@ class Form {
     });
 
     if (areAllFormValuesKnown) {
-      // If we know all the values do not prompt to store data
+      // …if we know all the values do not prompt to store data
       this.shouldPromptToStoreData = false;
     } else {
-      // Otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;
     }
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -5495,7 +5495,7 @@ class InterfacePrototype {
       }
     }
 
-    if (dataType === 'credentials' && this.settings.globalConfig.isMobileApp) {
+    if (dataType === 'credentials' && formObj.shouldAutoSubmit) {
       formObj.attemptSubmissionIfNeeded();
     }
   }
@@ -6046,6 +6046,7 @@ class Form {
     this.isAutofilling = false;
     this.handlerExecuted = false;
     this.shouldPromptToStoreData = true;
+    this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     /**
      * @type {IntersectionObserver | null}
      */
@@ -6543,7 +6544,7 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false; // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+    this.isAutofilling = false; // After autofill we check if form values match the data provided
 
     const formValues = this.getValues();
     const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
@@ -6553,7 +6554,11 @@ class Form {
     });
 
     if (areAllFormValuesKnown) {
+      // If we know all the values do not prompt to store data
       this.shouldPromptToStoreData = false;
+    } else {
+      // Otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      this.shouldAutoSubmit = false;
     }
 
     (_this$device$postAuto = (_this$device2 = this.device).postAutofill) === null || _this$device$postAuto === void 0 ? void 0 : _this$device$postAuto.call(_this$device2, data, dataType, this);

--- a/integration-test/helpers/mocks.android.js
+++ b/integration-test/helpers/mocks.android.js
@@ -46,7 +46,7 @@ export function androidStringReplacements (overrides = {}) {
                             emailProtection: true,
                             password_generation: false,
                             credentials_saving: true,
-                            inlineIcon_credentials: false,
+                            inlineIcon_credentials: true,
                             ...overrides.featureToggles
                         }
                     }

--- a/integration-test/helpers/mocks.webkit.js
+++ b/integration-test/helpers/mocks.webkit.js
@@ -36,7 +36,7 @@ export const iosContentScopeReplacements = (overrides = {}) => {
                 autofill: {
                     settings: {
                         featureToggles: {
-                            inlineIcon_credentials: false,
+                            inlineIcon_credentials: true,
                             ...overrides.featureToggles
                         }
                     }

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -191,6 +191,9 @@ export function loginPage (page, server, opts = {}) {
             // click the input field (not within Dax icon)
             await usernameField.click()
         },
+        async typeIntoUsernameInput (username) {
+            await page.type('#email', username)
+        },
         async clickIntoPasswordInput () {
             const passwordField = page.locator('#password').first()
             // click the input field (not within Dax icon)
@@ -351,6 +354,9 @@ export function loginPage (page, server, opts = {}) {
         async submitLoginForm (data) {
             await page.type('#password', data.password)
             await page.type('#email', data.username)
+            await page.click('#login button[type="submit"]')
+        },
+        async submitFormAsIs () {
             await page.click('#login button[type="submit"]')
         },
         /** @param {Platform} platform */

--- a/integration-test/pages/login-with-text.html
+++ b/integration-test/pages/login-with-text.html
@@ -33,6 +33,7 @@
   [...document.forms].forEach((form) => {
     form.addEventListener("submit", (e) => {
       e.preventDefault();
+      setTimeout(() => form.innerHTML = '<h1>Submitted!</h1>', 100)
     })
   })
 </script>

--- a/integration-test/pages/login-with-text.html
+++ b/integration-test/pages/login-with-text.html
@@ -33,7 +33,9 @@
   [...document.forms].forEach((form) => {
     form.addEventListener("submit", (e) => {
       e.preventDefault();
-      setTimeout(() => form.innerHTML = '<h1>Submitted!</h1>', 100)
+      const submittedMsg = document.createElement('h1')
+      submittedMsg.innerText = 'Submitted!'
+      setTimeout(() => form.append(submittedMsg), 100)
     })
   })
 </script>

--- a/integration-test/tests/login-form.android.spec.js
+++ b/integration-test/tests/login-form.android.spec.js
@@ -101,8 +101,8 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                 })
                 await login.fieldsContainIcons()
                 await login.clickIntoUsernameInput()
-                await login.promptWasShown()
                 await login.assertFirstCredential(personalAddress, password)
+                await login.promptWasShown()
             })
             test('I should not be prompted automatically to use my saved credentials if the form is below the fold', async ({page}) => {
                 const {login} = await testLoginPage(page, server, {
@@ -112,7 +112,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                     credentials,
                     pageType: 'withExtraText'
                 })
-                await login.fieldsDoNotContainIcons()
+                await login.fieldsContainIcons()
                 await login.promptWasNotShown()
                 await login.clickIntoUsernameInput()
                 await login.assertFirstCredential(personalAddress, password)
@@ -133,7 +133,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                 await login.clickIntoUsernameInput()
                 await login.assertFormSubmitted()
             })
-            test.only('should prompt to store and not autosubmit when the form completes a partial credential stored', async ({page}) => {
+            test('should prompt to store and not autosubmit when the form completes a partial credential stored', async ({page}) => {
                 const {login} = await testLoginPage(page, server, {
                     featureToggles: {
                         inputType_credentials: true,

--- a/integration-test/tests/login-form.android.spec.js
+++ b/integration-test/tests/login-form.android.spec.js
@@ -88,7 +88,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                     credentials
                 })
                 await login.promptWasShown()
-                await login.fieldsDoNotContainIcons()
+                await login.fieldsContainIcons()
                 await login.assertFirstCredential(personalAddress, password)
             })
             test('I should be prompted to use my saved credentials when clicking the field even if the form was below the fold', async ({page}) => {
@@ -99,7 +99,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                     credentials,
                     pageType: 'withExtraText'
                 })
-                await login.fieldsDoNotContainIcons()
+                await login.fieldsContainIcons()
                 await login.clickIntoUsernameInput()
                 await login.promptWasShown()
                 await login.assertFirstCredential(personalAddress, password)
@@ -128,10 +128,36 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                 await login.promptWasNotShown()
                 await login.assertDialogClose()
                 await login.openDialog()
-                await login.fieldsDoNotContainIcons()
+                await login.fieldsContainIcons()
 
                 await login.clickIntoUsernameInput()
                 await login.assertFormSubmitted()
+            })
+            test.only('should prompt to store and not autosubmit when the form completes a partial credential stored', async ({page}) => {
+                const {login} = await testLoginPage(page, server, {
+                    featureToggles: {
+                        inputType_credentials: true,
+                        inlineIcon_credentials: true,
+                        credentials_saving: true
+                    },
+                    availableInputTypes: {credentials: {password: true, username: false}},
+                    credentials: {
+                        ...credentials,
+                        username: ''
+                    },
+                    pageType: 'withExtraText'
+                })
+
+                const {username, password} = credentials
+
+                await login.onlyPasswordFieldHasIcon()
+
+                await login.typeIntoUsernameInput(username)
+
+                await login.clickIntoPasswordInput()
+                await login.assertPasswordFilled(password)
+                await login.assertFormNotSubmittedAutomatically()
+                await login.assertWasPromptedToSave({username, password}, 'android')
             })
         })
         test.describe('but I dont have saved credentials', () => {

--- a/integration-test/tests/login-form.ios.spec.js
+++ b/integration-test/tests/login-form.ios.spec.js
@@ -94,7 +94,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                 })
                 await login.promptWasShown('ios')
                 await login.assertFirstCredential(personalAddress, password)
-                await login.fieldsDoNotContainIcons()
+                await login.fieldsContainIcons()
             })
             test('I should not be prompted automatically to use my saved credentials if the form is below the fold', async ({page}) => {
                 const {login} = await testLoginPage(page, server, {
@@ -105,7 +105,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                     pageType: 'withExtraText'
                 })
                 await login.promptWasNotShown()
-                await login.fieldsDoNotContainIcons()
+                await login.fieldsContainIcons()
 
                 await login.clickIntoUsernameInput()
                 await login.assertFirstCredential(personalAddress, password)
@@ -118,7 +118,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                     credentials,
                     pageType: 'covered'
                 })
-                await login.fieldsDoNotContainIcons()
+                await login.fieldsContainIcons()
                 await login.promptWasNotShown()
                 await login.closeCookieDialog()
 
@@ -151,10 +151,36 @@ test.describe('Auto-fill a login form on iOS', () => {
                 await login.promptWasNotShown()
                 await login.assertDialogClose()
                 await login.openDialog()
-                await login.fieldsDoNotContainIcons()
+                await login.fieldsContainIcons()
 
                 await login.clickIntoUsernameInput()
                 await login.assertFormSubmitted()
+            })
+            test('should prompt to store and not autosubmit when the form completes a partial credential stored', async ({page}) => {
+                const {login} = await testLoginPage(page, server, {
+                    featureToggles: {
+                        inputType_credentials: true,
+                        inlineIcon_credentials: true,
+                        credentials_saving: true
+                    },
+                    availableInputTypes: {credentials: {password: true, username: false}},
+                    credentials: {
+                        ...credentials,
+                        username: ''
+                    },
+                    pageType: 'withExtraText'
+                })
+
+                const {username, password} = credentials
+
+                await login.onlyPasswordFieldHasIcon()
+
+                await login.typeIntoUsernameInput(username)
+
+                await login.clickIntoPasswordInput()
+                await login.assertPasswordFilled(password)
+                await login.assertFormNotSubmittedAutomatically()
+                await login.assertWasPromptedToSave({username, password}, 'ios')
             })
         })
         test.describe('but I dont have saved credentials', () => {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,7 +27,7 @@ const config = {
     /* Retry on CI only */
     retries: process.env.CI ? 5 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : 6,
+    workers: process.env.CI ? 1 : 10,
     // workers: 1,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: process.env.CI ? 'github' : [ ['html', { open: 'never' }] ],

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,7 +27,7 @@ const config = {
     /* Retry on CI only */
     retries: process.env.CI ? 5 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : 10,
+    workers: process.env.CI ? 1 : 6,
     // workers: 1,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: process.env.CI ? 'github' : [ ['html', { open: 'never' }] ],

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -723,7 +723,7 @@ class InterfacePrototype {
             }
         }
 
-        if (dataType === 'credentials' && this.settings.globalConfig.isMobileApp) {
+        if (dataType === 'credentials' && formObj.shouldAutoSubmit) {
             formObj.attemptSubmissionIfNeeded()
         }
     }

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -544,12 +544,13 @@ class Form {
 
         // After autofill we check if form values match the data provided…
         const formValues = this.getValues()
-        const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every((subtype) => {
-            return formValues[dataType]?.[subtype] === data[subtype]
-        })
+        const areAllFormValuesKnown = Object.keys(formValues[dataType] || {})
+            .every((subtype) => formValues[dataType][subtype] === data[subtype])
         if (areAllFormValuesKnown) {
             // …if we know all the values do not prompt to store data
             this.shouldPromptToStoreData = false
+            // reset this to its initial value
+            this.shouldAutoSubmit = this.device.globalConfig.isMobileApp
         } else {
             // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
             this.shouldAutoSubmit = false

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -66,6 +66,7 @@ class Form {
         this.isAutofilling = false
         this.handlerExecuted = false
         this.shouldPromptToStoreData = true
+        this.shouldAutoSubmit = this.device.globalConfig.isMobileApp
 
         /**
          * @type {IntersectionObserver | null}
@@ -541,13 +542,17 @@ class Form {
 
         this.isAutofilling = false
 
-        // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+        // After autofill we check if form values match the data provided…
         const formValues = this.getValues()
         const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every((subtype) => {
             return formValues[dataType]?.[subtype] === data[subtype]
         })
         if (areAllFormValuesKnown) {
+            // …if we know all the values do not prompt to store data
             this.shouldPromptToStoreData = false
+        } else {
+            // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
+            this.shouldAutoSubmit = false
         }
 
         this.device.postAutofill?.(data, dataType, this)

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -9171,7 +9171,7 @@ class InterfacePrototype {
       }
     }
 
-    if (dataType === 'credentials' && this.settings.globalConfig.isMobileApp) {
+    if (dataType === 'credentials' && formObj.shouldAutoSubmit) {
       formObj.attemptSubmissionIfNeeded();
     }
   }
@@ -9722,6 +9722,7 @@ class Form {
     this.isAutofilling = false;
     this.handlerExecuted = false;
     this.shouldPromptToStoreData = true;
+    this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     /**
      * @type {IntersectionObserver | null}
      */
@@ -10219,7 +10220,7 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false; // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+    this.isAutofilling = false; // After autofill we check if form values match the data provided
 
     const formValues = this.getValues();
     const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
@@ -10229,7 +10230,11 @@ class Form {
     });
 
     if (areAllFormValuesKnown) {
+      // If we know all the values do not prompt to store data
       this.shouldPromptToStoreData = false;
+    } else {
+      // Otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      this.shouldAutoSubmit = false;
     }
 
     (_this$device$postAuto = (_this$device2 = this.device).postAutofill) === null || _this$device$postAuto === void 0 ? void 0 : _this$device$postAuto.call(_this$device2, data, dataType, this);

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -9823,7 +9823,9 @@ class Form {
         this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
           var _elText$match;
 
-          const elText = (0, _autofillUtils.getText)(el);
+          const elText = (0, _autofillUtils.getText)(el); // Ignore long texts to avoid false positives
+
+          if (elText.length > 70) return;
           const emailOrUsername = (_elText$match = elText.match( // https://www.emailregex.com/
           /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/)) === null || _elText$match === void 0 ? void 0 : _elText$match[0];
 
@@ -9879,9 +9881,9 @@ class Form {
 
   removeAllHighlights(e, dataType) {
     // This ensures we are not removing the highlight ourselves when autofilling more than once
-    if (e && !e.isTrusted) return; // If the user has changed the value, we prompt to update the stored creds
+    if (e && !e.isTrusted) return; // If the user has changed the value, we prompt to update the stored data
 
-    this.shouldPromptToStoreCredentials = true;
+    this.shouldPromptToStoreData = true;
     this.execOnInputs(input => this.removeInputHighlight(input), dataType);
   }
 
@@ -10198,7 +10200,6 @@ class Form {
   autofillData(data, dataType) {
     var _this$device$postAuto, _this$device2;
 
-    this.shouldPromptToStoreData = false;
     this.isAutofilling = true;
     this.execOnInputs(input => {
       const inputSubtype = (0, _matching.getInputSubtype)(input);
@@ -10218,7 +10219,19 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false;
+    this.isAutofilling = false; // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+
+    const formValues = this.getValues();
+    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
+      var _formValues$dataType;
+
+      return ((_formValues$dataType = formValues[dataType]) === null || _formValues$dataType === void 0 ? void 0 : _formValues$dataType[subtype]) === data[subtype];
+    });
+
+    if (areAllFormValuesKnown) {
+      this.shouldPromptToStoreData = false;
+    }
+
     (_this$device$postAuto = (_this$device2 = this.device).postAutofill) === null || _this$device$postAuto === void 0 ? void 0 : _this$device$postAuto.call(_this$device2, data, dataType, this);
     this.removeTooltip();
   }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10220,7 +10220,7 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false; // After autofill we check if form values match the data provided
+    this.isAutofilling = false; // After autofill we check if form values match the data provided…
 
     const formValues = this.getValues();
     const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
@@ -10230,10 +10230,10 @@ class Form {
     });
 
     if (areAllFormValuesKnown) {
-      // If we know all the values do not prompt to store data
+      // …if we know all the values do not prompt to store data
       this.shouldPromptToStoreData = false;
     } else {
-      // Otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;
     }
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10223,15 +10223,13 @@ class Form {
     this.isAutofilling = false; // After autofill we check if form values match the data provided…
 
     const formValues = this.getValues();
-    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
-      var _formValues$dataType;
-
-      return ((_formValues$dataType = formValues[dataType]) === null || _formValues$dataType === void 0 ? void 0 : _formValues$dataType[subtype]) === data[subtype];
-    });
+    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => formValues[dataType][subtype] === data[subtype]);
 
     if (areAllFormValuesKnown) {
       // …if we know all the values do not prompt to store data
-      this.shouldPromptToStoreData = false;
+      this.shouldPromptToStoreData = false; // reset this to its initial value
+
+      this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     } else {
       // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6147,7 +6147,9 @@ class Form {
         this.form.querySelectorAll('*:not(select):not(option)').forEach(el => {
           var _elText$match;
 
-          const elText = (0, _autofillUtils.getText)(el);
+          const elText = (0, _autofillUtils.getText)(el); // Ignore long texts to avoid false positives
+
+          if (elText.length > 70) return;
           const emailOrUsername = (_elText$match = elText.match( // https://www.emailregex.com/
           /[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*/)) === null || _elText$match === void 0 ? void 0 : _elText$match[0];
 
@@ -6203,9 +6205,9 @@ class Form {
 
   removeAllHighlights(e, dataType) {
     // This ensures we are not removing the highlight ourselves when autofilling more than once
-    if (e && !e.isTrusted) return; // If the user has changed the value, we prompt to update the stored creds
+    if (e && !e.isTrusted) return; // If the user has changed the value, we prompt to update the stored data
 
-    this.shouldPromptToStoreCredentials = true;
+    this.shouldPromptToStoreData = true;
     this.execOnInputs(input => this.removeInputHighlight(input), dataType);
   }
 
@@ -6522,7 +6524,6 @@ class Form {
   autofillData(data, dataType) {
     var _this$device$postAuto, _this$device2;
 
-    this.shouldPromptToStoreData = false;
     this.isAutofilling = true;
     this.execOnInputs(input => {
       const inputSubtype = (0, _matching.getInputSubtype)(input);
@@ -6542,7 +6543,19 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false;
+    this.isAutofilling = false; // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+
+    const formValues = this.getValues();
+    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
+      var _formValues$dataType;
+
+      return ((_formValues$dataType = formValues[dataType]) === null || _formValues$dataType === void 0 ? void 0 : _formValues$dataType[subtype]) === data[subtype];
+    });
+
+    if (areAllFormValuesKnown) {
+      this.shouldPromptToStoreData = false;
+    }
+
     (_this$device$postAuto = (_this$device2 = this.device).postAutofill) === null || _this$device$postAuto === void 0 ? void 0 : _this$device$postAuto.call(_this$device2, data, dataType, this);
     this.removeTooltip();
   }

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6547,15 +6547,13 @@ class Form {
     this.isAutofilling = false; // After autofill we check if form values match the data provided…
 
     const formValues = this.getValues();
-    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
-      var _formValues$dataType;
-
-      return ((_formValues$dataType = formValues[dataType]) === null || _formValues$dataType === void 0 ? void 0 : _formValues$dataType[subtype]) === data[subtype];
-    });
+    const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => formValues[dataType][subtype] === data[subtype]);
 
     if (areAllFormValuesKnown) {
       // …if we know all the values do not prompt to store data
-      this.shouldPromptToStoreData = false;
+      this.shouldPromptToStoreData = false; // reset this to its initial value
+
+      this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     } else {
       // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6544,7 +6544,7 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false; // After autofill we check if form values match the data provided
+    this.isAutofilling = false; // After autofill we check if form values match the data provided…
 
     const formValues = this.getValues();
     const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
@@ -6554,10 +6554,10 @@ class Form {
     });
 
     if (areAllFormValuesKnown) {
-      // If we know all the values do not prompt to store data
+      // …if we know all the values do not prompt to store data
       this.shouldPromptToStoreData = false;
     } else {
-      // Otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;
     }
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -5495,7 +5495,7 @@ class InterfacePrototype {
       }
     }
 
-    if (dataType === 'credentials' && this.settings.globalConfig.isMobileApp) {
+    if (dataType === 'credentials' && formObj.shouldAutoSubmit) {
       formObj.attemptSubmissionIfNeeded();
     }
   }
@@ -6046,6 +6046,7 @@ class Form {
     this.isAutofilling = false;
     this.handlerExecuted = false;
     this.shouldPromptToStoreData = true;
+    this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     /**
      * @type {IntersectionObserver | null}
      */
@@ -6543,7 +6544,7 @@ class Form {
 
       if (autofillData) this.autofillInput(input, autofillData, dataType);
     }, dataType);
-    this.isAutofilling = false; // After autofill we check if form values match the data provided. If so we avoid sending the prompting message
+    this.isAutofilling = false; // After autofill we check if form values match the data provided
 
     const formValues = this.getValues();
     const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(subtype => {
@@ -6553,7 +6554,11 @@ class Form {
     });
 
     if (areAllFormValuesKnown) {
+      // If we know all the values do not prompt to store data
       this.shouldPromptToStoreData = false;
+    } else {
+      // Otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      this.shouldAutoSubmit = false;
     }
 
     (_this$device$postAuto = (_this$device2 = this.device).postAutofill) === null || _this$device$postAuto === void 0 ? void 0 : _this$device$postAuto.call(_this$device2, data, dataType, this);


### PR DESCRIPTION
**Reviewer:** @alistairjcbrown 
**Asana:** https://app.asana.com/0/0/1204135364308888/f

## Description
We noticed that we were not prompting on incomplete credentials where the user completed them in a form. This is fixed now. Steps to reproduce:
- Manually add credential for fill.dev (just a password)
- Go to https://fill.dev/form/login-simple
- Enter username
- Autofill password; accept to autofill
- Behaviour: ~~no prompt to update username~~ **<- Now we do prompt! 🎉** 

Notes:
- On macOS we save silently instead of prompting. We will follow up there, but the js behavior is now correct.
- When we detect such an instance we avoid autosubmitting the form on mobile to avoid a jarring experience.

## Steps to test
Added automated tests.
