### PR TITLE
Add checkout path to node version file path

### DIFF
--- a/.github/workflows/asana-release.yml
+++ b/.github/workflows/asana-release.yml
@@ -14,7 +14,7 @@ jobs:
           path: autofill/
       - uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: 'autofill/.nvmrc'
 
       - name: Create Asana Tasks
         id: create-asana-tasks


### PR DESCRIPTION
**Reviewer:** @GioSensation @shakyShane 
**Asana:** N/A

## Description
Release script errored with
> `Error: The specified node version file at: /home/runner/work/duckduckgo-autofill/duckduckgo-autofill/.nvmrc does not exist`
https://github.com/duckduckgo/duckduckgo-autofill/actions/runs/4500578305/jobs/7919890810
