### PR TITLE
Add Email Protection tooltip pixel

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15428,6 +15428,10 @@ class HTMLTooltipUIController extends _UIController.UIController {
     };
 
     if (this._options.tooltipKind === 'legacy') {
+      this._options.device.firePixel({
+        pixelName: 'autofill_show'
+      });
+
       return new _EmailHTMLTooltip.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
     }
 
@@ -17022,6 +17026,8 @@ const sendJSPixelParamsSchema = _zod.z.union([_zod.z.object({
   params: _zod.z.object({
     fieldType: _zod.z.string().optional()
   }).optional()
+}), _zod.z.object({
+  pixelName: _zod.z.literal("autofill_show")
 }), _zod.z.object({
   pixelName: _zod.z.literal("autofill_personal_address")
 }), _zod.z.object({

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -11752,6 +11752,10 @@ class HTMLTooltipUIController extends _UIController.UIController {
     };
 
     if (this._options.tooltipKind === 'legacy') {
+      this._options.device.firePixel({
+        pixelName: 'autofill_show'
+      });
+
       return new _EmailHTMLTooltip.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
     }
 

--- a/integration-test/tests/email-autofill.extension.spec.js
+++ b/integration-test/tests/email-autofill.extension.spec.js
@@ -41,7 +41,7 @@ test.describe('chrome extension', () => {
         await emailPage.assertEmailValue(personalAddress)
 
         // ensure background page received pixel
-        await emailPage.assertExtensionPixelsCaptured(['autofill_personal_address'])
+        await emailPage.assertExtensionPixelsCaptured(['autofill_show', 'autofill_personal_address'])
 
         // now ensure a second click into the input doesn't show the dropdown
         await emailPage.clickIntoInput()
@@ -59,6 +59,6 @@ test.describe('chrome extension', () => {
         await emailPage.assertEmailValue(privateAddress0)
 
         // assert that the background page received  pixel
-        await emailPage.assertExtensionPixelsCaptured(['autofill_personal_address', 'autofill_private_address'])
+        await emailPage.assertExtensionPixelsCaptured(['autofill_show', 'autofill_personal_address', 'autofill_show', 'autofill_private_address'])
     })
 })

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -64,6 +64,7 @@ export class HTMLTooltipUIController extends UIController {
         if (this.getActiveTooltip()) {
             return
         }
+
         const { topContextData, getPosition, input, form } = args
         const tooltip = this.createTooltip(getPosition, topContextData)
         this.setActiveTooltip(tooltip)
@@ -94,6 +95,7 @@ export class HTMLTooltipUIController extends UIController {
         }
 
         if (this._options.tooltipKind === 'legacy') {
+            this._options.device.firePixel({pixelName: 'autofill_show'})
             return new EmailHTMLTooltip(config, topContextData.inputType, getPosition, tooltipOptions)
                 .render(this._options.device)
         }

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -17,6 +17,9 @@ export type SendJSPixelParams =
       };
     }
   | {
+      pixelName: "autofill_show";
+    }
+  | {
       pixelName: "autofill_personal_address";
     }
   | {

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -8,6 +8,8 @@ export const sendJSPixelParamsSchema = z.union([z.object({
             fieldType: z.string().optional()
         }).optional()
     }), z.object({
+        pixelName: z.literal("autofill_show")
+    }), z.object({
         pixelName: z.literal("autofill_personal_address")
     }), z.object({
         pixelName: z.literal("autofill_private_address")

--- a/src/deviceApiCalls/schemas/sendJSPixel.params.json
+++ b/src/deviceApiCalls/schemas/sendJSPixel.params.json
@@ -29,6 +29,18 @@
       "properties": {
         "pixelName": {
           "type": "string",
+          "const": "autofill_show"
+        }
+      },
+      "required": [
+        "pixelName"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "pixelName": {
+          "type": "string",
           "const": "autofill_personal_address"
         }
       },

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15428,6 +15428,10 @@ class HTMLTooltipUIController extends _UIController.UIController {
     };
 
     if (this._options.tooltipKind === 'legacy') {
+      this._options.device.firePixel({
+        pixelName: 'autofill_show'
+      });
+
       return new _EmailHTMLTooltip.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
     }
 
@@ -17022,6 +17026,8 @@ const sendJSPixelParamsSchema = _zod.z.union([_zod.z.object({
   params: _zod.z.object({
     fieldType: _zod.z.string().optional()
   }).optional()
+}), _zod.z.object({
+  pixelName: _zod.z.literal("autofill_show")
 }), _zod.z.object({
   pixelName: _zod.z.literal("autofill_personal_address")
 }), _zod.z.object({

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -11752,6 +11752,10 @@ class HTMLTooltipUIController extends _UIController.UIController {
     };
 
     if (this._options.tooltipKind === 'legacy') {
+      this._options.device.firePixel({
+        pixelName: 'autofill_show'
+      });
+
       return new _EmailHTMLTooltip.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
     }
 


### PR DESCRIPTION
**Reviewer:** @GioSensation
**Asana:** https://app.asana.com/0/0/1204146951435128/f

## Description
Add pixel for when Email Protection tooltip is shown

Corresponding extension update commit -- https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1740/commits/55e910fe3026f007e5f1c7919ab7907487fbc27b

## Steps to test
1. Build branch into extension and install
2. Open extension developer tools
3. Log into Email Protection
4. Go to https://duckduckgo.com/newsletter and click into the email input
5. Confirm pixel is triggered when the Email Protection autofill tooltip is shown