### PR TITLE
Trigger tooltip option on pointer up

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -16742,6 +16742,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
+    window.addEventListener('pointerup', this, true);
   }
 
   /**
@@ -16751,6 +16752,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
+    window.removeEventListener('pointerup', this, true);
   }
   /**
    * @param {import('./UIController').AttachArgs} args
@@ -16907,6 +16909,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
           break;
         }
+
+      case 'pointerup':
+        {
+          this._pointerUpListener(event);
+
+          break;
+        }
     }
   } // Global listener for event delegation
 
@@ -16918,20 +16927,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     if (e.target.nodeName === 'DDG-AUTOFILL') {
       e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-
-      if (!activeTooltip) {
-        console.warn('Could not get activeTooltip');
-      } else {
-        activeTooltip.dispatchClick();
-      }
+      e.stopImmediatePropagation(); // Ignore pointer down events, we'll handle them on pointer up
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
       });
+    }
+  } // Global listener for event delegation
+
+
+  _pointerUpListener(e) {
+    if (!e.isTrusted) return; // Ignore events on the Dax icon, we handle those elsewhere
+
+    if ((0, _autofillUtils.isEventWithinDax)(e, e.target)) return; // @ts-ignore
+
+    if (e.target.nodeName === 'DDG-AUTOFILL') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const isMainMouseButton = e.button === 0;
+      if (!isMainMouseButton) return;
+      const activeTooltip = this.getActiveTooltip();
+      activeTooltip === null || activeTooltip === void 0 ? void 0 : activeTooltip.dispatchClick();
     }
   }
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -13066,6 +13066,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
+    window.addEventListener('pointerup', this, true);
   }
 
   /**
@@ -13075,6 +13076,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
+    window.removeEventListener('pointerup', this, true);
   }
   /**
    * @param {import('./UIController').AttachArgs} args
@@ -13231,6 +13233,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
           break;
         }
+
+      case 'pointerup':
+        {
+          this._pointerUpListener(event);
+
+          break;
+        }
     }
   } // Global listener for event delegation
 
@@ -13242,20 +13251,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     if (e.target.nodeName === 'DDG-AUTOFILL') {
       e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-
-      if (!activeTooltip) {
-        console.warn('Could not get activeTooltip');
-      } else {
-        activeTooltip.dispatchClick();
-      }
+      e.stopImmediatePropagation(); // Ignore pointer down events, we'll handle them on pointer up
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
       });
+    }
+  } // Global listener for event delegation
+
+
+  _pointerUpListener(e) {
+    if (!e.isTrusted) return; // Ignore events on the Dax icon, we handle those elsewhere
+
+    if ((0, _autofillUtils.isEventWithinDax)(e, e.target)) return; // @ts-ignore
+
+    if (e.target.nodeName === 'DDG-AUTOFILL') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const isMainMouseButton = e.button === 0;
+      if (!isMainMouseButton) return;
+      const activeTooltip = this.getActiveTooltip();
+      activeTooltip === null || activeTooltip === void 0 ? void 0 : activeTooltip.dispatchClick();
     }
   }
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -16742,6 +16742,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
+    window.addEventListener('pointerup', this, true);
   }
 
   /**
@@ -16751,6 +16752,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
+    window.removeEventListener('pointerup', this, true);
   }
   /**
    * @param {import('./UIController').AttachArgs} args
@@ -16907,6 +16909,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
           break;
         }
+
+      case 'pointerup':
+        {
+          this._pointerUpListener(event);
+
+          break;
+        }
     }
   } // Global listener for event delegation
 
@@ -16918,20 +16927,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     if (e.target.nodeName === 'DDG-AUTOFILL') {
       e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-
-      if (!activeTooltip) {
-        console.warn('Could not get activeTooltip');
-      } else {
-        activeTooltip.dispatchClick();
-      }
+      e.stopImmediatePropagation(); // Ignore pointer down events, we'll handle them on pointer up
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
       });
+    }
+  } // Global listener for event delegation
+
+
+  _pointerUpListener(e) {
+    if (!e.isTrusted) return; // Ignore events on the Dax icon, we handle those elsewhere
+
+    if ((0, _autofillUtils.isEventWithinDax)(e, e.target)) return; // @ts-ignore
+
+    if (e.target.nodeName === 'DDG-AUTOFILL') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const isMainMouseButton = e.button === 0;
+      if (!isMainMouseButton) return;
+      const activeTooltip = this.getActiveTooltip();
+      activeTooltip === null || activeTooltip === void 0 ? void 0 : activeTooltip.dispatchClick();
     }
   }
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -13066,6 +13066,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
+    window.addEventListener('pointerup', this, true);
   }
 
   /**
@@ -13075,6 +13076,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
+    window.removeEventListener('pointerup', this, true);
   }
   /**
    * @param {import('./UIController').AttachArgs} args
@@ -13231,6 +13233,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
           break;
         }
+
+      case 'pointerup':
+        {
+          this._pointerUpListener(event);
+
+          break;
+        }
     }
   } // Global listener for event delegation
 
@@ -13242,20 +13251,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     if (e.target.nodeName === 'DDG-AUTOFILL') {
       e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-
-      if (!activeTooltip) {
-        console.warn('Could not get activeTooltip');
-      } else {
-        activeTooltip.dispatchClick();
-      }
+      e.stopImmediatePropagation(); // Ignore pointer down events, we'll handle them on pointer up
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
       });
+    }
+  } // Global listener for event delegation
+
+
+  _pointerUpListener(e) {
+    if (!e.isTrusted) return; // Ignore events on the Dax icon, we handle those elsewhere
+
+    if ((0, _autofillUtils.isEventWithinDax)(e, e.target)) return; // @ts-ignore
+
+    if (e.target.nodeName === 'DDG-AUTOFILL') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const isMainMouseButton = e.button === 0;
+      if (!isMainMouseButton) return;
+      const activeTooltip = this.getActiveTooltip();
+      activeTooltip === null || activeTooltip === void 0 ? void 0 : activeTooltip.dispatchClick();
     }
   }
 


### PR DESCRIPTION
**Reviewer:** @shakyShane @GioSensation 
**Asana:** https://app.asana.com/0/1201048563534612/1204865574234316/f

## Description
Feedback from windows integration which detects clicks on pointer up -- changes our tooltip option click to only trigger on pointer up too. This is a nicer UX as it follow the same as other menus.

## Steps to test
1. Go to website where autofill will show.
2. Click the mouse down on an autofill option, but don't release. The option won't be selected yet.
3. You can drag your mouse away before releasing and the option won't be selected.
4. Or release your mouse and it'll select that option.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204874704354919