### PR TITLE
Remove separator above Duck Address whenever it's first item

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15504,17 +15504,19 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
     const isTopAutofill = wrapperClass === null || wrapperClass === void 0 ? void 0 : wrapperClass.includes('top-autofill');
     let hasAddedSeparator = false; // Only show an hr above the first duck address button, but it can be either personal or private
 
-    const shouldShowSeparator = dataId => {
+    const shouldShowSeparator = (dataId, index) => {
       const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator;
-      if (shouldShow) hasAddedSeparator = true;
-      return shouldShow;
+      if (shouldShow) hasAddedSeparator = true; // Don't show the separator if we want to show it, but it's unnecessary as the first item in the menu
+
+      const isFirst = index === 0;
+      return shouldShow && !isFirst;
     }; // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
 
 
     const shouldShowManageButton = isTopAutofill && items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
     const topClass = wrapperClass || '';
     const dataTypeClass = "tooltip__button--data--".concat(config.type);
-    this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map(item => {
+    this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map((item, index) => {
       var _item$credentialsProv, _item$labelSmall, _item$label;
 
       const credentialsProvider = (_item$credentialsProv = item.credentialsProvider) === null || _item$credentialsProv === void 0 ? void 0 : _item$credentialsProv.call(item);
@@ -15522,7 +15524,7 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
 
       const labelSmall = (_item$labelSmall = item.labelSmall) === null || _item$labelSmall === void 0 ? void 0 : _item$labelSmall.call(item, this.subtype);
       const label = (_item$label = item.label) === null || _item$label === void 0 ? void 0 : _item$label.call(item, this.subtype);
-      return "\n                ".concat(shouldShowSeparator(item.id()) ? '<hr />' : '', "\n                <button id=\"").concat(item.id(), "\" class=\"tooltip__button tooltip__button--data ").concat(dataTypeClass, " ").concat(providerIconClass, " js-autofill-button\" >\n                    <span class=\"tooltip__button__text-container\">\n                        <span class=\"label label--medium\">").concat((0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype)), "</span>\n                        ").concat(label ? "<span class=\"label\">".concat((0, _autofillUtils.escapeXML)(label), "</span>") : '', "\n                        ").concat(labelSmall ? "<span class=\"label label--small\">".concat((0, _autofillUtils.escapeXML)(labelSmall), "</span>") : '', "\n                    </span>\n                </button>\n            ");
+      return "\n                ".concat(shouldShowSeparator(item.id(), index) ? '<hr />' : '', "\n                <button id=\"").concat(item.id(), "\" class=\"tooltip__button tooltip__button--data ").concat(dataTypeClass, " ").concat(providerIconClass, " js-autofill-button\" >\n                    <span class=\"tooltip__button__text-container\">\n                        <span class=\"label label--medium\">").concat((0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype)), "</span>\n                        ").concat(label ? "<span class=\"label\">".concat((0, _autofillUtils.escapeXML)(label), "</span>") : '', "\n                        ").concat(labelSmall ? "<span class=\"label label--small\">".concat((0, _autofillUtils.escapeXML)(labelSmall), "</span>") : '', "\n                    </span>\n                </button>\n            ");
     }).join(''), "\n        ").concat(shouldShowManageButton ? "\n            <hr />\n            <button id=\"manage-button\" class=\"tooltip__button tooltip__button--manage\" type=\"button\">\n                <span class=\"tooltip__button__text-container\">\n                    <span class=\"label label--medium\">Manage ".concat(config.displayName, "\u2026</span>\n                </span>\n            </button>") : '', "\n    </div>\n</div>");
     this.wrapper = this.shadow.querySelector('.wrapper');
     this.tooltip = this.shadow.querySelector('.tooltip');

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -11828,17 +11828,19 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
     const isTopAutofill = wrapperClass === null || wrapperClass === void 0 ? void 0 : wrapperClass.includes('top-autofill');
     let hasAddedSeparator = false; // Only show an hr above the first duck address button, but it can be either personal or private
 
-    const shouldShowSeparator = dataId => {
+    const shouldShowSeparator = (dataId, index) => {
       const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator;
-      if (shouldShow) hasAddedSeparator = true;
-      return shouldShow;
+      if (shouldShow) hasAddedSeparator = true; // Don't show the separator if we want to show it, but it's unnecessary as the first item in the menu
+
+      const isFirst = index === 0;
+      return shouldShow && !isFirst;
     }; // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
 
 
     const shouldShowManageButton = isTopAutofill && items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
     const topClass = wrapperClass || '';
     const dataTypeClass = "tooltip__button--data--".concat(config.type);
-    this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map(item => {
+    this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map((item, index) => {
       var _item$credentialsProv, _item$labelSmall, _item$label;
 
       const credentialsProvider = (_item$credentialsProv = item.credentialsProvider) === null || _item$credentialsProv === void 0 ? void 0 : _item$credentialsProv.call(item);
@@ -11846,7 +11848,7 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
 
       const labelSmall = (_item$labelSmall = item.labelSmall) === null || _item$labelSmall === void 0 ? void 0 : _item$labelSmall.call(item, this.subtype);
       const label = (_item$label = item.label) === null || _item$label === void 0 ? void 0 : _item$label.call(item, this.subtype);
-      return "\n                ".concat(shouldShowSeparator(item.id()) ? '<hr />' : '', "\n                <button id=\"").concat(item.id(), "\" class=\"tooltip__button tooltip__button--data ").concat(dataTypeClass, " ").concat(providerIconClass, " js-autofill-button\" >\n                    <span class=\"tooltip__button__text-container\">\n                        <span class=\"label label--medium\">").concat((0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype)), "</span>\n                        ").concat(label ? "<span class=\"label\">".concat((0, _autofillUtils.escapeXML)(label), "</span>") : '', "\n                        ").concat(labelSmall ? "<span class=\"label label--small\">".concat((0, _autofillUtils.escapeXML)(labelSmall), "</span>") : '', "\n                    </span>\n                </button>\n            ");
+      return "\n                ".concat(shouldShowSeparator(item.id(), index) ? '<hr />' : '', "\n                <button id=\"").concat(item.id(), "\" class=\"tooltip__button tooltip__button--data ").concat(dataTypeClass, " ").concat(providerIconClass, " js-autofill-button\" >\n                    <span class=\"tooltip__button__text-container\">\n                        <span class=\"label label--medium\">").concat((0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype)), "</span>\n                        ").concat(label ? "<span class=\"label\">".concat((0, _autofillUtils.escapeXML)(label), "</span>") : '', "\n                        ").concat(labelSmall ? "<span class=\"label label--small\">".concat((0, _autofillUtils.escapeXML)(labelSmall), "</span>") : '', "\n                    </span>\n                </button>\n            ");
     }).join(''), "\n        ").concat(shouldShowManageButton ? "\n            <hr />\n            <button id=\"manage-button\" class=\"tooltip__button tooltip__button--manage\" type=\"button\">\n                <span class=\"tooltip__button__text-container\">\n                    <span class=\"label label--medium\">Manage ".concat(config.displayName, "\u2026</span>\n                </span>\n            </button>") : '', "\n    </div>\n</div>");
     this.wrapper = this.shadow.querySelector('.wrapper');
     this.tooltip = this.shadow.querySelector('.tooltip');

--- a/src/UI/DataHTMLTooltip.js
+++ b/src/UI/DataHTMLTooltip.js
@@ -13,10 +13,13 @@ class DataHTMLTooltip extends HTMLTooltip {
         const isTopAutofill = wrapperClass?.includes('top-autofill')
         let hasAddedSeparator = false
         // Only show an hr above the first duck address button, but it can be either personal or private
-        const shouldShowSeparator = (dataId) => {
+        const shouldShowSeparator = (dataId, index) => {
             const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator
             if (shouldShow) hasAddedSeparator = true
-            return shouldShow
+
+            // Don't show the separator if we want to show it, but it's unnecessary as the first item in the menu
+            const isFirst = index === 0
+            return shouldShow && !isFirst
         }
 
         // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
@@ -30,7 +33,7 @@ class DataHTMLTooltip extends HTMLTooltip {
 ${css}
 <div class="wrapper wrapper--data ${topClass}" hidden>
     <div class="tooltip tooltip--data">
-        ${items.map((item) => {
+        ${items.map((item, index) => {
         const credentialsProvider = item.credentialsProvider?.()
         const providerIconClass = credentialsProvider ? `tooltip__button--data--${credentialsProvider}` : ''
         // these 2 are optional
@@ -38,7 +41,7 @@ ${css}
         const label = item.label?.(this.subtype)
 
         return `
-                ${shouldShowSeparator(item.id()) ? '<hr />' : ''}
+                ${shouldShowSeparator(item.id(), index) ? '<hr />' : ''}
                 <button id="${item.id()}" class="tooltip__button tooltip__button--data ${dataTypeClass} ${providerIconClass} js-autofill-button" >
                     <span class="tooltip__button__text-container">
                         <span class="label label--medium">${escapeXML(item.labelMedium(this.subtype))}</span>

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15504,17 +15504,19 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
     const isTopAutofill = wrapperClass === null || wrapperClass === void 0 ? void 0 : wrapperClass.includes('top-autofill');
     let hasAddedSeparator = false; // Only show an hr above the first duck address button, but it can be either personal or private
 
-    const shouldShowSeparator = dataId => {
+    const shouldShowSeparator = (dataId, index) => {
       const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator;
-      if (shouldShow) hasAddedSeparator = true;
-      return shouldShow;
+      if (shouldShow) hasAddedSeparator = true; // Don't show the separator if we want to show it, but it's unnecessary as the first item in the menu
+
+      const isFirst = index === 0;
+      return shouldShow && !isFirst;
     }; // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
 
 
     const shouldShowManageButton = isTopAutofill && items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
     const topClass = wrapperClass || '';
     const dataTypeClass = "tooltip__button--data--".concat(config.type);
-    this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map(item => {
+    this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map((item, index) => {
       var _item$credentialsProv, _item$labelSmall, _item$label;
 
       const credentialsProvider = (_item$credentialsProv = item.credentialsProvider) === null || _item$credentialsProv === void 0 ? void 0 : _item$credentialsProv.call(item);
@@ -15522,7 +15524,7 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
 
       const labelSmall = (_item$labelSmall = item.labelSmall) === null || _item$labelSmall === void 0 ? void 0 : _item$labelSmall.call(item, this.subtype);
       const label = (_item$label = item.label) === null || _item$label === void 0 ? void 0 : _item$label.call(item, this.subtype);
-      return "\n                ".concat(shouldShowSeparator(item.id()) ? '<hr />' : '', "\n                <button id=\"").concat(item.id(), "\" class=\"tooltip__button tooltip__button--data ").concat(dataTypeClass, " ").concat(providerIconClass, " js-autofill-button\" >\n                    <span class=\"tooltip__button__text-container\">\n                        <span class=\"label label--medium\">").concat((0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype)), "</span>\n                        ").concat(label ? "<span class=\"label\">".concat((0, _autofillUtils.escapeXML)(label), "</span>") : '', "\n                        ").concat(labelSmall ? "<span class=\"label label--small\">".concat((0, _autofillUtils.escapeXML)(labelSmall), "</span>") : '', "\n                    </span>\n                </button>\n            ");
+      return "\n                ".concat(shouldShowSeparator(item.id(), index) ? '<hr />' : '', "\n                <button id=\"").concat(item.id(), "\" class=\"tooltip__button tooltip__button--data ").concat(dataTypeClass, " ").concat(providerIconClass, " js-autofill-button\" >\n                    <span class=\"tooltip__button__text-container\">\n                        <span class=\"label label--medium\">").concat((0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype)), "</span>\n                        ").concat(label ? "<span class=\"label\">".concat((0, _autofillUtils.escapeXML)(label), "</span>") : '', "\n                        ").concat(labelSmall ? "<span class=\"label label--small\">".concat((0, _autofillUtils.escapeXML)(labelSmall), "</span>") : '', "\n                    </span>\n                </button>\n            ");
     }).join(''), "\n        ").concat(shouldShowManageButton ? "\n            <hr />\n            <button id=\"manage-button\" class=\"tooltip__button tooltip__button--manage\" type=\"button\">\n                <span class=\"tooltip__button__text-container\">\n                    <span class=\"label label--medium\">Manage ".concat(config.displayName, "\u2026</span>\n                </span>\n            </button>") : '', "\n    </div>\n</div>");
     this.wrapper = this.shadow.querySelector('.wrapper');
     this.tooltip = this.shadow.querySelector('.tooltip');

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -11828,17 +11828,19 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
     const isTopAutofill = wrapperClass === null || wrapperClass === void 0 ? void 0 : wrapperClass.includes('top-autofill');
     let hasAddedSeparator = false; // Only show an hr above the first duck address button, but it can be either personal or private
 
-    const shouldShowSeparator = dataId => {
+    const shouldShowSeparator = (dataId, index) => {
       const shouldShow = ['personalAddress', 'privateAddress'].includes(dataId) && !hasAddedSeparator;
-      if (shouldShow) hasAddedSeparator = true;
-      return shouldShow;
+      if (shouldShow) hasAddedSeparator = true; // Don't show the separator if we want to show it, but it's unnecessary as the first item in the menu
+
+      const isFirst = index === 0;
+      return shouldShow && !isFirst;
     }; // Only show manage Manage… when it's topAutofill, the provider is unlocked, and it's not just EmailProtection
 
 
     const shouldShowManageButton = isTopAutofill && items.some(item => !['personalAddress', 'privateAddress', _Credentials.PROVIDER_LOCKED].includes(item.id()));
     const topClass = wrapperClass || '';
     const dataTypeClass = "tooltip__button--data--".concat(config.type);
-    this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map(item => {
+    this.shadow.innerHTML = "\n".concat(css, "\n<div class=\"wrapper wrapper--data ").concat(topClass, "\" hidden>\n    <div class=\"tooltip tooltip--data\">\n        ").concat(items.map((item, index) => {
       var _item$credentialsProv, _item$labelSmall, _item$label;
 
       const credentialsProvider = (_item$credentialsProv = item.credentialsProvider) === null || _item$credentialsProv === void 0 ? void 0 : _item$credentialsProv.call(item);
@@ -11846,7 +11848,7 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
 
       const labelSmall = (_item$labelSmall = item.labelSmall) === null || _item$labelSmall === void 0 ? void 0 : _item$labelSmall.call(item, this.subtype);
       const label = (_item$label = item.label) === null || _item$label === void 0 ? void 0 : _item$label.call(item, this.subtype);
-      return "\n                ".concat(shouldShowSeparator(item.id()) ? '<hr />' : '', "\n                <button id=\"").concat(item.id(), "\" class=\"tooltip__button tooltip__button--data ").concat(dataTypeClass, " ").concat(providerIconClass, " js-autofill-button\" >\n                    <span class=\"tooltip__button__text-container\">\n                        <span class=\"label label--medium\">").concat((0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype)), "</span>\n                        ").concat(label ? "<span class=\"label\">".concat((0, _autofillUtils.escapeXML)(label), "</span>") : '', "\n                        ").concat(labelSmall ? "<span class=\"label label--small\">".concat((0, _autofillUtils.escapeXML)(labelSmall), "</span>") : '', "\n                    </span>\n                </button>\n            ");
+      return "\n                ".concat(shouldShowSeparator(item.id(), index) ? '<hr />' : '', "\n                <button id=\"").concat(item.id(), "\" class=\"tooltip__button tooltip__button--data ").concat(dataTypeClass, " ").concat(providerIconClass, " js-autofill-button\" >\n                    <span class=\"tooltip__button__text-container\">\n                        <span class=\"label label--medium\">").concat((0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype)), "</span>\n                        ").concat(label ? "<span class=\"label\">".concat((0, _autofillUtils.escapeXML)(label), "</span>") : '', "\n                        ").concat(labelSmall ? "<span class=\"label label--small\">".concat((0, _autofillUtils.escapeXML)(labelSmall), "</span>") : '', "\n                    </span>\n                </button>\n            ");
     }).join(''), "\n        ").concat(shouldShowManageButton ? "\n            <hr />\n            <button id=\"manage-button\" class=\"tooltip__button tooltip__button--manage\" type=\"button\">\n                <span class=\"tooltip__button__text-container\">\n                    <span class=\"label label--medium\">Manage ".concat(config.displayName, "\u2026</span>\n                </span>\n            </button>") : '', "\n    </div>\n</div>");
     this.wrapper = this.shadow.querySelector('.wrapper');
     this.tooltip = this.shadow.querySelector('.tooltip');


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1203822806345703/1204735822913086/f

## Description
Remove separator above Duck Address whenever it's first item

## Steps to test
1. Add to device
2. Have only Email Protection enabled (no identities, logins, etc. which match the current page)
3. Go to https://duckduckgo.com/newsletter

Separator is no longer present, spacing is better

Before | After
--- | ---
![image](https://github.com/duckduckgo/duckduckgo-autofill/assets/635903/18da7279-d0dc-4a0b-b466-c4df71059550) |  ![image](https://github.com/duckduckgo/duckduckgo-autofill/assets/635903/06e18ebf-61aa-4a55-8cc4-27ab804da339)
![image](https://github.com/duckduckgo/duckduckgo-autofill/assets/635903/1f1b40b5-eae2-43f4-a510-3a08389026c2) | ![image](https://github.com/duckduckgo/duckduckgo-autofill/assets/635903/84f52907-871a-47d6-8092-02c6fb07a747)


