### PR TITLE
Add temporary incontext_eligible pixel

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -7442,6 +7442,10 @@ class AndroidInterface extends _InterfacePrototype.default {
       }
     });
   }
+  /** Noop */
+
+
+  firePixel(_pixelParam) {}
 
 }
 
@@ -9937,9 +9941,10 @@ class Form {
       let {
         el,
         type,
-        fn
+        fn,
+        opts
       } = _ref;
-      return el.removeEventListener(type, fn);
+      return el.removeEventListener(type, fn, opts);
     });
   }
 
@@ -10069,17 +10074,39 @@ class Form {
     };
     this.matching.setInputType(input, this.form, opts);
     const mainInputType = (0, _matching.getInputMainType)(input);
-    this.inputs[mainInputType].add(input);
+    this.inputs[mainInputType].add(input); // TODO: temporary pixel
+
+    const subtype = (0, _matching.getInputSubtype)(input);
+
+    if (subtype === 'emailAddress') {
+      this.addListener(input, 'focus', () => {
+        this.device.firePixel({
+          pixelName: 'incontext_eligible'
+        });
+      }, {
+        once: true
+      });
+    }
+
     this.decorateInput(input);
     return this;
   }
+  /**
+   * Adds event listeners and keeps track of them for subsequent removal
+   * @param {HTMLElement} el
+   * @param {Event['type']} type
+   * @param {() => void} fn
+   * @param {AddEventListenerOptions} [opts]
+   */
 
-  addListener(el, type, fn) {
-    el.addEventListener(type, fn);
+
+  addListener(el, type, fn, opts) {
+    el.addEventListener(type, fn, opts);
     this.listeners.add({
       el,
       type,
-      fn
+      fn,
+      opts
     });
   }
 
@@ -17445,6 +17472,8 @@ const sendJSPixelParamsSchema = _zod.z.union([_zod.z.object({
   pixelName: _zod.z.literal("incontext_dismiss_persisted")
 }), _zod.z.object({
   pixelName: _zod.z.literal("incontext_close_x")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_eligible")
 })]);
 
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10079,7 +10079,7 @@ class Form {
     const subtype = (0, _matching.getInputSubtype)(input);
 
     if (subtype === 'emailAddress') {
-      this.addListener(input, 'focus', () => {
+      this.addListener(input, 'pointerdown', () => {
         this.device.firePixel({
           pixelName: 'incontext_eligible'
         });

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6403,7 +6403,7 @@ class Form {
     const subtype = (0, _matching.getInputSubtype)(input);
 
     if (subtype === 'emailAddress') {
-      this.addListener(input, 'focus', () => {
+      this.addListener(input, 'pointerdown', () => {
         this.device.firePixel({
           pixelName: 'incontext_eligible'
         });

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -3766,6 +3766,10 @@ class AndroidInterface extends _InterfacePrototype.default {
       }
     });
   }
+  /** Noop */
+
+
+  firePixel(_pixelParam) {}
 
 }
 
@@ -6261,9 +6265,10 @@ class Form {
       let {
         el,
         type,
-        fn
+        fn,
+        opts
       } = _ref;
-      return el.removeEventListener(type, fn);
+      return el.removeEventListener(type, fn, opts);
     });
   }
 
@@ -6393,17 +6398,39 @@ class Form {
     };
     this.matching.setInputType(input, this.form, opts);
     const mainInputType = (0, _matching.getInputMainType)(input);
-    this.inputs[mainInputType].add(input);
+    this.inputs[mainInputType].add(input); // TODO: temporary pixel
+
+    const subtype = (0, _matching.getInputSubtype)(input);
+
+    if (subtype === 'emailAddress') {
+      this.addListener(input, 'focus', () => {
+        this.device.firePixel({
+          pixelName: 'incontext_eligible'
+        });
+      }, {
+        once: true
+      });
+    }
+
     this.decorateInput(input);
     return this;
   }
+  /**
+   * Adds event listeners and keeps track of them for subsequent removal
+   * @param {HTMLElement} el
+   * @param {Event['type']} type
+   * @param {() => void} fn
+   * @param {AddEventListenerOptions} [opts]
+   */
 
-  addListener(el, type, fn) {
-    el.addEventListener(type, fn);
+
+  addListener(el, type, fn, opts) {
+    el.addEventListener(type, fn, opts);
     this.listeners.add({
       el,
       type,
-      fn
+      fn,
+      opts
     });
   }
 

--- a/integration-test/tests/email-autofill.extension.spec.js
+++ b/integration-test/tests/email-autofill.extension.spec.js
@@ -34,7 +34,7 @@ test.describe('chrome extension', () => {
         await emailPage.assertEmailValue(personalAddress)
 
         // ensure background page received pixel
-        await emailPage.assertExtensionPixelsCaptured(['autofill_show', 'autofill_personal_address'])
+        await emailPage.assertExtensionPixelsCaptured(['incontext_eligible', 'autofill_show', 'autofill_personal_address'])
 
         // now ensure a second click into the input doesn't show the dropdown
         await emailPage.clickIntoInput()
@@ -52,6 +52,6 @@ test.describe('chrome extension', () => {
         await emailPage.assertEmailValue(privateAddress0)
 
         // assert that the background page received  pixel
-        await emailPage.assertExtensionPixelsCaptured(['autofill_show', 'autofill_personal_address', 'autofill_show', 'autofill_private_address'])
+        await emailPage.assertExtensionPixelsCaptured(['incontext_eligible', 'autofill_show', 'autofill_personal_address', 'autofill_show', 'autofill_private_address'])
     })
 })

--- a/integration-test/tests/email-autofill.macos.spec.js
+++ b/integration-test/tests/email-autofill.macos.spec.js
@@ -52,6 +52,7 @@ test.describe('macos', () => {
 
         // ensure pixel was fired
         await emailPage.assertPixelsFired([
+            {pixelName: 'incontext_eligible'},
             {pixelName: 'autofill_identity', params: {fieldType: 'emailAddress'}},
             {pixelName: 'autofill_personal_address'}
         ])
@@ -68,6 +69,7 @@ test.describe('macos', () => {
 
         // ensure pixel was fired
         await emailPage.assertPixelsFired([
+            {pixelName: 'incontext_eligible'},
             {pixelName: 'autofill_identity', params: {fieldType: 'emailAddress'}},
             {pixelName: 'autofill_personal_address'},
             {pixelName: 'autofill_identity', params: {fieldType: 'emailAddress'}},
@@ -146,6 +148,7 @@ test.describe('macos', () => {
             await signup.selectFirstEmailField(identityWithDuckAddress.emailAddress)
             await signup.assertEmailValue(identityWithDuckAddress.emailAddress)
             await signup.assertPixelsFired([
+                {pixelName: 'incontext_eligible'},
                 {pixelName: 'autofill_identity', params: {fieldType: 'emailAddress'}},
                 {pixelName: 'autofill_personal_address'}
             ])
@@ -208,6 +211,7 @@ test.describe('macos', () => {
         await signup.assertSecondEmailValue(personalAddress)
         await signup.assertFirstEmailEmpty()
         await signup.assertPixelsFired([
+            {pixelName: 'incontext_eligible'},
             {pixelName: 'autofill_identity', params: {fieldType: 'emailAddress'}},
             {pixelName: 'autofill_personal_address'}
         ])

--- a/integration-test/tests/incontext-signup.extension.spec.js
+++ b/integration-test/tests/incontext-signup.extension.spec.js
@@ -36,7 +36,7 @@ test.describe('chrome extension', () => {
         await emailProtectionPage.close()
 
         // Confirm pixels triggered
-        await emailPage.assertExtensionPixelsCaptured(['incontext_show', 'incontext_primary_cta'])
+        await emailPage.assertExtensionPixelsCaptured(['incontext_eligible', 'incontext_show', 'incontext_primary_cta'])
     })
 
     test('should allow tooptip to be dismissed', async ({page}) => {
@@ -57,7 +57,7 @@ test.describe('chrome extension', () => {
         await emailPage.assertDaxIconIsHidden()
 
         // Confirm pixels triggered
-        await emailPage.assertExtensionPixelsCaptured(['incontext_show', 'incontext_dismiss_persisted'])
+        await emailPage.assertExtensionPixelsCaptured(['incontext_eligible', 'incontext_show', 'incontext_dismiss_persisted'])
     })
 
     test('should allow tooptip to be closed', async ({page}) => {
@@ -78,7 +78,7 @@ test.describe('chrome extension', () => {
         await emailPage.assertDaxIconIsShowing()
 
         // Confirm pixels triggered
-        await emailPage.assertExtensionPixelsCaptured(['incontext_show', 'incontext_close_x'])
+        await emailPage.assertExtensionPixelsCaptured(['incontext_eligible', 'incontext_show', 'incontext_close_x'])
     })
 
     test('should display properly in iframes with small width', async ({page}) => {

--- a/src/DeviceInterface/AndroidInterface.js
+++ b/src/DeviceInterface/AndroidInterface.js
@@ -109,6 +109,9 @@ class AndroidInterface extends InterfacePrototype {
             }
         })
     }
+
+    /** Noop */
+    firePixel (_pixelParam) {}
 }
 
 export {AndroidInterface}

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -378,7 +378,7 @@ class Form {
         // TODO: temporary pixel
         const subtype = getInputSubtype(input)
         if (subtype === 'emailAddress') {
-            this.addListener(input, 'focus', () => {
+            this.addListener(input, 'pointerdown', () => {
                 this.device.firePixel({pixelName: 'incontext_eligible'})
             }, {once: true})
         }

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -249,7 +249,7 @@ class Form {
     }
     removeAllDecorations () {
         this.execOnInputs((input) => this.removeInputDecoration(input))
-        this.listeners.forEach(({el, type, fn}) => el.removeEventListener(type, fn))
+        this.listeners.forEach(({el, type, fn, opts}) => el.removeEventListener(type, fn, opts))
     }
     redecorateAllInputs () {
         this.removeAllDecorations()
@@ -375,14 +375,29 @@ class Form {
         const mainInputType = getInputMainType(input)
         this.inputs[mainInputType].add(input)
 
+        // TODO: temporary pixel
+        const subtype = getInputSubtype(input)
+        if (subtype === 'emailAddress') {
+            this.addListener(input, 'focus', () => {
+                this.device.firePixel({pixelName: 'incontext_eligible'})
+            }, {once: true})
+        }
+
         this.decorateInput(input)
 
         return this
     }
 
-    addListener (el, type, fn) {
-        el.addEventListener(type, fn)
-        this.listeners.add({el, type, fn})
+    /**
+     * Adds event listeners and keeps track of them for subsequent removal
+     * @param {HTMLElement} el
+     * @param {Event['type']} type
+     * @param {() => void} fn
+     * @param {AddEventListenerOptions} [opts]
+     */
+    addListener (el, type, fn, opts) {
+        el.addEventListener(type, fn, opts)
+        this.listeners.add({el, type, fn, opts})
     }
 
     addAutofillStyles (input) {

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -36,6 +36,9 @@ export type SendJSPixelParams =
     }
   | {
       pixelName: "incontext_close_x";
+    }
+  | {
+      pixelName: "incontext_eligible";
     };
 
 /**

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -21,6 +21,8 @@ export const sendJSPixelParamsSchema = z.union([z.object({
         pixelName: z.literal("incontext_dismiss_persisted")
     }), z.object({
         pixelName: z.literal("incontext_close_x")
+    }), z.object({
+        pixelName: z.literal("incontext_eligible")
     })]);
 
 export const triggerContextSchema = z.object({

--- a/src/deviceApiCalls/schemas/sendJSPixel.params.json
+++ b/src/deviceApiCalls/schemas/sendJSPixel.params.json
@@ -108,6 +108,18 @@
         "pixelName"
       ],
       "additionalProperties": false
+    },
+    {
+      "properties": {
+        "pixelName": {
+          "type": "string",
+          "const": "incontext_eligible"
+        }
+      },
+      "required": [
+        "pixelName"
+      ],
+      "additionalProperties": false
     }
   ]
 }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -7442,6 +7442,10 @@ class AndroidInterface extends _InterfacePrototype.default {
       }
     });
   }
+  /** Noop */
+
+
+  firePixel(_pixelParam) {}
 
 }
 
@@ -9937,9 +9941,10 @@ class Form {
       let {
         el,
         type,
-        fn
+        fn,
+        opts
       } = _ref;
-      return el.removeEventListener(type, fn);
+      return el.removeEventListener(type, fn, opts);
     });
   }
 
@@ -10069,17 +10074,39 @@ class Form {
     };
     this.matching.setInputType(input, this.form, opts);
     const mainInputType = (0, _matching.getInputMainType)(input);
-    this.inputs[mainInputType].add(input);
+    this.inputs[mainInputType].add(input); // TODO: temporary pixel
+
+    const subtype = (0, _matching.getInputSubtype)(input);
+
+    if (subtype === 'emailAddress') {
+      this.addListener(input, 'focus', () => {
+        this.device.firePixel({
+          pixelName: 'incontext_eligible'
+        });
+      }, {
+        once: true
+      });
+    }
+
     this.decorateInput(input);
     return this;
   }
+  /**
+   * Adds event listeners and keeps track of them for subsequent removal
+   * @param {HTMLElement} el
+   * @param {Event['type']} type
+   * @param {() => void} fn
+   * @param {AddEventListenerOptions} [opts]
+   */
 
-  addListener(el, type, fn) {
-    el.addEventListener(type, fn);
+
+  addListener(el, type, fn, opts) {
+    el.addEventListener(type, fn, opts);
     this.listeners.add({
       el,
       type,
-      fn
+      fn,
+      opts
     });
   }
 
@@ -17445,6 +17472,8 @@ const sendJSPixelParamsSchema = _zod.z.union([_zod.z.object({
   pixelName: _zod.z.literal("incontext_dismiss_persisted")
 }), _zod.z.object({
   pixelName: _zod.z.literal("incontext_close_x")
+}), _zod.z.object({
+  pixelName: _zod.z.literal("incontext_eligible")
 })]);
 
 exports.sendJSPixelParamsSchema = sendJSPixelParamsSchema;

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10079,7 +10079,7 @@ class Form {
     const subtype = (0, _matching.getInputSubtype)(input);
 
     if (subtype === 'emailAddress') {
-      this.addListener(input, 'focus', () => {
+      this.addListener(input, 'pointerdown', () => {
         this.device.firePixel({
           pixelName: 'incontext_eligible'
         });

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6403,7 +6403,7 @@ class Form {
     const subtype = (0, _matching.getInputSubtype)(input);
 
     if (subtype === 'emailAddress') {
-      this.addListener(input, 'focus', () => {
+      this.addListener(input, 'pointerdown', () => {
         this.device.firePixel({
           pixelName: 'incontext_eligible'
         });

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -3766,6 +3766,10 @@ class AndroidInterface extends _InterfacePrototype.default {
       }
     });
   }
+  /** Noop */
+
+
+  firePixel(_pixelParam) {}
 
 }
 
@@ -6261,9 +6265,10 @@ class Form {
       let {
         el,
         type,
-        fn
+        fn,
+        opts
       } = _ref;
-      return el.removeEventListener(type, fn);
+      return el.removeEventListener(type, fn, opts);
     });
   }
 
@@ -6393,17 +6398,39 @@ class Form {
     };
     this.matching.setInputType(input, this.form, opts);
     const mainInputType = (0, _matching.getInputMainType)(input);
-    this.inputs[mainInputType].add(input);
+    this.inputs[mainInputType].add(input); // TODO: temporary pixel
+
+    const subtype = (0, _matching.getInputSubtype)(input);
+
+    if (subtype === 'emailAddress') {
+      this.addListener(input, 'focus', () => {
+        this.device.firePixel({
+          pixelName: 'incontext_eligible'
+        });
+      }, {
+        once: true
+      });
+    }
+
     this.decorateInput(input);
     return this;
   }
+  /**
+   * Adds event listeners and keeps track of them for subsequent removal
+   * @param {HTMLElement} el
+   * @param {Event['type']} type
+   * @param {() => void} fn
+   * @param {AddEventListenerOptions} [opts]
+   */
 
-  addListener(el, type, fn) {
-    el.addEventListener(type, fn);
+
+  addListener(el, type, fn, opts) {
+    el.addEventListener(type, fn, opts);
     this.listeners.add({
       el,
       type,
-      fn
+      fn,
+      opts
     });
   }
 


### PR DESCRIPTION
**Reviewer:** @alistairjcbrown 
**Asana:** https://app.asana.com/0/0/1204486716187196/f

## Description
Sends a pixel when an email-eligible field is first interacted with. Clients will add info on install time and decide if to send the pixel at all. This pixel is temporary and will be removed in a couple of weeks.

## Steps to test
See https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1943.