### PR TITLE
Only center tooltip on small screensizes

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15334,7 +15334,9 @@ class HTMLTooltip {
       left,
       top
     } = _ref;
-    const tooltipBoundingBox = this.tooltip.getBoundingClientRect(); // If overflowing from the bottom, try moving to the top
+    const tooltipBoundingBox = this.tooltip.getBoundingClientRect();
+    const smallScreenWidth = tooltipBoundingBox.width * 2;
+    const spacing = 5; // If overflowing from the bottom, move to above the input
 
     if (tooltipBoundingBox.bottom > window.innerHeight) {
       const inputPosition = this.getPosition();
@@ -15344,23 +15346,33 @@ class HTMLTooltip {
         left,
         top: overriddenTopPosition
       };
-    } // If overflowing from the left, try centering it in the window
+    } // If overflowing from the left on smaller screen, center in the window
 
 
-    if (tooltipBoundingBox.left < 0) {
+    if (tooltipBoundingBox.left < 0 && window.innerWidth <= smallScreenWidth) {
+      const leftOverflow = Math.abs(tooltipBoundingBox.left);
       const leftPosWhenCentered = (window.innerWidth - tooltipBoundingBox.width) / 2;
-      const overriddenLeftPosition = left + Math.abs(tooltipBoundingBox.left) + leftPosWhenCentered;
+      const overriddenLeftPosition = left + leftOverflow + leftPosWhenCentered;
       return {
         left: overriddenLeftPosition,
         top
       };
-    } // If overflowing from the right, move it slightly to the left
+    } // If overflowing from the left on larger screen, move so it's just on screen on the left
+
+
+    if (tooltipBoundingBox.left < 0 && window.innerWidth > smallScreenWidth) {
+      const leftOverflow = Math.abs(tooltipBoundingBox.left);
+      const overriddenLeftPosition = left + leftOverflow + spacing;
+      return {
+        left: overriddenLeftPosition,
+        top
+      };
+    } // If overflowing from the right, move so it's just on screen on the right
 
 
     if (tooltipBoundingBox.right > window.innerWidth) {
       const rightOverflow = tooltipBoundingBox.right - window.innerWidth;
-      const extraPadding = 5;
-      const overriddenLeftPosition = left - rightOverflow - extraPadding;
+      const overriddenLeftPosition = left - rightOverflow - spacing;
       return {
         left: overriddenLeftPosition,
         top

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -11658,7 +11658,9 @@ class HTMLTooltip {
       left,
       top
     } = _ref;
-    const tooltipBoundingBox = this.tooltip.getBoundingClientRect(); // If overflowing from the bottom, try moving to the top
+    const tooltipBoundingBox = this.tooltip.getBoundingClientRect();
+    const smallScreenWidth = tooltipBoundingBox.width * 2;
+    const spacing = 5; // If overflowing from the bottom, move to above the input
 
     if (tooltipBoundingBox.bottom > window.innerHeight) {
       const inputPosition = this.getPosition();
@@ -11668,23 +11670,33 @@ class HTMLTooltip {
         left,
         top: overriddenTopPosition
       };
-    } // If overflowing from the left, try centering it in the window
+    } // If overflowing from the left on smaller screen, center in the window
 
 
-    if (tooltipBoundingBox.left < 0) {
+    if (tooltipBoundingBox.left < 0 && window.innerWidth <= smallScreenWidth) {
+      const leftOverflow = Math.abs(tooltipBoundingBox.left);
       const leftPosWhenCentered = (window.innerWidth - tooltipBoundingBox.width) / 2;
-      const overriddenLeftPosition = left + Math.abs(tooltipBoundingBox.left) + leftPosWhenCentered;
+      const overriddenLeftPosition = left + leftOverflow + leftPosWhenCentered;
       return {
         left: overriddenLeftPosition,
         top
       };
-    } // If overflowing from the right, move it slightly to the left
+    } // If overflowing from the left on larger screen, move so it's just on screen on the left
+
+
+    if (tooltipBoundingBox.left < 0 && window.innerWidth > smallScreenWidth) {
+      const leftOverflow = Math.abs(tooltipBoundingBox.left);
+      const overriddenLeftPosition = left + leftOverflow + spacing;
+      return {
+        left: overriddenLeftPosition,
+        top
+      };
+    } // If overflowing from the right, move so it's just on screen on the right
 
 
     if (tooltipBoundingBox.right > window.innerWidth) {
       const rightOverflow = tooltipBoundingBox.right - window.innerWidth;
-      const extraPadding = 5;
-      const overriddenLeftPosition = left - rightOverflow - extraPadding;
+      const overriddenLeftPosition = left - rightOverflow - spacing;
       return {
         left: overriddenLeftPosition,
         top

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -6,6 +6,7 @@ export const constants = {
         'overlay': 'pages/overlay.html',
         'email-autofill': 'pages/email-autofill.html',
         'emailAtBottom': 'pages/email-at-bottom.html',
+        'emailAtTopLeft': 'pages/email-at-top-left.html',
         'iframeContainer': 'pages/iframe-container.html',
         'signup': 'pages/signup.html',
         'login': 'pages/login.html',

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -6,6 +6,7 @@ import {clickOnIcon} from './utils.js'
 const ATTR_AUTOFILL = 'data-ddg-autofill'
 
 export function incontextSignupPage (page) {
+    const {selectors} = constants.fields.email
     const getCallToAction = () => page.locator(`text=Protect My Email`)
     const getTooltip = () => page.locator('.tooltip--email')
     return {
@@ -26,6 +27,10 @@ export function incontextSignupPage (page) {
         async closeTooltip () {
             const dismissTooltipButton = await page.locator(`[aria-label=Close]`)
             await dismissTooltipButton.click({timeout: 500})
+        },
+        async clickDirectlyOnDax () {
+            const input = page.locator(selectors.identity)
+            await clickOnIcon(input)
         }
     }
 }
@@ -50,16 +55,21 @@ export function incontextSignupPageWithinIframe (page) {
 }
 
 export function incontextSignupPageEmailBottomPage (page) {
-    const {selectors} = constants.fields.email
     return {
         async navigate (domain) {
             const pageName = constants.pages['emailAtBottom']
             const pagePath = `integration-test/${pageName}`
             await page.goto(new URL(pagePath, domain).href)
-        },
-        async clickDirectlyOnDax () {
-            const input = page.locator(selectors.identity)
-            await clickOnIcon(input)
+        }
+    }
+}
+
+export function incontextSignupPageEmailTopLeftPage (page) {
+    return {
+        async navigate (domain) {
+            const pageName = constants.pages['emailAtTopLeft']
+            const pagePath = `integration-test/${pageName}`
+            await page.goto(new URL(pagePath, domain).href)
         }
     }
 }

--- a/integration-test/pages/email-at-top-left.html
+++ b/integration-test/pages/email-at-top-left.html
@@ -9,11 +9,7 @@
 </head>
 
 <body>
-<p><a href="../index.html">[Home]</a></p>
-
-<p id="demo"></p>
-
-<div class="subscribe-newsletter-bottom">
+<div class="subscribe-newsletter-top-left">
   <form action="/subscribe">
     <fieldset>
       <label for="email-fixed">Email</label>
@@ -22,6 +18,10 @@
     </fieldset>
   </form>
 </div>
+
+<p><a href="../index.html">[Home]</a></p>
+
+<p id="demo"></p>
 
 </body>
 

--- a/integration-test/pages/index.html
+++ b/integration-test/pages/index.html
@@ -10,6 +10,7 @@
 <body>
 <ul>
     <li><a href="email-at-bottom.html">email-at-bottom.html</a></li>
+    <li><a href="email-at-top-left.html">email-at-top-left.html</a></li>
     <li><a href="email-autofill.html">email-autofill.html</a></li>
     <li><a href="iframe-container.html">iframe-container.html</a></li>
     <li><a href="login.html">login.html</a></li>

--- a/integration-test/pages/style.css
+++ b/integration-test/pages/style.css
@@ -26,7 +26,15 @@ iframe {
     left: 1em;
 }
 
-.subscribe-newsletter {
+.subscribe-newsletter-top-left {
+    padding: 1rem;
+    position: fixed;
+    left: 0;
+    top: 0;
+    z-index: 1;
+}
+
+.subscribe-newsletter-bottom {
     padding: 1rem;
     position: fixed;
     left: 0;
@@ -36,7 +44,8 @@ iframe {
     z-index: 1;
 }
 
-.subscribe-newsletter fieldset {
+.subscribe-newsletter-top-left fieldset,
+.subscribe-newsletter-bottom fieldset {
     display: flex;
     margin: 0 auto;
 }

--- a/integration-test/tests/incontext-signup.extension.spec.js
+++ b/integration-test/tests/incontext-signup.extension.spec.js
@@ -1,6 +1,6 @@
 import {forwardConsoleMessages, withChromeExtensionContext, setupMockedDomain} from '../helpers/harness.js'
 import { test as base, expect } from '@playwright/test'
-import {emailAutofillPage, incontextSignupPage, incontextSignupPageWithinIframe, incontextSignupPageEmailBottomPage} from '../helpers/pages.js'
+import {emailAutofillPage, incontextSignupPage, incontextSignupPageWithinIframe, incontextSignupPageEmailBottomPage, incontextSignupPageEmailTopLeftPage} from '../helpers/pages.js'
 
 /**
  *  Tests for email autofill in chrome extension.
@@ -100,8 +100,21 @@ test.describe('chrome extension', () => {
         const pageWidthEmailBottomPage = incontextSignupPageEmailBottomPage(page)
         await pageWidthEmailBottomPage.navigate('https://example.com')
 
-        await pageWidthEmailBottomPage.clickDirectlyOnDax()
+        await incontextSignup.clickDirectlyOnDax()
         await incontextSignup.assertIsShowing()
-        await incontextSignup.dismissTooltipWith("Don't Show Again")
+        await incontextSignup.closeTooltip()
+    })
+
+    test('should display properly above when email at top left of page', async ({page}) => {
+        forwardConsoleMessages(page)
+        await setupMockedDomain(page, 'https://example.com')
+
+        const incontextSignup = incontextSignupPage(page)
+        const pageWidthEmailTopLeftPage = incontextSignupPageEmailTopLeftPage(page)
+        await pageWidthEmailTopLeftPage.navigate('https://example.com')
+
+        await incontextSignup.clickDirectlyOnDax()
+        await incontextSignup.assertIsShowing()
+        await incontextSignup.closeTooltip()
     })
 })

--- a/src/UI/HTMLTooltip.js
+++ b/src/UI/HTMLTooltip.js
@@ -155,8 +155,10 @@ export class HTMLTooltip {
 
     getOverridePosition ({left, top}) {
         const tooltipBoundingBox = this.tooltip.getBoundingClientRect()
+        const smallScreenWidth = tooltipBoundingBox.width * 2
+        const spacing = 5
 
-        // If overflowing from the bottom, try moving to the top
+        // If overflowing from the bottom, move to above the input
         if (tooltipBoundingBox.bottom > window.innerHeight) {
             const inputPosition = this.getPosition()
             const caretHeight = 14
@@ -164,18 +166,25 @@ export class HTMLTooltip {
             if (overriddenTopPosition >= 0) return {left, top: overriddenTopPosition}
         }
 
-        // If overflowing from the left, try centering it in the window
-        if (tooltipBoundingBox.left < 0) {
+        // If overflowing from the left on smaller screen, center in the window
+        if (tooltipBoundingBox.left < 0 && window.innerWidth <= smallScreenWidth) {
+            const leftOverflow = Math.abs(tooltipBoundingBox.left)
             const leftPosWhenCentered = (window.innerWidth - tooltipBoundingBox.width) / 2
-            const overriddenLeftPosition = left + Math.abs(tooltipBoundingBox.left) + leftPosWhenCentered
+            const overriddenLeftPosition = left + leftOverflow + leftPosWhenCentered
             return {left: overriddenLeftPosition, top}
         }
 
-        // If overflowing from the right, move it slightly to the left
+        // If overflowing from the left on larger screen, move so it's just on screen on the left
+        if (tooltipBoundingBox.left < 0 && window.innerWidth > smallScreenWidth) {
+            const leftOverflow = Math.abs(tooltipBoundingBox.left)
+            const overriddenLeftPosition = left + leftOverflow + spacing
+            return {left: overriddenLeftPosition, top}
+        }
+
+        // If overflowing from the right, move so it's just on screen on the right
         if (tooltipBoundingBox.right > window.innerWidth) {
             const rightOverflow = tooltipBoundingBox.right - window.innerWidth
-            const extraPadding = 5
-            const overriddenLeftPosition = left - rightOverflow - extraPadding
+            const overriddenLeftPosition = left - rightOverflow - spacing
             return {left: overriddenLeftPosition, top}
         }
     }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15334,7 +15334,9 @@ class HTMLTooltip {
       left,
       top
     } = _ref;
-    const tooltipBoundingBox = this.tooltip.getBoundingClientRect(); // If overflowing from the bottom, try moving to the top
+    const tooltipBoundingBox = this.tooltip.getBoundingClientRect();
+    const smallScreenWidth = tooltipBoundingBox.width * 2;
+    const spacing = 5; // If overflowing from the bottom, move to above the input
 
     if (tooltipBoundingBox.bottom > window.innerHeight) {
       const inputPosition = this.getPosition();
@@ -15344,23 +15346,33 @@ class HTMLTooltip {
         left,
         top: overriddenTopPosition
       };
-    } // If overflowing from the left, try centering it in the window
+    } // If overflowing from the left on smaller screen, center in the window
 
 
-    if (tooltipBoundingBox.left < 0) {
+    if (tooltipBoundingBox.left < 0 && window.innerWidth <= smallScreenWidth) {
+      const leftOverflow = Math.abs(tooltipBoundingBox.left);
       const leftPosWhenCentered = (window.innerWidth - tooltipBoundingBox.width) / 2;
-      const overriddenLeftPosition = left + Math.abs(tooltipBoundingBox.left) + leftPosWhenCentered;
+      const overriddenLeftPosition = left + leftOverflow + leftPosWhenCentered;
       return {
         left: overriddenLeftPosition,
         top
       };
-    } // If overflowing from the right, move it slightly to the left
+    } // If overflowing from the left on larger screen, move so it's just on screen on the left
+
+
+    if (tooltipBoundingBox.left < 0 && window.innerWidth > smallScreenWidth) {
+      const leftOverflow = Math.abs(tooltipBoundingBox.left);
+      const overriddenLeftPosition = left + leftOverflow + spacing;
+      return {
+        left: overriddenLeftPosition,
+        top
+      };
+    } // If overflowing from the right, move so it's just on screen on the right
 
 
     if (tooltipBoundingBox.right > window.innerWidth) {
       const rightOverflow = tooltipBoundingBox.right - window.innerWidth;
-      const extraPadding = 5;
-      const overriddenLeftPosition = left - rightOverflow - extraPadding;
+      const overriddenLeftPosition = left - rightOverflow - spacing;
       return {
         left: overriddenLeftPosition,
         top

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -11658,7 +11658,9 @@ class HTMLTooltip {
       left,
       top
     } = _ref;
-    const tooltipBoundingBox = this.tooltip.getBoundingClientRect(); // If overflowing from the bottom, try moving to the top
+    const tooltipBoundingBox = this.tooltip.getBoundingClientRect();
+    const smallScreenWidth = tooltipBoundingBox.width * 2;
+    const spacing = 5; // If overflowing from the bottom, move to above the input
 
     if (tooltipBoundingBox.bottom > window.innerHeight) {
       const inputPosition = this.getPosition();
@@ -11668,23 +11670,33 @@ class HTMLTooltip {
         left,
         top: overriddenTopPosition
       };
-    } // If overflowing from the left, try centering it in the window
+    } // If overflowing from the left on smaller screen, center in the window
 
 
-    if (tooltipBoundingBox.left < 0) {
+    if (tooltipBoundingBox.left < 0 && window.innerWidth <= smallScreenWidth) {
+      const leftOverflow = Math.abs(tooltipBoundingBox.left);
       const leftPosWhenCentered = (window.innerWidth - tooltipBoundingBox.width) / 2;
-      const overriddenLeftPosition = left + Math.abs(tooltipBoundingBox.left) + leftPosWhenCentered;
+      const overriddenLeftPosition = left + leftOverflow + leftPosWhenCentered;
       return {
         left: overriddenLeftPosition,
         top
       };
-    } // If overflowing from the right, move it slightly to the left
+    } // If overflowing from the left on larger screen, move so it's just on screen on the left
+
+
+    if (tooltipBoundingBox.left < 0 && window.innerWidth > smallScreenWidth) {
+      const leftOverflow = Math.abs(tooltipBoundingBox.left);
+      const overriddenLeftPosition = left + leftOverflow + spacing;
+      return {
+        left: overriddenLeftPosition,
+        top
+      };
+    } // If overflowing from the right, move so it's just on screen on the right
 
 
     if (tooltipBoundingBox.right > window.innerWidth) {
       const rightOverflow = tooltipBoundingBox.right - window.innerWidth;
-      const extraPadding = 5;
-      const overriddenLeftPosition = left - rightOverflow - extraPadding;
+      const overriddenLeftPosition = left - rightOverflow - spacing;
       return {
         left: overriddenLeftPosition,
         top


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1200930669568058/1204260378586823/f

## Description
When the tooltip goes offscreen to the left, we center it withiin the window. This usually happens on small screens or iframes. However, there are some sites which have the email input close to the left and which this triggers.

Example: On https://thehustle.co/ with a screensize between 1025px and 1188px

Instead, on larger screensizes (e.g. ones which are as big as two tooltip widths), let's so the same as when we're offscreen on the right and just bring the tooltip back onscreen.

Before | After
--- | ---
<img width="1065" alt="Screenshot 2023-03-24 at 15 31 58" src="https://user-images.githubusercontent.com/635903/227585539-1390e4ab-611c-4733-a714-f76dbdcc1b58.png"> | <img width="1061" alt="Screenshot 2023-03-24 at 15 33 31" src="https://user-images.githubusercontent.com/635903/227585564-e6af0ace-4c1f-4bd4-b6b8-8d34ac83bc10.png">

### Integration test
<img width="1136" alt="Screenshot 2023-03-24 at 16 11 03" src="https://user-images.githubusercontent.com/635903/227585577-a96ed6fa-1746-467f-9ea3-57a82428f984.png">


## Steps to test
1. Go to https://thehustle.co/
2. Change your window width to 1100px
3. Open incontext signup on the email input