### PR TITLE
tests: remove manual server setup in tests

### DIFF
--- a/docs/playwright-tests.md
+++ b/docs/playwright-tests.md
@@ -62,7 +62,7 @@ page, nor the specific details of what `clickIntoInput` does - it's about readab
 methods should be named in a styles that matches what the application does, or what you expect it to do.
 
 ```js
-const emailPage = emailAutofillPage(page, server)
+const emailPage = emailAutofillPage(page)
 await emailPage.navigate()
 await emailPage.clickIntoInput()
 ```

--- a/integration-test/helpers/harness.js
+++ b/integration-test/helpers/harness.js
@@ -1,8 +1,5 @@
-import * as fs from 'fs'
 import {mkdtempSync, readFileSync} from 'fs'
-import * as path from 'path'
 import {join} from 'path'
-import * as http from 'http'
 import {tmpdir} from 'os'
 import {devices} from 'playwright'
 import {chromium, firefox} from '@playwright/test'
@@ -11,53 +8,7 @@ import {macosContentScopeReplacements, iosContentScopeReplacements} from './mock
 const DATA_DIR_PREFIX = 'ddg-temp-'
 
 /**
- * A simple file server, this is done manually here to enable us
- * to manipulate some requests if needed.
- * @param {string|number} [port]
- * @return {ServerWrapper}
- */
-export function setupServer (port) {
-    const server = http.createServer(function (req, res) {
-        if (!req.url) throw new Error('unreachable')
-        const url = new URL(req.url, `http://${req.headers.host}`)
-        const importUrl = new URL(import.meta.url)
-        const dirname = importUrl.pathname.replace(/\/[^/]*$/, '')
-        let pathname = path.join(dirname, '../pages', url.pathname)
-
-        if (url.pathname.startsWith('/src')) {
-            pathname = path.join(dirname, '../../', url.pathname)
-        }
-
-        fs.readFile(pathname, (err, data) => {
-            if (err) {
-                res.writeHead(404)
-                res.end(JSON.stringify(err))
-                return
-            }
-            res.writeHead(200)
-            res.end(data)
-        })
-    }).listen(port)
-
-    const address = server.address()
-    if (address === null || typeof address === 'string') throw new Error('unreachable')
-    const url = new URL('http://localhost:' + address.port)
-
-    return {
-        address,
-        url,
-        urlForPath (path) {
-            const nextUrl = new URL(path, url)
-            return nextUrl.href
-        },
-        close () {
-            server.close()
-        }
-    }
-}
-
-/**
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {string} domain
  */
 export async function setupMockedDomain (page, domain) {
@@ -115,7 +66,7 @@ export async function withEmailProtectionExtensionSignedInAs (page, username) {
 }
 
 /**
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {Record<string, string | boolean>} replacements
  * @param {Platform} [platform]
  * @return {Promise<void>}
@@ -210,7 +161,7 @@ export function createAutofillScript () {
 }
 
 /**
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  */
 export async function defaultMacosScript (page) {
     return createAutofillScript()
@@ -220,7 +171,7 @@ export async function defaultMacosScript (page) {
 }
 
 /**
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  */
 export async function defaultIOSScript (page) {
     return createAutofillScript()
@@ -230,7 +181,7 @@ export async function defaultIOSScript (page) {
 }
 
 /**
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {Partial<import('../../src/deviceApiCalls/__generated__/validators-ts').AutofillFeatureToggles>} featureToggles
  */
 export async function withIOSFeatureToggles (page, featureToggles) {
@@ -245,7 +196,7 @@ export async function withIOSFeatureToggles (page, featureToggles) {
 /**
  * Relay browser exceptions to the terminal to aid debugging.
  *
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {{verbose?: boolean}} [_opts]
  */
 export function forwardConsoleMessages (page, _opts = {}) {
@@ -334,7 +285,7 @@ export function withWindowsContext (test) {
 }
 
 /**
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {string} measureName
  * @return {Promise<PerformanceEntryList>}
  */
@@ -355,14 +306,14 @@ export async function printPerformanceSummary (name, times) {
 }
 
 /**
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {string[]} [names]
  * @returns {Promise<MockCall[]>}
  */
 export async function mockedCalls (page, names = [], mustExist = true) {
     if (names.length > 0 && mustExist) {
         await page.waitForFunction(({names}) => {
-            const calls = window.__playwright.mocks.calls
+            const calls = window.__playwright_autofill.mocks.calls
             return calls.some(([name]) => names.includes(name))
         }, {names})
     }
@@ -372,17 +323,17 @@ export async function mockedCalls (page, names = [], mustExist = true) {
     }
 
     return page.evaluate(({names}) => {
-        if (!Array.isArray(window.__playwright?.mocks?.calls)) {
-            throw new Error('unreachable, window.__playwright.mocks.calls must be defined')
+        if (!Array.isArray(window.__playwright_autofill?.mocks?.calls)) {
+            throw new Error('unreachable, window.__playwright_autofill.mocks.calls must be defined')
         }
 
         // no need to filter if no names were given, assume the caller wants all mocks
         if (names.length === 0) {
-            return window.__playwright.mocks.calls
+            return window.__playwright_autofill.mocks.calls
         }
 
         // otherwise filter on the given names
-        return window.__playwright.mocks.calls
+        return window.__playwright_autofill.mocks.calls
             .filter(([name]) => names.includes(name))
     }, {names})
 }
@@ -394,7 +345,7 @@ export async function mockedCalls (page, names = [], mustExist = true) {
  * This means that when you run `npx playwright show-results` you can
  * access every piece of JSON that was sent and received.
  *
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {typeof import("@playwright/test").test} test
  * @returns {Promise<void>}
  */

--- a/integration-test/helpers/harness.types.d.ts
+++ b/integration-test/helpers/harness.types.d.ts
@@ -45,7 +45,7 @@ interface MockBuilder<State, Mocks extends Record<string, any>> {
     // observe the current state
     tap(fn: (currentState: State) => void): MockBuilder<State, Mocks>
     // apply to the page, this is the final step
-    applyTo(page: import("playwright").Page): Promise<void>
+    applyTo(page: import("@playwright/test").Page): Promise<void>
 }
 
 
@@ -69,7 +69,7 @@ interface ScriptBuilder {
     // set the platform - this is required
     platform(platform: Platform): Omit<ScriptBuilder, "platform">
     // apply to the page, this is the final step
-    applyTo(page: import("playwright").Page): Promise<void>
+    applyTo(page: import("@playwright/test").Page): Promise<void>
 }
 
 /**

--- a/integration-test/helpers/mocks.android.js
+++ b/integration-test/helpers/mocks.android.js
@@ -119,7 +119,7 @@ export function createAndroidMocks () {
         },
         async applyTo (page) {
             return page.evaluate(mocks => {
-                window.__playwright = {mocks: {calls: []}}
+                window.__playwright_autofill = {mocks: {calls: []}}
                 window.EmailInterface = {
                     showTooltip () {
                         window.postMessage({
@@ -153,7 +153,7 @@ export function createAndroidMocks () {
                  */
                 function respond (name, request, response) {
                     const call = [name, request, response]
-                    window.__playwright.mocks.calls.push(JSON.parse(JSON.stringify(call)))
+                    window.__playwright_autofill.mocks.calls.push(JSON.parse(JSON.stringify(call)))
                     window.postMessage(JSON.stringify({
                         type: name + 'Response',
                         success: response
@@ -166,8 +166,9 @@ export function createAndroidMocks () {
                     },
                     storeFormData (request) {
                         /** @type {MockCall} */
+                        // @ts-expect-error
                         const call = ['storeFormData', request, mocks.getAutofillData]
-                        window.__playwright.mocks.calls.push(JSON.parse(JSON.stringify(call)))
+                        window.__playwright_autofill.mocks.calls.push(JSON.parse(JSON.stringify(call)))
                     }
                 }
             }, mocks)

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -3,17 +3,17 @@
  */
 export const constants = {
     pages: {
-        'overlay': 'overlay.html',
-        'email-autofill': 'email-autofill.html',
-        'emailAtBottom': 'email-at-bottom.html',
-        'iframeContainer': 'iframe-container.html',
-        'signup': 'signup.html',
-        'login': 'login.html',
-        'loginWithPoorForm': 'login-poor-form.html',
-        'loginWithText': 'login-with-text.html',
-        'loginWithFormInModal': 'login-in-modal.html',
-        'loginCovered': 'login-covered.html',
-        'loginMultistep': 'login-multistep.html'
+        'overlay': 'pages/overlay.html',
+        'email-autofill': 'pages/email-autofill.html',
+        'emailAtBottom': 'pages/email-at-bottom.html',
+        'iframeContainer': 'pages/iframe-container.html',
+        'signup': 'pages/signup.html',
+        'login': 'pages/login.html',
+        'loginWithPoorForm': 'pages/login-poor-form.html',
+        'loginWithText': 'pages/login-with-text.html',
+        'loginWithFormInModal': 'pages/login-in-modal.html',
+        'loginCovered': 'pages/login-covered.html',
+        'loginMultistep': 'pages/login-multistep.html'
     },
     fields: {
         email: {

--- a/integration-test/helpers/mocks.webkit.js
+++ b/integration-test/helpers/mocks.webkit.js
@@ -360,28 +360,32 @@ export function createWebkitMocks (platform = 'macos') {
  * This will mock webkit handlers based on the key-values you provide
  *
  * @private
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {Record<string, any>} mocks
  */
 async function withMockedWebkit (page, mocks) {
     await page.addInitScript((mocks) => {
-        window.__playwright = { mocks: { calls: [] } }
+        window.__playwright_autofill = { mocks: { calls: [] } }
         window.webkit = {
             messageHandlers: {}
         }
         for (let [msgName, response] of Object.entries(mocks)) {
             window.webkit.messageHandlers[msgName] = {
+                /**
+                 * @param {any} data
+                 * @return {Promise<string|undefined>}
+                 */
                 postMessage: async (data) => {
                     /** @type {MockCall} */
                     const call = [msgName, data, response]
                     let thisResponse = response
-                    window.__playwright.mocks.calls.push(JSON.parse(JSON.stringify(call)))
+                    window.__playwright_autofill.mocks.calls.push(JSON.parse(JSON.stringify(call)))
 
                     // This allows mocks to have multiple return values.
                     // It has to be inline here since it's serialized into the page.
                     const isMulti = Array.isArray(response)
                     if (isMulti) {
-                        const prevCount = window.__playwright.mocks.calls.filter(([name]) => name === msgName).length
+                        const prevCount = window.__playwright_autofill.mocks.calls.filter(([name]) => name === msgName).length
                         const next = response[prevCount - 1]
                         if (next) {
                             thisResponse = next

--- a/integration-test/helpers/mocks.windows.js
+++ b/integration-test/helpers/mocks.windows.js
@@ -115,12 +115,12 @@ export function createWindowsMocks () {
         },
         async applyTo (page) {
             return page.evaluate(mocks => {
-                window.__playwright = { mocks: { calls: [] } }
+                window.__playwright_autofill = { mocks: { calls: [] } }
                 const listeners = []
 
                 function recordCall (name, request, response) {
                     const call = [name, request, response]
-                    window.__playwright.mocks.calls.push(JSON.parse(JSON.stringify(call)))
+                    window.__playwright_autofill.mocks.calls.push(JSON.parse(JSON.stringify(call)))
                 }
                 /**
                  * @param {any} request
@@ -128,7 +128,7 @@ export function createWindowsMocks () {
                  */
                 function respond (name, request, response) {
                     const call = [name, request, response]
-                    window.__playwright.mocks.calls.push(JSON.parse(JSON.stringify(call)))
+                    window.__playwright_autofill.mocks.calls.push(JSON.parse(JSON.stringify(call)))
                     setTimeout(() => {
                         for (let listener of listeners) {
                             listener({

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -69,7 +69,7 @@ export function incontextSignupPageEmailBottomPage (page) {
  *
  * @param {import("@playwright/test").Page} page
  */
-export function signupPage(page) {
+export function signupPage (page) {
     const decoratedFirstInputSelector = '#email' + constants.fields.email.selectors.identity
     const decoratedSecondInputSelector = '#email-2' + constants.fields.email.selectors.identity
     const emailStyleAttr = () => page.locator('#email').first().getAttribute('style')
@@ -550,7 +550,7 @@ export function loginPageWithPoorForm (page, opts) {
  * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPageWithFormInModal(page, opts) {
+export function loginPageWithFormInModal (page, opts) {
     const originalLoginPage = loginPage(page, opts)
     return {
         ...originalLoginPage,
@@ -585,7 +585,7 @@ export function loginPageWithFormInModal(page, opts) {
  * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPageCovered(page, opts) {
+export function loginPageCovered (page, opts) {
     const originalLoginPage = loginPage(page, opts)
     return {
         ...originalLoginPage,
@@ -604,7 +604,7 @@ export function loginPageCovered(page, opts) {
  * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPageMultistep(page, opts) {
+export function loginPageMultistep (page, opts) {
     const originalLoginPage = loginPage(page, opts)
     return {
         ...originalLoginPage,
@@ -622,7 +622,7 @@ export function loginPageMultistep(page, opts) {
  *
  * @param {import("@playwright/test").Page} page
  */
-export function emailAutofillPage(page) {
+export function emailAutofillPage (page) {
     const {selectors} = constants.fields.email
     return {
         async navigate (domain) {
@@ -688,7 +688,7 @@ export function emailAutofillPage(page) {
 /**
  * @param {import("@playwright/test").Page} page
  */
-export function overlayPage(page) {
+export function overlayPage (page) {
     return {
         async navigate () {
             await page.goto(constants.pages['overlay'])

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -67,17 +67,16 @@ export function incontextSignupPageEmailBottomPage (page) {
 /**
  * A wrapper around interactions for `integration-test/pages/signup.html`
  *
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  */
-export function signupPage (page, server) {
+export function signupPage(page) {
     const decoratedFirstInputSelector = '#email' + constants.fields.email.selectors.identity
     const decoratedSecondInputSelector = '#email-2' + constants.fields.email.selectors.identity
     const emailStyleAttr = () => page.locator('#email').first().getAttribute('style')
     const passwordStyleAttr = () => page.locator('#password' + constants.fields.password.selectors.credential).getAttribute('style')
     return {
         async navigate () {
-            await page.goto(server.urlForPath(constants.pages['signup']))
+            await page.goto(constants.pages['signup'])
         },
         async selectGeneratedPassword () {
             const input = page.locator('#password')
@@ -165,7 +164,7 @@ export function signupPage (page, server) {
          * @returns {Promise<void>}
          */
         async assertWasPromptedToSave (credentials, platform) {
-            const calls = await page.evaluate('window.__playwright.mocks.calls')
+            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
             const mockNames = {
                 ios: 'pmHandlerStoreData',
                 macos: 'pmHandlerStoreData',
@@ -187,6 +186,7 @@ export function signupPage (page, server) {
             const calls = await mockedCalls(page, ['storeFormData'])
             expect(calls.length).toBeGreaterThanOrEqual(1)
             const [, sent] = calls[0]
+            // @ts-expect-error
             expect(sent.Data.credentials).toEqual(credentials)
         },
         /**
@@ -217,15 +217,14 @@ export function signupPage (page, server) {
 /**
  * A wrapper around interactions for `integration-test/pages/login.html`
  *
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPage (page, server, opts = {}) {
+export function loginPage (page, opts = {}) {
     const { overlay = false, clickLabel = false } = opts
     return {
         async navigate () {
-            await page.goto(server.urlForPath(constants.pages['login']))
+            await page.goto(constants.pages['login'])
         },
         async clickIntoUsernameInput () {
             const usernameField = page.locator('#email').first()
@@ -359,6 +358,7 @@ export function loginPage (page, server, opts = {}) {
             let params
             if (platform === 'android') {
                 expect(typeof sent).toBe('string')
+                // @ts-expect-error
                 params = JSON.parse(sent)
             } else {
                 params = sent
@@ -367,7 +367,7 @@ export function loginPage (page, server, opts = {}) {
             expect(params.inputType).toBe('credentials.username')
         },
         async promptWasNotShown () {
-            const calls = await page.evaluate('window.__playwright.mocks.calls')
+            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
             const mockCalls = calls.filter(([name]) => name === 'getAutofillData')
             expect(mockCalls.length).toBe(0)
         },
@@ -378,6 +378,7 @@ export function loginPage (page, server, opts = {}) {
          */
         async assertParentOpened () {
             const credsCalls = await mockedCalls(page, ['getSelectedCredentials'], true)
+            // @ts-expect-error
             const hasSucceeded = credsCalls.some((call) => call[2]?.some(({type}) => type === 'ok'))
             expect(hasSucceeded).toBe(true)
         },
@@ -418,12 +419,12 @@ export function loginPage (page, server, opts = {}) {
          * @returns {Promise<void>}
          */
         async assertAnyMockCallOccurred () {
-            const calls = await page.evaluate('window.__playwright.mocks.calls')
+            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
             expect(calls.length).toBeGreaterThan(0)
         },
         /** @param {string} mockCallName */
         async assertMockCallOccurred (mockCallName) {
-            const calls = await page.evaluate('window.__playwright.mocks.calls')
+            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
             const mockCall = calls.find(([name]) => name === mockCallName)
             expect(mockCall).toBeDefined()
         },
@@ -432,7 +433,7 @@ export function loginPage (page, server, opts = {}) {
          * @param {number} times
          */
         async assertMockCallOccurredTimes (mockCallName, times) {
-            const calls = await page.evaluate('window.__playwright.mocks.calls')
+            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
             const mockCalls = calls.filter(([name]) => name === mockCallName)
             expect(mockCalls).toHaveLength(times)
         },
@@ -440,7 +441,7 @@ export function loginPage (page, server, opts = {}) {
          * @param {Partial<import('../../src/deviceApiCalls/__generated__/validators-ts').AutofillFeatureToggles>} expected
          */
         async assertTogglesWereMocked (expected) {
-            const calls = await page.evaluate('window.__playwright.mocks.calls')
+            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
             const mockCalls = calls.find(([name]) => name === 'getRuntimeConfiguration')
             const [, , resp] = mockCalls
             const actual = resp.userPreferences.features.autofill.settings.featureToggles
@@ -453,7 +454,7 @@ export function loginPage (page, server, opts = {}) {
          * @param {Platform} [platform]
          */
         async assertWasPromptedToSave (data, platform = 'ios') {
-            const calls = await page.evaluate('window.__playwright.mocks.calls')
+            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
             // todo(Shane): is it too apple specific?
             const mockNames = {
                 ios: 'pmHandlerStoreData',
@@ -514,16 +515,15 @@ export function loginPage (page, server, opts = {}) {
 /**
  * A wrapper around interactions for `integration-test/pages/login.html`
  *
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPageWithText (page, server, opts) {
-    const originalLoginPage = loginPage(page, server, opts)
+export function loginPageWithText (page, opts) {
+    const originalLoginPage = loginPage(page, opts)
     return {
         ...originalLoginPage,
         async navigate () {
-            await page.goto(server.urlForPath(constants.pages['loginWithText']))
+            await page.goto(constants.pages['loginWithText'])
         }
     }
 }
@@ -531,16 +531,15 @@ export function loginPageWithText (page, server, opts) {
 /**
  * A wrapper around interactions for `integration-test/pages/login-poor-form.html`
  *
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPageWithPoorForm (page, server, opts) {
-    const originalLoginPage = loginPage(page, server, opts)
+export function loginPageWithPoorForm (page, opts) {
+    const originalLoginPage = loginPage(page, opts)
     return {
         ...originalLoginPage,
         async navigate () {
-            await page.goto(server.urlForPath(constants.pages['loginWithPoorForm']))
+            await page.goto(constants.pages['loginWithPoorForm'])
         }
     }
 }
@@ -548,16 +547,15 @@ export function loginPageWithPoorForm (page, server, opts) {
 /**
  * A wrapper around interactions for `integration-test/pages/login-in-modal.html`
  *
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPageWithFormInModal (page, server, opts) {
-    const originalLoginPage = loginPage(page, server, opts)
+export function loginPageWithFormInModal(page, opts) {
+    const originalLoginPage = loginPage(page, opts)
     return {
         ...originalLoginPage,
         async navigate () {
-            await page.goto(server.urlForPath(constants.pages['loginWithFormInModal']))
+            await page.goto(constants.pages['loginWithFormInModal'])
         },
         async openDialog () {
             const button = await page.waitForSelector(`button:has-text("Click here to Login")`)
@@ -584,16 +582,15 @@ export function loginPageWithFormInModal (page, server, opts) {
 /**
  * A wrapper around interactions for `integration-test/pages/login-covered.html`
  *
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPageCovered (page, server, opts) {
-    const originalLoginPage = loginPage(page, server, opts)
+export function loginPageCovered(page, opts) {
+    const originalLoginPage = loginPage(page, opts)
     return {
         ...originalLoginPage,
         async navigate () {
-            await page.goto(server.urlForPath(constants.pages['loginCovered']))
+            await page.goto(constants.pages['loginCovered'])
         },
         async closeCookieDialog () {
             await page.click('button:has-text("Accept all cookies")')
@@ -604,16 +601,15 @@ export function loginPageCovered (page, server, opts) {
 /**
  * A wrapper around interactions for `integration-test/pages/login-multistep.html`
  *
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
  */
-export function loginPageMultistep (page, server, opts) {
-    const originalLoginPage = loginPage(page, server, opts)
+export function loginPageMultistep(page, opts) {
+    const originalLoginPage = loginPage(page, opts)
     return {
         ...originalLoginPage,
         async navigate () {
-            await page.goto(server.urlForPath(constants.pages['loginMultistep']))
+            await page.goto(constants.pages['loginMultistep'])
         },
         async clickContinue () {
             await page.click('button:has-text("Continue")')
@@ -624,10 +620,9 @@ export function loginPageMultistep (page, server, opts) {
 /**
  * A wrapper around interactions for `integration-test/pages/email-autofill.html`
  *
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} [server]
+ * @param {import("@playwright/test").Page} page
  */
-export function emailAutofillPage (page, server) {
+export function emailAutofillPage(page) {
     const {selectors} = constants.fields.email
     return {
         async navigate (domain) {
@@ -636,7 +631,7 @@ export function emailAutofillPage (page, server) {
                 const pagePath = `integration-test/pages/${emailAutofillPageName}`
                 await page.goto(new URL(pagePath, domain).href)
             } else {
-                await page.goto(server.urlForPath(emailAutofillPageName))
+                await page.goto(emailAutofillPageName)
             }
         },
         async clickIntoInput () {
@@ -691,13 +686,12 @@ export function emailAutofillPage (page, server) {
 }
 
 /**
- * @param {import("playwright").Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  */
-export function overlayPage (page, server) {
+export function overlayPage(page) {
     return {
         async navigate () {
-            await page.goto(server.urlForPath(constants.pages['overlay']))
+            await page.goto(constants.pages['overlay'])
         },
         /**
          * @param {string} text
@@ -722,7 +716,7 @@ export function overlayPage (page, server) {
          */
         async assertSelectedDetail () {
             return page.waitForFunction(() => {
-                const calls = window.__playwright.mocks.calls
+                const calls = window.__playwright_autofill.mocks.calls
                 return calls.some(call => call[0] === 'selectedDetail')
             })
         }
@@ -732,7 +726,7 @@ export function overlayPage (page, server) {
 /**
  * A wrapper around interactions for `integration-test/pages/signup.html`
  *
- * @param {import("playwright").Page} page
+ * @param {import("@playwright/test").Page} page
  * @param {ServerWrapper} server
  */
 export function loginAndSignup (page, server) {

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -10,11 +10,11 @@ export function incontextSignupPage (page) {
     const getTooltip = () => page.locator('.tooltip--email')
     return {
         async assertIsShowing () {
-            expect(await getCallToAction()).toBeVisible()
-            expect(await getTooltip()).toBeInViewport({ ratio: 1 })
+            await expect(getCallToAction()).toBeVisible()
+            await expect(getTooltip()).toBeInViewport({ ratio: 1 })
         },
         async assertIsHidden () {
-            expect(await getCallToAction()).toBeHidden()
+            await expect(getCallToAction()).toBeHidden()
         },
         async getEmailProtection () {
             (await getCallToAction()).click({timeout: 500})
@@ -34,7 +34,7 @@ export function incontextSignupPageWithinIframe (page) {
     return {
         async navigate (domain) {
             const pageName = constants.pages['iframeContainer']
-            const pagePath = `integration-test/pages/${pageName}`
+            const pagePath = `integration-test/${pageName}`
             await page.goto(new URL(pagePath, domain).href)
         },
         async clickDirectlyOnDax () {
@@ -54,7 +54,7 @@ export function incontextSignupPageEmailBottomPage (page) {
     return {
         async navigate (domain) {
             const pageName = constants.pages['emailAtBottom']
-            const pagePath = `integration-test/pages/${pageName}`
+            const pagePath = `integration-test/${pageName}`
             await page.goto(new URL(pagePath, domain).href)
         },
         async clickDirectlyOnDax () {
@@ -628,7 +628,7 @@ export function emailAutofillPage (page) {
         async navigate (domain) {
             const emailAutofillPageName = constants.pages['email-autofill']
             if (domain) {
-                const pagePath = `integration-test/pages/${emailAutofillPageName}`
+                const pagePath = `integration-test/${emailAutofillPageName}`
                 await page.goto(new URL(pagePath, domain).href)
             } else {
                 await page.goto(emailAutofillPageName)

--- a/integration-test/helpers/utils.js
+++ b/integration-test/helpers/utils.js
@@ -26,7 +26,7 @@ const stripDuckExtension = (emailAddress) => {
 
 /**
  * Clicks directly on the icon within the input field
- * @param {import('playwright').Locator} input
+ * @param {import('@playwright/test').Locator} input
  * @returns {Promise<void>}
  */
 const clickOnIcon = async (input) => {

--- a/integration-test/tests/email-autofill.android.spec.js
+++ b/integration-test/tests/email-autofill.android.spec.js
@@ -1,7 +1,6 @@
 import {
     createAutofillScript,
     forwardConsoleMessages,
-    setupServer,
     withAndroidContext
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
@@ -15,18 +14,11 @@ import {androidStringReplacements, createAndroidMocks} from '../helpers/mocks.an
 const test = withAndroidContext(base)
 
 test.describe('android', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('when signed in', () => {
         test('should autofill the selected email', async ({page}) => {
             // enable in-terminal exceptions
             await forwardConsoleMessages(page)
-            const emailPage = emailAutofillPage(page, server)
+            const emailPage = emailAutofillPage(page)
             await emailPage.navigate()
 
             // android specific mocks, withPersonalEmail will ensure the signed-in check works
@@ -52,7 +44,7 @@ test.describe('android', () => {
     test.describe('when availableInputTypes are available', () => {
         test('should use availableInputTypes.email', async ({page}) => {
             await forwardConsoleMessages(page)
-            const emailPage = emailAutofillPage(page, server)
+            const emailPage = emailAutofillPage(page)
             await emailPage.navigate()
             const {personalAddress} = constants.fields.email
             await createAndroidMocks()
@@ -80,7 +72,7 @@ test.describe('android', () => {
             await forwardConsoleMessages(page)
 
             // page abstraction
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
             await signup.navigate()
 
             // android specific mocks

--- a/integration-test/tests/email-autofill.extension.spec.js
+++ b/integration-test/tests/email-autofill.extension.spec.js
@@ -1,4 +1,4 @@
-import {forwardConsoleMessages, setupServer, withChromeExtensionContext, withEmailProtectionExtensionSignedInAs} from '../helpers/harness.js'
+import {forwardConsoleMessages, withChromeExtensionContext, withEmailProtectionExtensionSignedInAs} from '../helpers/harness.js'
 import { test as base, expect } from '@playwright/test'
 import {constants} from '../helpers/mocks.js'
 import {emailAutofillPage} from '../helpers/pages.js'
@@ -12,13 +12,6 @@ import { stripDuckExtension } from '../helpers/utils.js'
 const test = withChromeExtensionContext(base)
 
 test.describe('chrome extension', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test('should autofill the selected email', async ({page}) => {
         const {personalAddress, privateAddress0} = constants.fields.email
 
@@ -26,7 +19,7 @@ test.describe('chrome extension', () => {
         await withEmailProtectionExtensionSignedInAs(page, stripDuckExtension(personalAddress))
 
         // page abstraction
-        const emailPage = emailAutofillPage(page, server)
+        const emailPage = emailAutofillPage(page)
         await emailPage.navigate()
         await emailPage.clickIntoInput()
 

--- a/integration-test/tests/email-autofill.ios.spec.js
+++ b/integration-test/tests/email-autofill.ios.spec.js
@@ -1,7 +1,6 @@
 import {
     createAutofillScript,
     forwardConsoleMessages,
-    setupServer,
     withIOSContext
 } from '../helpers/harness.js'
 import { test as base } from '@playwright/test'
@@ -15,13 +14,6 @@ import {createWebkitMocks, iosContentScopeReplacements} from '../helpers/mocks.w
 const test = withIOSContext(base)
 
 test.describe('ios', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test('should autofill the selected email when email protection is enabled', async ({page}) => {
         // enable in-terminal exceptions
         await forwardConsoleMessages(page)
@@ -43,7 +35,7 @@ test.describe('ios', () => {
         const {privateAddress0} = constants.fields.email
 
         // page abstraction
-        const emailPage = emailAutofillPage(page, server)
+        const emailPage = emailAutofillPage(page)
         await emailPage.navigate()
 
         // Click in the input, a native window will appear
@@ -72,7 +64,7 @@ test.describe('ios', () => {
             .applyTo(page)
 
         // page abstraction
-        const emailPage = emailAutofillPage(page, server)
+        const emailPage = emailAutofillPage(page)
         await emailPage.navigate()
 
         await emailPage.clickIntoInput()

--- a/integration-test/tests/email-autofill.macos.spec.js
+++ b/integration-test/tests/email-autofill.macos.spec.js
@@ -1,6 +1,6 @@
 import {
     createAutofillScript,
-    forwardConsoleMessages, performanceEntries,
+    forwardConsoleMessages, performanceEntries
 } from '../helpers/harness.js'
 import {test as base, expect} from '@playwright/test'
 import {constants} from '../helpers/mocks.js'

--- a/integration-test/tests/email-autofill.macos.spec.js
+++ b/integration-test/tests/email-autofill.macos.spec.js
@@ -1,7 +1,6 @@
 import {
     createAutofillScript,
     forwardConsoleMessages, performanceEntries,
-    setupServer
 } from '../helpers/harness.js'
 import {test as base, expect} from '@playwright/test'
 import {constants} from '../helpers/mocks.js'
@@ -15,13 +14,6 @@ import {createAvailableInputTypes, stripDuckExtension} from '../helpers/utils.js
 const test = base.extend({})
 
 test.describe('macos', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test('should autofill the selected email', async ({page}) => {
         // enable in-terminal exceptions
         await forwardConsoleMessages(page)
@@ -41,7 +33,7 @@ test.describe('macos', () => {
         const {personalAddress, privateAddress0} = constants.fields.email
 
         // page abstraction
-        const emailPage = emailAutofillPage(page, server)
+        const emailPage = emailAutofillPage(page)
         await emailPage.navigate()
 
         // first click into the field
@@ -98,7 +90,7 @@ test.describe('macos', () => {
         }
         test('with an identity only - filling firstName', async ({page}) => {
             await forwardConsoleMessages(page)
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
 
             await createWebkitMocks()
                 .withAvailableInputTypes(createAvailableInputTypes())
@@ -118,7 +110,7 @@ test.describe('macos', () => {
         })
         test('with an identity only - filling lastName', async ({page}) => {
             await forwardConsoleMessages(page)
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
 
             await createWebkitMocks()
                 .withAvailableInputTypes(createAvailableInputTypes())
@@ -138,7 +130,7 @@ test.describe('macos', () => {
         })
         test('with an identity + Email Protection, autofill using duck address in identity', async ({page}) => {
             await forwardConsoleMessages(page)
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
 
             await createWebkitMocks()
                 .withAvailableInputTypes(createAvailableInputTypes())
@@ -160,7 +152,7 @@ test.describe('macos', () => {
         })
         test('with an identity + Email Protection, autofill using duck address in identity triggered from name field', async ({page}) => {
             await forwardConsoleMessages(page)
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
 
             await createWebkitMocks()
                 .withAvailableInputTypes(createAvailableInputTypes())
@@ -181,7 +173,7 @@ test.describe('macos', () => {
         })
         test('with no input types', async ({page}) => {
             await forwardConsoleMessages(page)
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
             await createWebkitMocks().applyTo(page)
             await applyScript(page)
             await signup.navigate()
@@ -209,7 +201,7 @@ test.describe('macos', () => {
             .platform('macos')
             .applyTo(page)
 
-        const signup = signupPage(page, server)
+        const signup = signupPage(page)
         await signup.navigate()
         await signup.addNewForm()
         await signup.selectSecondEmailField(personalAddress)
@@ -229,7 +221,7 @@ test.describe('macos', () => {
                 .platform('macos')
                 .applyTo(page)
 
-            await page.goto(server.urlForPath('src/Form/test-cases/usps_signup.html'))
+            await page.goto('src/Form/test-cases/usps_signup.html')
             const r = await performanceEntries(page, 'scanner:init')
             for (let performanceEntry of r) {
                 console.log(performanceEntry.duration)

--- a/integration-test/tests/incontext-signup.extension.spec.js
+++ b/integration-test/tests/incontext-signup.extension.spec.js
@@ -9,7 +9,7 @@ import {emailAutofillPage, incontextSignupPage, incontextSignupPageWithinIframe,
  */
 const test = withChromeExtensionContext(base)
 
-test.describe('chrome extension', () => {
+test.describe.skip('chrome extension', () => {
     test('should allow user to sign up for Email Protection', async ({page, context}) => {
         forwardConsoleMessages(page)
         await setupMockedDomain(page, 'https://example.com')

--- a/integration-test/tests/incontext-signup.extension.spec.js
+++ b/integration-test/tests/incontext-signup.extension.spec.js
@@ -9,7 +9,7 @@ import {emailAutofillPage, incontextSignupPage, incontextSignupPageWithinIframe,
  */
 const test = withChromeExtensionContext(base)
 
-test.describe.skip('chrome extension', () => {
+test.describe('chrome extension', () => {
     test('should allow user to sign up for Email Protection', async ({page, context}) => {
         forwardConsoleMessages(page)
         await setupMockedDomain(page, 'https://example.com')

--- a/integration-test/tests/login-form.android.spec.js
+++ b/integration-test/tests/login-form.android.spec.js
@@ -1,5 +1,5 @@
 import {constants} from '../helpers/mocks.js'
-import {createAutofillScript, forwardConsoleMessages, setupServer, withAndroidContext} from '../helpers/harness.js'
+import {createAutofillScript, forwardConsoleMessages, withAndroidContext} from '../helpers/harness.js'
 import {loginPage, loginPageWithFormInModal, loginPageWithText} from '../helpers/pages.js'
 import {androidStringReplacements, createAndroidMocks} from '../helpers/mocks.android.js'
 import {test as base} from '@playwright/test'
@@ -16,28 +16,27 @@ import {test as base} from '@playwright/test'
 const test = withAndroidContext(base)
 
 /**
- * @param {import('playwright').Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  * @param {object} opts
  * @param {Partial<AutofillFeatureToggles>} opts.featureToggles
  * @param {Partial<AvailableInputTypes>} [opts.availableInputTypes]
  * @param {CredentialsMock} [opts.credentials]
  * @param {'standard' | 'withExtraText' | 'withModal'} [opts.pageType]
  */
-async function testLoginPage (page, server, opts) {
+async function testLoginPage (page, opts) {
     // enable in-terminal exceptions
     await forwardConsoleMessages(page)
 
     let login
     switch (opts.pageType) {
     case 'withExtraText':
-        login = loginPageWithText(page, server)
+        login = loginPageWithText(page)
         break
     case 'withModal':
-        login = loginPageWithFormInModal(page, server)
+        login = loginPageWithFormInModal(page)
         break
     default:
-        login = loginPage(page, server)
+        login = loginPage(page)
         break
     }
     await login.navigate()
@@ -71,17 +70,10 @@ test.describe('Feature: auto-filling a login form on Android', () => {
         username: personalAddress,
         password
     }
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('when `inputType_credentials` is true', () => {
         test.describe('and I have saved credentials', () => {
             test('I should be prompted to use my saved credentials with autoprompt', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -92,7 +84,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                 await login.assertFirstCredential(personalAddress, password)
             })
             test('I should be prompted to use my saved credentials when clicking the field even if the form was below the fold', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -105,7 +97,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                 await login.promptWasShown()
             })
             test('I should not be prompted automatically to use my saved credentials if the form is below the fold', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -118,7 +110,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                 await login.assertFirstCredential(personalAddress, password)
             })
             test('the form should be submitted after autofill', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -134,7 +126,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                 await login.assertFormSubmitted()
             })
             test('should prompt to store and not autosubmit when the form completes a partial credential stored', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true,
                         inlineIcon_credentials: true,
@@ -162,7 +154,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
         })
         test.describe('but I dont have saved credentials', () => {
             test('I should not be prompted', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -174,7 +166,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
     })
     test.describe('when `inputType_credentials` is false', () => {
         test('I should not be prompted at all', async ({page}) => {
-            const {login} = await testLoginPage(page, server, {
+            const {login} = await testLoginPage(page, {
                 featureToggles: {
                     inputType_credentials: false
                 },

--- a/integration-test/tests/login-form.ios.spec.js
+++ b/integration-test/tests/login-form.ios.spec.js
@@ -1,7 +1,6 @@
 import {constants} from '../helpers/mocks.js'
 import {
     forwardConsoleMessages,
-    setupServer,
     withIOSContext, withIOSFeatureToggles
 } from '../helpers/harness.js'
 import {
@@ -21,15 +20,14 @@ import {createAvailableInputTypes} from '../helpers/utils.js'
 const test = withIOSContext(base)
 
 /**
- * @param {import('playwright').Page} page
- * @param {ServerWrapper} server
+ * @param {import("@playwright/test").Page} page
  * @param {object} opts
  * @param {Partial<import('../../src/deviceApiCalls/__generated__/validators-ts').AutofillFeatureToggles>} opts.featureToggles
  * @param {Partial<import('../../src/deviceApiCalls/__generated__/validators-ts').AvailableInputTypes>} [opts.availableInputTypes]
  * @param {CredentialsMock} [opts.credentials]
  * @param {'standard' | 'withExtraText' | 'withModal' | 'covered' | 'multistep'} [opts.pageType]
  */
-async function testLoginPage (page, server, opts) {
+async function testLoginPage (page, opts) {
     // enable in-terminal exceptions
     await forwardConsoleMessages(page)
 
@@ -48,19 +46,19 @@ async function testLoginPage (page, server, opts) {
     let login
     switch (opts.pageType) {
     case 'withExtraText':
-        login = loginPageWithText(page, server)
+        login = loginPageWithText(page)
         break
     case 'withModal':
-        login = loginPageWithFormInModal(page, server)
+        login = loginPageWithFormInModal(page)
         break
     case 'covered':
-        login = loginPageCovered(page, server)
+        login = loginPageCovered(page)
         break
     case 'multistep':
-        login = loginPageMultistep(page, server)
+        login = loginPageMultistep(page)
         break
     default:
-        login = loginPage(page, server)
+        login = loginPage(page)
         break
     }
 
@@ -76,17 +74,10 @@ test.describe('Auto-fill a login form on iOS', () => {
         username: personalAddress,
         password
     }
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('when `inputType_credentials` is true', () => {
         test.describe('and I have saved credentials', () => {
             test('I should be prompted to use my saved credentials with autoprompt', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -97,7 +88,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                 await login.fieldsContainIcons()
             })
             test('I should not be prompted automatically to use my saved credentials if the form is below the fold', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -111,7 +102,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                 await login.assertFirstCredential(personalAddress, password)
             })
             test('I should not be prompted automatically to use my saved credentials if the form is covered by something else', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -126,7 +117,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                 await login.assertFormSubmitted()
             })
             test('should work fine with multistep forms', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -141,7 +132,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                 await login.assertFormSubmitted()
             })
             test('the form should be submitted after autofill', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -157,7 +148,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                 await login.assertFormSubmitted()
             })
             test('should prompt to store and not autosubmit when the form completes a partial credential stored', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true,
                         inlineIcon_credentials: true,
@@ -185,7 +176,7 @@ test.describe('Auto-fill a login form on iOS', () => {
         })
         test.describe('but I dont have saved credentials', () => {
             test('I should not be prompted', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -197,7 +188,7 @@ test.describe('Auto-fill a login form on iOS', () => {
 
         test.describe('check tooltip opening logic', () => {
             test('tapping into an autofilled field does not prompt', async ({page}) => {
-                const {login} = await testLoginPage(page, server, {
+                const {login} = await testLoginPage(page, {
                     featureToggles: {
                         inputType_credentials: true
                     },
@@ -212,7 +203,7 @@ test.describe('Auto-fill a login form on iOS', () => {
     })
     test.describe('when `inputType_credentials` is false', () => {
         test('I should not be prompted at all', async ({page}) => {
-            const {login} = await testLoginPage(page, server, {
+            const {login} = await testLoginPage(page, {
                 featureToggles: {
                     inputType_credentials: false
                 },

--- a/integration-test/tests/login-form.windows.spec.js
+++ b/integration-test/tests/login-form.windows.spec.js
@@ -21,7 +21,7 @@ test.describe('Auto-fill a login form on windows', () => {
 
                 const login = loginPage(page, {overlay: true})
                 await login.navigate()
-                await page.pause();
+                await page.pause()
 
                 await createWindowsMocks()
                     .withAvailableInputTypes(createAvailableInputTypes())

--- a/integration-test/tests/login-form.windows.spec.js
+++ b/integration-test/tests/login-form.windows.spec.js
@@ -2,7 +2,6 @@ import {constants} from '../helpers/mocks.js'
 import {
     createAutofillScript,
     forwardConsoleMessages,
-    setupServer,
     withWindowsContext
 } from '../helpers/harness.js'
 import {loginPage, overlayPage} from '../helpers/pages.js'
@@ -13,13 +12,6 @@ import {createAvailableInputTypes} from '../helpers/utils.js'
 const test = withWindowsContext(base)
 
 test.describe('Auto-fill a login form on windows', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('when `inputType_credentials` is true', () => {
         test.describe('and I have saved credentials', () => {
             test('I should be prompted to use my saved credentials', async ({page}) => {
@@ -27,8 +19,9 @@ test.describe('Auto-fill a login form on windows', () => {
                 const {personalAddress} = constants.fields.email
                 const password = '123456'
 
-                const login = loginPage(page, server, {overlay: true})
+                const login = loginPage(page, {overlay: true})
                 await login.navigate()
+                await page.pause();
 
                 await createWindowsMocks()
                     .withAvailableInputTypes(createAvailableInputTypes())
@@ -54,7 +47,7 @@ test.describe('Auto-fill a login form on windows', () => {
         test.describe('but I dont have saved credentials', () => {
             test('I should not be prompted', async ({page}) => {
                 await forwardConsoleMessages(page)
-                const login = loginPage(page, server)
+                const login = loginPage(page)
                 await login.navigate()
 
                 await createWindowsMocks()
@@ -72,7 +65,7 @@ test.describe('Auto-fill a login form on windows', () => {
         test.describe('when `inputType_credentials` is false', () => {
             test('I should not be prompted at all', async ({page}) => {
                 await forwardConsoleMessages(page)
-                const login = loginPage(page, server)
+                const login = loginPage(page)
                 await login.navigate()
 
                 await createWindowsMocks()
@@ -95,7 +88,7 @@ test.describe('Auto-fill a login form on windows', () => {
             const {personalAddress} = constants.fields.email
             const password = '123456'
 
-            const overlay = overlayPage(page, server)
+            const overlay = overlayPage(page)
             await overlay.navigate()
 
             await createWindowsMocks()

--- a/integration-test/tests/login-form.windows.spec.js
+++ b/integration-test/tests/login-form.windows.spec.js
@@ -21,7 +21,6 @@ test.describe('Auto-fill a login form on windows', () => {
 
                 const login = loginPage(page, {overlay: true})
                 await login.navigate()
-                await page.pause()
 
                 await createWindowsMocks()
                     .withAvailableInputTypes(createAvailableInputTypes())

--- a/integration-test/tests/messaging.windows.spec.js
+++ b/integration-test/tests/messaging.windows.spec.js
@@ -1,7 +1,7 @@
 import {
     createAutofillScript,
     forwardConsoleMessages,
-    setupServer, withWindowsContext
+    withWindowsContext
 } from '../helpers/harness.js'
 import {test as base, expect} from '@playwright/test'
 import {signupPage} from '../helpers/pages.js'
@@ -13,19 +13,12 @@ import {createWindowsMocks} from '../helpers/mocks.windows.js'
 const test = withWindowsContext(base)
 
 test.describe('Windows secure messaging', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('When autofill script runs', () => {
         test('the window.chrome.webview variables have been removed', async ({page}) => {
             // enable in-terminal exceptions
             await forwardConsoleMessages(page)
 
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
             await signup.navigate()
 
             // this will add `window.chome.webview` to mimic what the Windows platform would do

--- a/integration-test/tests/remote-config.windows.spec.js
+++ b/integration-test/tests/remote-config.windows.spec.js
@@ -1,7 +1,7 @@
 import {
     createAutofillScript,
     forwardConsoleMessages,
-    setupServer, withWindowsContext
+    withWindowsContext
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
 import {loginPage} from '../helpers/pages.js'
@@ -10,17 +10,10 @@ import {createWindowsMocks} from '../helpers/mocks.windows.js'
 const test = withWindowsContext(base)
 
 test.describe('Remote config on windows', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('when autofill is disabled remotely', () => {
         test('page scanning does not occur at all', async ({page}) => {
             await forwardConsoleMessages(page)
-            const login = loginPage(page, server)
+            const login = loginPage(page)
             await login.navigate()
 
             await createWindowsMocks()

--- a/integration-test/tests/save-prompts.android.spec.js
+++ b/integration-test/tests/save-prompts.android.spec.js
@@ -1,7 +1,7 @@
 import {
     createAutofillScript,
     forwardConsoleMessages,
-    setupServer, withAndroidContext
+    withAndroidContext
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
 import {loginPage, loginPageWithPoorForm, signupPage} from '../helpers/pages.js'
@@ -14,13 +14,6 @@ import {constants} from '../helpers/mocks.js'
 const test = withAndroidContext(base)
 
 test.describe('Android Save prompts', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('When saving credentials is enabled ✅ (default)', () => {
         test('Prompting to save from a signup form', async ({page}) => {
             // enable in-terminal exceptions
@@ -33,7 +26,7 @@ test.describe('Android Save prompts', () => {
                 password: '123456'
             }
 
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
             await signup.navigate()
 
             await createAndroidMocks().applyTo(page)
@@ -51,10 +44,10 @@ test.describe('Android Save prompts', () => {
             await signup.assertWasPromptedToSave(credentials, 'android')
         })
         test.describe('Prompting to save from a login form', () => {
-            /** @param {import("playwright").Page} page */
+            /** @param {import("@playwright/test").Page} page */
             async function setup (page) {
                 await forwardConsoleMessages(page)
-                const login = loginPage(page, server)
+                const login = loginPage(page)
                 await login.navigate()
 
                 await createAndroidMocks()
@@ -99,7 +92,7 @@ test.describe('Android Save prompts', () => {
         test('should not prompt to save', async ({page}) => {
             await forwardConsoleMessages(page)
 
-            const login = loginPage(page, server)
+            const login = loginPage(page)
             await login.navigate()
 
             /** @type {Partial<import('../../src/deviceApiCalls/__generated__/validators-ts').AutofillFeatureToggles>} */
@@ -137,11 +130,11 @@ test.describe('Android Save prompts', () => {
             password: '123456'
         }
         /**
-         * @param {import("playwright").Page} page
+         * @param {import("@playwright/test").Page} page
          */
         async function setup (page) {
             await forwardConsoleMessages(page)
-            const login = loginPageWithPoorForm(page, server)
+            const login = loginPageWithPoorForm(page)
             await login.navigate()
 
             await createAndroidMocks()

--- a/integration-test/tests/save-prompts.ios.spec.js
+++ b/integration-test/tests/save-prompts.ios.spec.js
@@ -1,6 +1,5 @@
 import {
     forwardConsoleMessages,
-    setupServer,
     withIOSContext, withIOSFeatureToggles
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
@@ -14,13 +13,6 @@ import {constants} from '../helpers/mocks.js'
 const test = withIOSContext(base)
 
 test.describe('iOS Save prompts', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('and saving credentials disabled ❌', () => {
         test('should not prompt to save', async ({page}) => {
             await forwardConsoleMessages(page)
@@ -33,7 +25,7 @@ test.describe('iOS Save prompts', () => {
 
             await withIOSFeatureToggles(page, toggles)
 
-            const login = loginPage(page, server)
+            const login = loginPage(page)
             await login.navigate()
 
             const credentials = {
@@ -77,14 +69,14 @@ test.describe('iOS Save prompts', () => {
                 password_generation: false
             })
 
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
             await signup.navigate()
             await signup.enterCredentials(credentials)
             await signup.assertWasPromptedToSave(credentials, 'ios')
         })
         test.describe('Prompting to save from a login form', () => {
             /**
-             * @param {import("playwright").Page} page
+             * @param {import("@playwright/test").Page} page
              */
             async function setup (page) {
                 await forwardConsoleMessages(page)
@@ -92,7 +84,7 @@ test.describe('iOS Save prompts', () => {
                 await withIOSFeatureToggles(page, {
                     credentials_saving: true
                 })
-                const login = loginPage(page, server)
+                const login = loginPage(page)
                 await login.navigate()
                 return login
             }
@@ -130,7 +122,7 @@ test.describe('iOS Save prompts', () => {
                 password: '123456'
             }
             /**
-             * @param {import("playwright").Page} page
+             * @param {import("@playwright/test").Page} page
              */
             async function setup (page) {
                 await forwardConsoleMessages(page)
@@ -138,7 +130,7 @@ test.describe('iOS Save prompts', () => {
                 await withIOSFeatureToggles(page, {
                     credentials_saving: true
                 })
-                const login = loginPageWithPoorForm(page, server)
+                const login = loginPageWithPoorForm(page)
                 await login.navigate()
 
                 await page.type('#password', credentials.password)

--- a/integration-test/tests/save-prompts.macos.spec.js
+++ b/integration-test/tests/save-prompts.macos.spec.js
@@ -1,4 +1,4 @@
-import {createAutofillScript, defaultMacosScript, forwardConsoleMessages, setupServer} from '../helpers/harness.js'
+import {createAutofillScript, defaultMacosScript, forwardConsoleMessages} from '../helpers/harness.js'
 import {constants} from '../helpers/mocks.js'
 import {createWebkitMocks, macosContentScopeReplacements} from '../helpers/mocks.webkit.js'
 import {loginPage, signupPage} from '../helpers/pages.js'
@@ -10,13 +10,6 @@ import {test as base} from '@playwright/test'
 const test = base.extend({})
 
 test.describe('macos', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('prompting to save data', () => {
         test('Prompting to save from a signup form', async ({page}) => {
             // enable in-terminal exceptions
@@ -38,7 +31,7 @@ test.describe('macos', () => {
                 .platform('macos')
                 .applyTo(page)
 
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
             await signup.navigate()
             await signup.enterCredentials(credentials)
             await signup.assertWasPromptedToSave(credentials, 'macos')
@@ -56,7 +49,7 @@ test.describe('macos', () => {
                 await createWebkitMocks().applyTo(page)
                 await defaultMacosScript(page)
 
-                const login = loginPage(page, server)
+                const login = loginPage(page)
                 await login.navigate()
                 await login.submitLoginForm(credentials)
                 await login.assertWasPromptedToSave(credentials)
@@ -67,7 +60,7 @@ test.describe('macos', () => {
                 await createWebkitMocks().applyTo(page)
                 await defaultMacosScript(page)
 
-                const login = loginPage(page, server)
+                const login = loginPage(page)
 
                 const credentials = { password: '123456' }
                 await login.navigate()
@@ -83,7 +76,7 @@ test.describe('macos', () => {
                 await createWebkitMocks().applyTo(page)
                 await defaultMacosScript(page)
 
-                const login = loginPage(page, server)
+                const login = loginPage(page)
                 await login.navigate()
                 await login.submitUsernameOnlyForm(credentials.username)
                 await login.shouldNotPromptToSave()

--- a/integration-test/tests/save-prompts.windows.spec.js
+++ b/integration-test/tests/save-prompts.windows.spec.js
@@ -1,7 +1,7 @@
 import {
     createAutofillScript,
     forwardConsoleMessages,
-    setupServer, withWindowsContext
+    withWindowsContext
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
 import {signupPage} from '../helpers/pages.js'
@@ -11,13 +11,6 @@ import {createWindowsMocks} from '../helpers/mocks.windows.js'
 const test = withWindowsContext(base)
 
 test.describe('Save prompts on windows', () => {
-    let server
-    test.beforeAll(async () => {
-        server = setupServer()
-    })
-    test.afterAll(async () => {
-        server.close()
-    })
     test.describe('When saving credentials is enabled ✅ (default)', () => {
         test('Prompting to save from a signup form', async ({page}) => {
             // enable in-terminal exceptions
@@ -30,7 +23,7 @@ test.describe('Save prompts on windows', () => {
                 password: '123456'
             }
 
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
             await signup.navigate()
 
             await createWindowsMocks().applyTo(page)
@@ -55,7 +48,7 @@ test.describe('Save prompts on windows', () => {
                 password: '123456'
             }
 
-            const signup = signupPage(page, server)
+            const signup = signupPage(page)
             await signup.navigate()
 
             await createWindowsMocks()

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/preset-env": "^7.16.11",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0",
         "@duckduckgo/content-scope-utils": "github:duckduckgo/content-scope-utils#1.0.1",
-        "@playwright/test": "^1.31.2",
+        "@playwright/test": "^1.32.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^16.11.36",
         "asana": "^1.0.0",
@@ -33,6 +33,7 @@
         "grunt-contrib-watch": "^1.1.0",
         "grunt-eslint": "^24.0.0",
         "grunt-exec": "^3.0.0",
+        "http-server": "^14.1.1",
         "jest": "^27.5.1",
         "jest-chrome": "^0.7.2",
         "jest-html-reporter": "^3.4.2",
@@ -3048,13 +3049,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
+      "integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.32.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3064,6 +3065,18 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
+      "integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -3944,6 +3957,18 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -4813,6 +4838,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -6051,6 +6085,12 @@
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6381,6 +6421,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -7473,6 +7533,15 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7538,6 +7607,20 @@
       "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
       "dev": true
     },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -7550,6 +7633,139 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/http-server/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/http-server/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-server/node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/http-server/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-server/node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/http-signature": {
@@ -11320,6 +11536,18 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -11697,6 +11925,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -12191,6 +12428,50 @@
         "node": ">=14"
       }
     },
+    "node_modules/portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/portfinder/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12649,6 +12930,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -12854,6 +13141,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",
@@ -13935,6 +14228,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -13962,6 +14267,12 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
     },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
@@ -16608,14 +16919,22 @@
       }
     },
     "@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
+      "integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.32.0"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "1.32.0",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
+          "integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
+          "dev": true
+        }
       }
     },
     "@sinonjs/commons": {
@@ -17365,6 +17684,15 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -18111,6 +18439,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "dev": true
     },
     "create-ecdh": {
@@ -19127,6 +19461,12 @@
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -19393,6 +19733,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
     },
     "for-in": {
@@ -20226,6 +20572,12 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -20279,6 +20631,17 @@
       "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
       "dev": true
     },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
     "http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -20288,6 +20651,105 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "html-encoding-sniffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+          "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+          "dev": true,
+          "requires": {
+            "whatwg-encoding": "^2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "whatwg-encoding": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+          "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.6.3"
+          }
+        }
       }
     },
     "http-signature": {
@@ -23196,6 +23658,12 @@
         }
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -23506,6 +23974,12 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -23890,6 +24364,46 @@
       "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
       "dev": true
     },
+    "portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -24255,6 +24769,12 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -24407,6 +24927,12 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
+    },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
     },
     "seedrandom": {
       "version": "3.0.5",
@@ -25310,6 +25836,15 @@
       "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
       "dev": true
     },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -25342,6 +25877,12 @@
           "dev": true
         }
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
     },
     "util": {
       "version": "0.12.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:watch": "jest --watch --verbose=false",
     "tsc": "tsc",
     "tsc:watch": "tsc --watch",
-    "verify:local": "npm run lint:fix && npm run tsc && npm run test:unit && npm run test:integration"
+    "verify:local": "npm run lint:fix && npm run tsc && npm run test:unit && npm run test:integration",
+    "serve": "http-server -c-1 --port 3210 integration-test"
   },
   "license": "Apache-2.0",
   "devDependencies": {
@@ -35,7 +36,7 @@
     "@babel/preset-env": "^7.16.11",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0",
     "@duckduckgo/content-scope-utils": "github:duckduckgo/content-scope-utils#1.0.1",
-    "@playwright/test": "^1.31.2",
+    "@playwright/test": "^1.32.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.11.36",
     "asana": "^1.0.0",
@@ -64,7 +65,8 @@
     "through2": "^4.0.2",
     "ts-to-zod": "^1.13.1",
     "typescript": "^4.7.2",
-    "zod": "^3.16.0"
+    "zod": "^3.16.0",
+    "http-server": "^14.1.1"
   },
   "dependencies": {}
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -41,6 +41,13 @@ const config = {
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry'
     },
+    /* let Playwright start/stop the server for us */
+    webServer: {
+        port: 3210,
+        reuseExistingServer: true,
+        command: "npm run serve",
+        ignoreHTTPSErrors: true,
+    },
 
     /* Configure projects for major browsers */
     projects: [

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -45,8 +45,8 @@ const config = {
     webServer: {
         port: 3210,
         reuseExistingServer: true,
-        command: "npm run serve",
-        ignoreHTTPSErrors: true,
+        command: 'npm run serve',
+        ignoreHTTPSErrors: true
     },
 
     /* Configure projects for major browsers */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,12 +31,14 @@
     "src",
     "scripts",
     "packages/password",
+    "integration-test",
     "packages/device-api",
     "*.js",
     "types.d.ts"
   ],
   "exclude": [
     "jest-test-environment.js",
-    "Gruntfile.js"
+    "Gruntfile.js",
+    "integration-test/extension"
   ]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -58,7 +58,7 @@ interface Window {
 
     providerStatusUpdated: (data: ProviderStatusUpdated) => void;
 
-    __playwright: {
+    __playwright_autofill: {
         mocks: {
             calls: MockCall[]
         }


### PR DESCRIPTION
**Reviewer:** 
**Asana:** https://app.asana.com/0/0/1204258885030984/f

## Description

- ✅ removed manual harness code for 'createServer'
- ✅ ensure `tsc` is running on all test files
- ✅ update to latest playwright

**Added Playwright Config**

```js
    /* let Playwright start/stop the server for us */
    webServer: {
        port: 3210,
        reuseExistingServer: true,
        command: "npm run serve",
        ignoreHTTPSErrors: true,
    },
```

**Before**

```javascript
test.describe('ios', () => {
    let server
    test.beforeAll(async () => {
        server = setupServer()
    })
    test.afterAll(async () => {
        server.close()
    })
    test('should autofill the selected email when email protection is enabled', async ({page}) => {
        const emailPage = emailAutofillPage(page, server)
        await emailPage.navigate()
        
        // snip
    })
})
```

**After**

```js
test.describe('ios', () => {
    test('should autofill the selected email when email protection is enabled', async ({page}) => {
        const emailPage = emailAutofillPage(page)
        await emailPage.navigate()

        // snip
    })
})
```

## Steps to test
