### PR TITLE
Ema/fix release again

### DIFF
--- a/.github/workflows/asana-release.yml
+++ b/.github/workflows/asana-release.yml
@@ -273,7 +273,6 @@ jobs:
           MACOS_PR_URL: ${{ steps.macos-pr.outputs.pull-request-url }}
           ANDROID_PR_URL: ${{ steps.android-pr.outputs.pull-request-url }}
           WINDOWS_PR_URL: ${{ steps.windows-pr.outputs.pull-request-url }}
-          EXTENSIONS_PR_URL: ${{ steps.extensions-pr.outputs.pull-request-url }}
         run:  node ./autofill/scripts/release/asana-update-tasks.js
 
       - name: Ouput workflow summary

--- a/.github/workflows/asana-release.yml
+++ b/.github/workflows/asana-release.yml
@@ -228,6 +228,7 @@ jobs:
           repository: duckduckgo/windows-browser
           path: windows/
           ref: develop
+          submodules: true
           token: ${{ secrets.DAXMOBILE_AUTOFILL_AUTOMATION }}
       - name: Update Windows autofill reference
         run: |

--- a/scripts/release/asana-create-tasks.js
+++ b/scripts/release/asana-create-tasks.js
@@ -22,7 +22,6 @@ const projectExtractorRegex = /\[\[project_gids=(.+)]]\s/
  * @typedef {{taskGid: string, taskUrl: string, displayName: string}} platformData
  *
  * @typedef {{
- *   extensions: platformData,
  *   android: platformData,
  *   bsk: platformData,
  *   windows: platformData
@@ -38,11 +37,6 @@ const platforms = {
     },
     bsk: {
         displayName: 'BrowserServicesKit',
-        taskGid: '',
-        taskUrl: ''
-    },
-    extensions: {
-        displayName: 'Extensions',
         taskGid: '',
         taskUrl: ''
     },

--- a/scripts/release/asana-update-tasks.js
+++ b/scripts/release/asana-update-tasks.js
@@ -11,7 +11,6 @@ const prUrls = {
     bsk: process.env.BSK_PR_URL || 'error',
     ios: process.env.IOS_PR_URL || 'error',
     macos: process.env.MACOS_PR_URL || 'error',
-    extensions: process.env.EXTENSIONS_PR_URL || 'error',
     windows: process.env.WINDOWS_PR_URL || 'error'
 }
 const asanaOutputRaw = process.env.ASANA_OUTPUT || '{}'

--- a/scripts/release/tests/create-pr-template.test.js
+++ b/scripts/release/tests/create-pr-template.test.js
@@ -38,11 +38,9 @@ describe('it returns the expected result', () => {
     test('for extensions', () => {
         const output = createPRTemplate('extensions', data)
         /** @type {import('../asana-create-tasks').AsanaOutput} */
-        const asanaData = JSON.parse(data.asanaOutputRaw)
         expect(output).toContain(data.version)
         expect(output).toContain(data.releaseNotesRaw)
         expect(output).toContain(data.releaseUrl)
-        expect(output).toContain(asanaData.extensions.taskGid)
         expect(output).not.toContain(data.bskPrUrl)
     })
 })


### PR DESCRIPTION
**Reviewer:** @alistairjcbrown @szanto90balazs 

## Description
- Removes the extension Asana creation task (handled by a separate workflow)
- Fixes the Windows workflow (submodules were not initialized properly on checkout). See [this job failure](https://github.com/duckduckgo/duckduckgo-autofill/actions/runs/4891596613/jobs/8732305383).
