### PR TITLE
Disable Manage button on Catalina

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15212,16 +15212,17 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
       wrapperClass,
       css
     } = this.options;
+    const isTopAutofill = wrapperClass === null || wrapperClass === void 0 ? void 0 : wrapperClass.includes('top-autofill');
     let hasAddedSeparator = false; // Only show an hr above the first duck address button, but it can be either personal or private
 
     const shouldShowSeparator = dataId => {
       const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator;
       if (shouldShow) hasAddedSeparator = true;
       return shouldShow;
-    }; // Don't show Manage… when we only have Email Protection addresses, or the provider is locked
+    }; // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
 
 
-    const shouldShowManageButton = items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
+    const shouldShowManageButton = isTopAutofill && items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
     const topClass = wrapperClass || '';
     const dataTypeClass = "tooltip__button--data--".concat(config.type);
     this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map(item => {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -11536,16 +11536,17 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
       wrapperClass,
       css
     } = this.options;
+    const isTopAutofill = wrapperClass === null || wrapperClass === void 0 ? void 0 : wrapperClass.includes('top-autofill');
     let hasAddedSeparator = false; // Only show an hr above the first duck address button, but it can be either personal or private
 
     const shouldShowSeparator = dataId => {
       const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator;
       if (shouldShow) hasAddedSeparator = true;
       return shouldShow;
-    }; // Don't show Manage… when we only have Email Protection addresses, or the provider is locked
+    }; // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
 
 
-    const shouldShowManageButton = items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
+    const shouldShowManageButton = isTopAutofill && items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
     const topClass = wrapperClass || '';
     const dataTypeClass = "tooltip__button--data--".concat(config.type);
     this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map(item => {

--- a/src/UI/DataHTMLTooltip.js
+++ b/src/UI/DataHTMLTooltip.js
@@ -10,6 +10,7 @@ class DataHTMLTooltip extends HTMLTooltip {
      */
     render (config, items, callbacks) {
         const {wrapperClass, css} = this.options
+        const isTopAutofill = wrapperClass?.includes('top-autofill')
         let hasAddedSeparator = false
         // Only show an hr above the first duck address button, but it can be either personal or private
         const shouldShowSeparator = (dataId) => {
@@ -18,8 +19,10 @@ class DataHTMLTooltip extends HTMLTooltip {
             return shouldShow
         }
 
-        // Don't show Manage… when we only have Email Protection addresses, or the provider is locked
-        const shouldShowManageButton = items.some(item => !['personalAddress', 'privateAddress', PROVIDER_LOCKED].includes(item.id()))
+        // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
+        const shouldShowManageButton =
+            isTopAutofill &&
+            items.some(item => !['personalAddress', 'privateAddress', PROVIDER_LOCKED].includes(item.id()))
 
         const topClass = wrapperClass || ''
         const dataTypeClass = `tooltip__button--data--${config.type}`

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15212,16 +15212,17 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
       wrapperClass,
       css
     } = this.options;
+    const isTopAutofill = wrapperClass === null || wrapperClass === void 0 ? void 0 : wrapperClass.includes('top-autofill');
     let hasAddedSeparator = false; // Only show an hr above the first duck address button, but it can be either personal or private
 
     const shouldShowSeparator = dataId => {
       const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator;
       if (shouldShow) hasAddedSeparator = true;
       return shouldShow;
-    }; // Don't show Manage… when we only have Email Protection addresses, or the provider is locked
+    }; // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
 
 
-    const shouldShowManageButton = items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
+    const shouldShowManageButton = isTopAutofill && items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
     const topClass = wrapperClass || '';
     const dataTypeClass = "tooltip__button--data--".concat(config.type);
     this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map(item => {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -11536,16 +11536,17 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
       wrapperClass,
       css
     } = this.options;
+    const isTopAutofill = wrapperClass === null || wrapperClass === void 0 ? void 0 : wrapperClass.includes('top-autofill');
     let hasAddedSeparator = false; // Only show an hr above the first duck address button, but it can be either personal or private
 
     const shouldShowSeparator = dataId => {
       const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator;
       if (shouldShow) hasAddedSeparator = true;
       return shouldShow;
-    }; // Don't show Manage… when we only have Email Protection addresses, or the provider is locked
+    }; // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
 
 
-    const shouldShowManageButton = items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
+    const shouldShowManageButton = isTopAutofill && items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
     const topClass = wrapperClass || '';
     const dataTypeClass = "tooltip__button--data--".concat(config.type);
     this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map(item => {


### PR DESCRIPTION
**Reviewer:** @alistairjcbrown 
**Asana:** https://app.asana.com/0/0/1204591519553355/f

## Description
Just hides the Manage… button on Catalina because the native layer has a bug and we don't want to invest time to debug there.

## Steps to test
Testing on Catalina is time consuming. I've verified the change but let me know if you want more info.