### PR TITLE
Update release scripts with latest Apple tooling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/scripts/release/release-utils.js
+++ b/scripts/release/release-utils.js
@@ -94,21 +94,48 @@ function updatePackageSwift (packageSwiftContent, version) {
 /**
  * Provide the source Package.resolved for BSK and get it updated with the autofill version
  * @param {string} packageResolvedContent
- * @param {string} version
- * @param {string} commit
+ * @param {{
+ *     autofill: {
+ *         version: string,
+ *         commit: string
+ *     },
+ *     bsk?: {
+ *         commit: string
+ *     }
+ * }} substitutions
  * @returns {string}
  */
-function updatePackageResolved (packageResolvedContent, version, commit) {
-    const autofillPackageResolvedRegex = new RegExp(
-        /("location" : "https:\/\/github.com\/duckduckgo\/duckduckgo-autofill.git",\s+"state" : {\s+"revision" : ")(\w+)(",\s+"version" : ")([\d.]+)("\s+})/,
-        'i'
-    )
+function updatePackageResolved (packageResolvedContent, substitutions) {
+    const regexes = {
+        autofill: new RegExp(
+            /("location" : "https:\/\/github.com\/duckduckgo\/duckduckgo-autofill.git",\s+"state" : {\s+"revision" : ")(\w+)(",\s+"version" : ")([\d.]+)("\s+})/,
+            'i'
+        ),
+        bsk: new RegExp(
+            /("location" : "https:\/\/github.com\/duckduckgo\/BrowserServicesKit",\s+"state" : {\s+"revision" : ")(\w+)(",\s+"version" : "[\d.]+)("\s+})/,
+            'i'
+        )
+    }
 
-    return replaceInString(
-        packageResolvedContent,
-        autofillPackageResolvedRegex,
-        `$1${commit}$3${version}$5`
-    )
+    let updatedContent = packageResolvedContent
+
+    if (substitutions.autofill) {
+        updatedContent = replaceInString(
+            updatedContent,
+            regexes.autofill,
+            `$1${substitutions.autofill.commit}$3${substitutions.autofill.version}$5`
+        )
+    }
+
+    if (substitutions.bsk) {
+        updatedContent = replaceInString(
+            updatedContent,
+            regexes.bsk,
+            `$1${substitutions.bsk.commit}$4`
+        )
+    }
+
+    return updatedContent
 }
 
 module.exports = {

--- a/scripts/release/release-utils.js
+++ b/scripts/release/release-utils.js
@@ -106,31 +106,30 @@ function updatePackageSwift (packageSwiftContent, version) {
  * @returns {string}
  */
 function updatePackageResolved (packageResolvedContent, substitutions) {
-    const regexes = {
-        autofill: new RegExp(
-            /("location" : "https:\/\/github.com\/duckduckgo\/duckduckgo-autofill.git",\s+"state" : {\s+"revision" : ")(\w+)(",\s+"version" : ")([\d.]+)("\s+})/,
-            'i'
-        ),
-        bsk: new RegExp(
-            /("location" : "https:\/\/github.com\/duckduckgo\/BrowserServicesKit",\s+"state" : {\s+"revision" : ")(\w+)(",\s+"version" : "[\d.]+)("\s+})/,
-            'i'
-        )
-    }
-
     let updatedContent = packageResolvedContent
 
     if (substitutions.autofill) {
+        const autofillRegex = new RegExp(
+            /("location" : "https:\/\/github.com\/duckduckgo\/duckduckgo-autofill.git",\s+"state" : {\s+"revision" : ")(\w+)(",\s+"version" : ")([\d.]+)("\s+})/,
+            'i'
+        )
+
         updatedContent = replaceInString(
             updatedContent,
-            regexes.autofill,
+            autofillRegex,
             `$1${substitutions.autofill.commit}$3${substitutions.autofill.version}$5`
         )
     }
 
     if (substitutions.bsk) {
+        const bskRegex = new RegExp(
+            /("location" : "https:\/\/github.com\/duckduckgo\/BrowserServicesKit",\s+"state" : {\s+"revision" : ")(\w+)(",\s+"version" : "[\d.]+)("\s+})/,
+            'i'
+        )
+
         updatedContent = replaceInString(
             updatedContent,
-            regexes.bsk,
+            bskRegex,
             `$1${substitutions.bsk.commit}$4`
         )
     }

--- a/scripts/release/release-utils.js
+++ b/scripts/release/release-utils.js
@@ -100,7 +100,7 @@ function updatePackageSwift (packageSwiftContent, version) {
  */
 function updatePackageResolved (packageResolvedContent, version, commit) {
     const autofillPackageResolvedRegex = new RegExp(
-        /("package": "Autofill",\s+"repositoryURL": "https:\/\/github.com\/duckduckgo\/duckduckgo-autofill.git",\s+"state": {\s+"branch": null,\s+"revision": ")(\w+)(",\s+"version": ")([\d.]+)("\s+})/,
+        /("location" : "https:\/\/github.com\/duckduckgo\/duckduckgo-autofill.git",\s+"state" : {\s+"revision" : ")(\w+)(",\s+"version" : ")([\d.]+)("\s+})/,
         'i'
     )
 

--- a/scripts/release/tests/regex-tests.test.js
+++ b/scripts/release/tests/regex-tests.test.js
@@ -2,6 +2,7 @@ import {updatePackageResolved, updatePackageSwift, updateProjectPbxproj} from '.
 
 const version = '0.0.0_test'
 const commit = 'd5ce164fecfaf7ff2324522b1ff7127e61596063'
+const bskCommit = 'e7756c9653ce1490be3f625299d1b752421d4834'
 
 describe('Platform replace regexes', () => {
     test('BSK can be updated successfully', () => {
@@ -10,7 +11,7 @@ dependencies: [
     .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.0.1")),
     .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
 ]`
-        const examplePackageResolved = `
+        const examplePackageResolvedForBSK = `
 {
     "identity" : "duckduckgo-autofill",
     "kind" : "remoteSourceControl",
@@ -21,12 +22,50 @@ dependencies: [
     }
 }`
 
+        const examplePackageResolvedForMacOS = `
+{
+        "identity" : "browserserviceskit",
+        "kind" : "remoteSourceControl",
+        "location" : "https://github.com/duckduckgo/BrowserServicesKit",
+        "state" : {
+            "revision" : "fc9ada07283575e3106e6fc5c670a96c34a86f55",
+            "version" : "54.1.0"
+        }
+    },
+    {
+        "identity" : "content-scope-scripts",
+        "kind" : "remoteSourceControl",
+        "location" : "https://github.com/duckduckgo/content-scope-scripts",
+        "state" : {
+            "revision" : "801b7f23476f797c6eaa72b070e6c80abb82801a",
+            "version" : "4.4.4"
+        }
+    },
+    {
+        "identity" : "duckduckgo-autofill",
+        "kind" : "remoteSourceControl",
+        "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
+        "state" : {
+            "revision" : "4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
+            "version" : "6.4.3"
+        }
+    },`
+
         const updatedPackageSwift = updatePackageSwift(examplePackageSwift, version)
         expect(updatedPackageSwift).toContain(`"https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("${version}")`)
 
-        const updatedPackageResolved = updatePackageResolved(examplePackageResolved, version, commit)
-        expect(updatedPackageResolved).toContain(`"revision" : "${commit}"`)
-        expect(updatedPackageResolved).toContain(`"version" : "${version}"`)
+        const updatedPackageResolvedForBSK = updatePackageResolved(examplePackageResolvedForBSK, {autofill: {version, commit}})
+        expect(updatedPackageResolvedForBSK).toContain(`"revision" : "${commit}"`)
+        expect(updatedPackageResolvedForBSK).toContain(`"version" : "${version}"`)
+
+        const substitutions = {
+            autofill: {version, commit},
+            bsk: {commit: bskCommit}
+        }
+        const updatedPackageResolvedForMacOS = updatePackageResolved(examplePackageResolvedForMacOS, substitutions)
+        expect(updatedPackageResolvedForMacOS).toContain(`"revision" : "${commit}"`)
+        expect(updatedPackageResolvedForMacOS).toContain(`"version" : "${version}"`)
+        expect(updatedPackageResolvedForMacOS).toContain(`"revision" : "${bskCommit}"`)
     })
 
     test('Apple platforms can be updated successfully', () => {

--- a/scripts/release/tests/regex-tests.test.js
+++ b/scripts/release/tests/regex-tests.test.js
@@ -22,6 +22,15 @@ dependencies: [
     }
 }`
 
+        const updatedPackageSwift = updatePackageSwift(examplePackageSwift, version)
+        expect(updatedPackageSwift).toContain(`"https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("${version}")`)
+
+        const updatedPackageResolvedForBSK = updatePackageResolved(examplePackageResolvedForBSK, {autofill: {version, commit}})
+        expect(updatedPackageResolvedForBSK).toContain(`"revision" : "${commit}"`)
+        expect(updatedPackageResolvedForBSK).toContain(`"version" : "${version}"`)
+    })
+
+    test('macOS can be updated successfully', () => {
         const examplePackageResolvedForMacOS = `
 {
         "identity" : "browserserviceskit",
@@ -50,13 +59,6 @@ dependencies: [
             "version" : "6.4.3"
         }
     },`
-
-        const updatedPackageSwift = updatePackageSwift(examplePackageSwift, version)
-        expect(updatedPackageSwift).toContain(`"https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("${version}")`)
-
-        const updatedPackageResolvedForBSK = updatePackageResolved(examplePackageResolvedForBSK, {autofill: {version, commit}})
-        expect(updatedPackageResolvedForBSK).toContain(`"revision" : "${commit}"`)
-        expect(updatedPackageResolvedForBSK).toContain(`"version" : "${version}"`)
 
         const substitutions = {
             autofill: {version, commit},

--- a/scripts/release/tests/regex-tests.test.js
+++ b/scripts/release/tests/regex-tests.test.js
@@ -12,12 +12,12 @@ dependencies: [
 ]`
         const examplePackageResolved = `
 {
-    "package": "Autofill",
-    "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
-    "state": {
-        "branch": null,
-        "revision": "d29c5abc7f473b69f3d81d8a15e137ed3aab029d",
-        "version": "5.0.1"
+    "identity" : "duckduckgo-autofill",
+    "kind" : "remoteSourceControl",
+    "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
+    "state" : {
+        "revision" : "4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
+        "version" : "6.4.3"
     }
 }`
 
@@ -25,8 +25,8 @@ dependencies: [
         expect(updatedPackageSwift).toContain(`"https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("${version}")`)
 
         const updatedPackageResolved = updatePackageResolved(examplePackageResolved, version, commit)
-        expect(updatedPackageResolved).toContain(`"revision": "${commit}"`)
-        expect(updatedPackageResolved).toContain(`"version": "${version}"`)
+        expect(updatedPackageResolved).toContain(`"revision" : "${commit}"`)
+        expect(updatedPackageResolved).toContain(`"version" : "${version}"`)
     })
 
     test('Apple platforms can be updated successfully', () => {

--- a/scripts/release/update-apple-device-repo.js
+++ b/scripts/release/update-apple-device-repo.js
@@ -1,11 +1,15 @@
 const {readFileSync, writeFileSync} = require('fs')
 const {join} = require('path')
 const {updateProjectPbxproj} = require('./release-utils.js')
+const {updatePackageResolved} = require('./release-utils.js')
 const cwd = join(__dirname, '..')
 const filepath = (...path) => join(cwd, ...path)
 const platform = process.argv[2]
 
-const bskCommit = process.env.BSK_SHA
+const autofillCommit = process.env.GITHUB_SHA || ''
+const autofillVersion = process.env.VERSION || ''
+
+const bskCommit = process.env.BSK_SHA || ''
 
 function updateAppleDeviceRepo (platform = 'ios', commit) {
     console.log(`running updateAppleDeviceRepo for ${platform}`)
@@ -17,6 +21,25 @@ function updateAppleDeviceRepo (platform = 'ios', commit) {
     const projectFile = readFileSync(projectFilePath, 'utf8')
     const updatedProjectFile = updateProjectPbxproj(projectFile, commit)
     writeFileSync(projectFilePath, updatedProjectFile)
+
+    if (platform === 'macos') {
+        const packageResolvedPath = filepath('../../macos/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved')
+
+        const substitutions = {
+            autofill: {
+                version: autofillVersion,
+                commit: autofillCommit
+            },
+            bsk: {
+                commit: bskCommit
+            }
+        }
+
+        const packageResolved = readFileSync(packageResolvedPath, 'utf8')
+        const updatedPackageResolve = updatePackageResolved(packageResolved, substitutions)
+        writeFileSync(packageResolvedPath, updatedPackageResolve)
+    }
+
     console.log(`BSK reference updated in ${platform} repo`)
 }
 

--- a/scripts/release/update-bsk-repo.js
+++ b/scripts/release/update-bsk-repo.js
@@ -22,7 +22,7 @@ function updateBSKRepo (version, commit) {
     console.log('Autofill reference updated in BSK\'s Package.swift')
 
     const packageResolved = readFileSync(packageResolvedPath, 'utf8')
-    const updatedPackageResolve = updatePackageResolved(packageResolved, version, commit)
+    const updatedPackageResolve = updatePackageResolved(packageResolved, {autofill: {version, commit}})
     writeFileSync(packageResolvedPath, updatedPackageResolve)
     console.log('Autofill reference updated in BSK\'s Package.resolved')
 }


### PR DESCRIPTION
**Reviewer:** @alistairjcbrown 
**Asana:** https://app.asana.com/0/1198964220583541/1204279142680454/f

## Description
The Apple team has recently updated their tooling. Trying to keep up 🙂. In the future, we should migrate to better tools, like the Xcode CLI, but hopefully the native apps team can automate this stuff for us.

## Steps to test
Updated automated tests, but this hasn't run on the real thing.