### PR TITLE
Fix form submission overtriggering

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -9586,6 +9586,9 @@ function initFormSubmissionsApi(forms) {
     ['fetch', 'xmlhttprequest'].includes(entry.initiatorType) && /login|sign-in|signin/.test(entry.name));
     if (!entries.length) return;
     const filledForm = [...forms.values()].find(form => form.hasValues());
+    const focusedForm = [...forms.values()].find(form => form.hasFocus()); // If a form is still focused the user is still typing: do nothing
+
+    if (focusedForm) return;
     filledForm === null || filledForm === void 0 ? void 0 : filledForm.submitHandler('performance observer');
   });
   observer.observe({

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -5910,6 +5910,9 @@ function initFormSubmissionsApi(forms) {
     ['fetch', 'xmlhttprequest'].includes(entry.initiatorType) && /login|sign-in|signin/.test(entry.name));
     if (!entries.length) return;
     const filledForm = [...forms.values()].find(form => form.hasValues());
+    const focusedForm = [...forms.values()].find(form => form.hasFocus()); // If a form is still focused the user is still typing: do nothing
+
+    if (focusedForm) return;
     filledForm === null || filledForm === void 0 ? void 0 : filledForm.submitHandler('performance observer');
   });
   observer.observe({

--- a/src/DeviceInterface/initFormSubmissionsApi.js
+++ b/src/DeviceInterface/initFormSubmissionsApi.js
@@ -82,6 +82,10 @@ export function initFormSubmissionsApi (forms) {
         if (!entries.length) return
 
         const filledForm = [...forms.values()].find(form => form.hasValues())
+        const focusedForm = [...forms.values()].find((form) => form.hasFocus())
+        // If a form is still focused the user is still typing: do nothing
+        if (focusedForm) return
+
         filledForm?.submitHandler('performance observer')
     })
     observer.observe({entryTypes: ['resource']})

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -9586,6 +9586,9 @@ function initFormSubmissionsApi(forms) {
     ['fetch', 'xmlhttprequest'].includes(entry.initiatorType) && /login|sign-in|signin/.test(entry.name));
     if (!entries.length) return;
     const filledForm = [...forms.values()].find(form => form.hasValues());
+    const focusedForm = [...forms.values()].find(form => form.hasFocus()); // If a form is still focused the user is still typing: do nothing
+
+    if (focusedForm) return;
     filledForm === null || filledForm === void 0 ? void 0 : filledForm.submitHandler('performance observer');
   });
   observer.observe({

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -5910,6 +5910,9 @@ function initFormSubmissionsApi(forms) {
     ['fetch', 'xmlhttprequest'].includes(entry.initiatorType) && /login|sign-in|signin/.test(entry.name));
     if (!entries.length) return;
     const filledForm = [...forms.values()].find(form => form.hasValues());
+    const focusedForm = [...forms.values()].find(form => form.hasFocus()); // If a form is still focused the user is still typing: do nothing
+
+    if (focusedForm) return;
     filledForm === null || filledForm === void 0 ? void 0 : filledForm.submitHandler('performance observer');
   });
   observer.observe({


### PR DESCRIPTION
**Reviewer:** @alistairjcbrown 
**Asana:** https://app.asana.com/0/0/1204675789628006/f

## Description
On some sites the prompt to save the form triggers while the user is still typing. This fixes it.

## Steps to test
Tested on the reported bugs. Fixes them all 🎉!