### PR TITLE
tests: attach JSON mocks as attachments

### DIFF
--- a/integration-test/helpers/harness.js
+++ b/integration-test/helpers/harness.js
@@ -1,11 +1,7 @@
-import {mkdtempSync, readFileSync} from 'fs'
+import {readFileSync} from 'fs'
 import {join} from 'path'
-import {tmpdir} from 'os'
-import {devices} from 'playwright'
-import {chromium, firefox} from '@playwright/test'
 import {macosContentScopeReplacements, iosContentScopeReplacements} from './mocks.webkit.js'
-
-const DATA_DIR_PREFIX = 'ddg-temp-'
+import {validPlatform} from './utils.js'
 
 /**
  * @param {import("@playwright/test").Page} page
@@ -25,42 +21,6 @@ export async function setupMockedDomain (page, domain) {
             contentType: contentType[fileType] || contentType.default,
             body: readFileSync(join('.', pathname), 'utf8')
         })
-    })
-}
-
-/**
- * Launch a chromium browser with the test extension pre-loaded.
- *
- * @param {typeof import("@playwright/test").test} test
- */
-export function withChromeExtensionContext (test) {
-    return test.extend({
-        context: async ({ browserName }, use, testInfo) => {
-            // ensure this test setup cannot be used by anything other than chrome
-            testInfo.skip(testInfo.project.name !== 'extension')
-
-            const tmpDirPrefix = join(tmpdir(), DATA_DIR_PREFIX)
-            const dataDir = mkdtempSync(tmpDirPrefix)
-            const browserTypes = { chromium, firefox }
-            const launchOptions = {
-                devtools: true,
-                headless: false,
-                viewport: {
-                    width: 1920,
-                    height: 1080
-                },
-                args: [
-                    '--disable-extensions-except=integration-test/extension',
-                    '--load-extension=integration-test/extension'
-                ]
-            }
-            const context = await browserTypes[browserName].launchPersistentContext(
-                dataDir,
-                launchOptions
-            )
-            await use(context)
-            await context.close()
-        }
     })
 }
 
@@ -225,73 +185,6 @@ export function forwardConsoleMessages (page, _opts = {}) {
 }
 
 /**
- * Launch a webkit browser with a user-agent that simulates our iOS application
- * @param {typeof import("@playwright/test").test} test
- */
-export function withIOSContext (test) {
-    return test.extend({
-        context: async ({ browser }, use, testInfo) => {
-            // ensure this test setup cannot be used by anything other than webkit browsers
-            testInfo.skip(testInfo.project.name !== 'webkit')
-
-            const context = await browser.newContext({
-                ...devices['iPhone 13'],
-                userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
-            })
-
-            await use(context)
-            await context.close()
-        }
-    })
-}
-
-/**
- * Launch a webkit browser with a user-agent that simulates our iOS application
- * @param {typeof import("@playwright/test").test} test
- */
-export function withAndroidContext (test) {
-    return test.extend({
-        context: async ({ browser }, use, testInfo) => {
-            // ensure this test setup cannot be used by anything other than webkit browsers
-            testInfo.skip(testInfo.project.name !== 'android')
-
-            const context = await browser.newContext({
-                ...devices.iPhone,
-                userAgent: 'Mozilla/5.0 (Linux; Android 12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 DuckDuckGo/7 Mobile Safari/537.36'
-            })
-
-            await use(context)
-            await context.close()
-        }
-    })
-}
-
-/**
- * Launch a chromium browser to simulates our Windows application
- *
- * Note: Autofill knows this is Windows via the isWindows string replacement
- * @param {typeof import("@playwright/test").test} test
- */
-export function withWindowsContext (test) {
-    return test.extend({
-        context: async ({ browser }, use, testInfo) => {
-            // ensure this test setup cannot be used by anything other than the Windows browser
-            testInfo.skip(testInfo.project.name !== 'windows')
-
-            const context = await browser.newContext({
-                ...devices['Desktop Chrome']
-            })
-
-            await use(context)
-            for (let page of context.pages()) {
-                await addMocksAsAttachments(page, test)
-            }
-            await context.close()
-        }
-    })
-}
-
-/**
  * @param {import("@playwright/test").Page} page
  * @param {string} measureName
  * @return {Promise<PerformanceEntryList>}
@@ -354,21 +247,32 @@ export async function mockedCalls (page, names = [], mustExist = true) {
  *
  * @param {import("@playwright/test").Page} page
  * @param {typeof import("@playwright/test").test} test
+ * @param {import("@playwright/test").TestInfo} testInfo
  * @returns {Promise<void>}
  */
-async function addMocksAsAttachments (page, test) {
+export async function addMocksAsAttachments (page, test, testInfo) {
     const calls = await mockedCalls(page)
+    const platform = validPlatform(testInfo.project.name)
     let index = 0
     for (let call of calls) {
         index += 1
-        const [name, params, response] = call
+        let [name, params, response] = call
         const lines = [`name: ${name}`]
-        lines.push(`params: \n\n` + JSON.stringify(params, null, 2))
-        lines.push(`response: \n\n` + JSON.stringify(response, null, 2))
+        if (platform === 'android') {
+            lines.push('sent as json string: \n\n' + JSON.stringify(params))
+            params = JSON.parse(/** @type {any} */(params))
+        }
+        lines.push(`\n\nparams: \n\n` + JSON.stringify(params, null, 2))
+        lines.push(`\n\nresponse: \n\n` + JSON.stringify(response, null, 2))
         test.info().attachments.push({
-            name: `mock ${index} ${name} params`,
+            name: `mock ${index} ${name} info`,
             contentType: 'text/plain',
             body: Buffer.from(lines.join('\n'))
+        })
+        test.info().attachments.push({
+            name: `mock ${index} params as JSON`,
+            contentType: 'text/json',
+            body: Buffer.from(JSON.stringify(params, null, 2))
         })
     }
 }

--- a/integration-test/helpers/mocks.windows.js
+++ b/integration-test/helpers/mocks.windows.js
@@ -141,12 +141,10 @@ export function createWindowsMocks () {
                     window.__playwright_autofill.mocks.calls.push(JSON.parse(JSON.stringify(call)))
                 }
                 /**
-                 * @param {any} request
+                 * @param {any} _request
                  * @param {any} response
                  */
-                function respond (name, request, response) {
-                    const call = [name, request, response]
-                    window.__playwright_autofill.mocks.calls.push(JSON.parse(JSON.stringify(call)))
+                function respond (name, _request, response) {
                     setTimeout(() => {
                         for (let listener of listeners) {
                             listener({

--- a/integration-test/helpers/test-context.js
+++ b/integration-test/helpers/test-context.js
@@ -1,0 +1,63 @@
+import {validPlatform} from './utils.js'
+import {join} from 'path'
+import {tmpdir} from 'os'
+import {mkdtempSync} from 'fs'
+import {chromium, firefox} from '@playwright/test'
+import {addMocksAsAttachments} from './harness.js'
+
+const DATA_DIR_PREFIX = 'ddg-temp-'
+
+/**
+ * @param {typeof import("@playwright/test").test} test
+ */
+export function testContext (test) {
+    return test.extend({
+        context: async ({ browser, browserName }, use, testInfo) => {
+            // ensure this test setup cannot be used by anything other than webkit browsers
+            const platform = validPlatform(testInfo.project.name)
+            let context
+
+            // first, create the context
+            switch (platform) {
+            case 'ios':
+            case 'android':
+            case 'macos':
+            case 'windows': {
+                context = await browser.newContext()
+                break
+            }
+            case 'extension': {
+                const tmpDirPrefix = join(tmpdir(), DATA_DIR_PREFIX)
+                const dataDir = mkdtempSync(tmpDirPrefix)
+                const browserTypes = { chromium, firefox }
+                const launchOptions = {
+                    devtools: true,
+                    headless: false,
+                    viewport: {
+                        width: 1920,
+                        height: 1080
+                    },
+                    args: [
+                        '--disable-extensions-except=integration-test/extension',
+                        '--load-extension=integration-test/extension'
+                    ]
+                }
+                context = await browserTypes[browserName].launchPersistentContext(
+                    dataDir,
+                    launchOptions
+                )
+            }
+            }
+
+            await use(context)
+
+            // skipping extension for a min, since it's testing setup has fallen behind
+            if (platform !== 'extension') {
+                for (let page of context.pages()) {
+                    await addMocksAsAttachments(page, test, testInfo)
+                }
+            }
+            await context.close()
+        }
+    })
+}

--- a/integration-test/helpers/test-context.js
+++ b/integration-test/helpers/test-context.js
@@ -8,12 +8,13 @@ import {addMocksAsAttachments} from './harness.js'
 const DATA_DIR_PREFIX = 'ddg-temp-'
 
 /**
+ * A single place
  * @param {typeof import("@playwright/test").test} test
  */
 export function testContext (test) {
     return test.extend({
         context: async ({ browser, browserName }, use, testInfo) => {
-            // ensure this test setup cannot be used by anything other than webkit browsers
+            // use `testInfo.project.name` is something we support.
             const platform = validPlatform(testInfo.project.name)
             let context
 
@@ -49,9 +50,11 @@ export function testContext (test) {
             }
             }
 
+            // actually run the tests
             await use(context)
 
-            // skipping extension for a min, since it's testing setup has fallen behind
+            // collect attachments (like mock calls) and append as attachments
+            // note: skipping the extension for now, since it's testing setup has fallen behind
             if (platform !== 'extension') {
                 for (let page of context.pages()) {
                     await addMocksAsAttachments(page, test, testInfo)

--- a/integration-test/helpers/utils.js
+++ b/integration-test/helpers/utils.js
@@ -81,4 +81,17 @@ async function addTopAutofillMouseFocus (page, button) {
     await page.mouse.move(x + 50, y + 15)
 }
 
+/**
+ * @param {any} stringInput
+ * @returns {Platform}
+ */
+export function validPlatform (stringInput) {
+    /** @type {Platform[]} */
+    const valid = ['extension', 'windows', 'ios', 'macos', 'android']
+    if (!valid.includes(stringInput)) {
+        throw new Error(`invalid platform: ${stringInput}`)
+    }
+    return stringInput
+}
+
 export {createAvailableInputTypes, stripDuckExtension, clickOnIcon, withDataType, addTopAutofillMouseFocus}

--- a/integration-test/tests/email-autofill.android.spec.js
+++ b/integration-test/tests/email-autofill.android.spec.js
@@ -1,17 +1,17 @@
 import {
     createAutofillScript,
-    forwardConsoleMessages,
-    withAndroidContext
+    forwardConsoleMessages
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
 import {constants} from '../helpers/mocks.js'
 import {emailAutofillPage, signupPage} from '../helpers/pages.js'
 import {androidStringReplacements, createAndroidMocks} from '../helpers/mocks.android.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for email autofill on android tooltipHandler
  */
-const test = withAndroidContext(base)
+const test = testContext(base)
 
 test.describe('android', () => {
     test.describe('when signed in', () => {

--- a/integration-test/tests/email-autofill.extension.spec.js
+++ b/integration-test/tests/email-autofill.extension.spec.js
@@ -1,15 +1,16 @@
-import {forwardConsoleMessages, withChromeExtensionContext, withEmailProtectionExtensionSignedInAs} from '../helpers/harness.js'
+import {forwardConsoleMessages, withEmailProtectionExtensionSignedInAs} from '../helpers/harness.js'
 import { test as base, expect } from '@playwright/test'
 import {constants} from '../helpers/mocks.js'
 import {emailAutofillPage} from '../helpers/pages.js'
 import { stripDuckExtension } from '../helpers/utils.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for email autofill in chrome extension.
  *
- *  Special setup is needed to load the extension, see withChromeExtensionContext();
+ *  Special setup is needed to load the extension, see testContext();
  */
-const test = withChromeExtensionContext(base)
+const test = testContext(base)
 
 test.describe('chrome extension', () => {
     test('should autofill the selected email', async ({page}) => {

--- a/integration-test/tests/email-autofill.ios.spec.js
+++ b/integration-test/tests/email-autofill.ios.spec.js
@@ -1,17 +1,17 @@
 import {
     createAutofillScript,
-    forwardConsoleMessages,
-    withIOSContext
+    forwardConsoleMessages
 } from '../helpers/harness.js'
 import { test as base } from '@playwright/test'
 import {constants} from '../helpers/mocks.js'
 import {emailAutofillPage} from '../helpers/pages.js'
 import {createWebkitMocks, iosContentScopeReplacements} from '../helpers/mocks.webkit.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for email autofill on ios tooltipHandler
  */
-const test = withIOSContext(base)
+const test = testContext(base)
 
 test.describe('ios', () => {
     test('should autofill the selected email when email protection is enabled', async ({page}) => {

--- a/integration-test/tests/email-autofill.macos.spec.js
+++ b/integration-test/tests/email-autofill.macos.spec.js
@@ -7,11 +7,12 @@ import {constants} from '../helpers/mocks.js'
 import {emailAutofillPage, signupPage} from '../helpers/pages.js'
 import {createWebkitMocks, macosContentScopeReplacements} from '../helpers/mocks.webkit.js'
 import {createAvailableInputTypes, stripDuckExtension} from '../helpers/utils.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for various auto-fill scenarios on macos
  */
-const test = base.extend({})
+const test = testContext(base)
 
 test.describe('macos', () => {
     test('should autofill the selected email', async ({page}) => {

--- a/integration-test/tests/incontext-signup.extension.spec.js
+++ b/integration-test/tests/incontext-signup.extension.spec.js
@@ -1,13 +1,14 @@
-import {forwardConsoleMessages, withChromeExtensionContext, setupMockedDomain} from '../helpers/harness.js'
+import {forwardConsoleMessages, setupMockedDomain} from '../helpers/harness.js'
 import { test as base, expect } from '@playwright/test'
 import {emailAutofillPage, incontextSignupPage, incontextSignupPageWithinIframe, incontextSignupPageEmailBottomPage, incontextSignupPageEmailTopLeftPage} from '../helpers/pages.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for email autofill in chrome extension.
  *
- *  Special setup is needed to load the extension, see withChromeExtensionContext();
+ *  Special setup is needed to load the extension, see testContext();
  */
-const test = withChromeExtensionContext(base)
+const test = testContext(base)
 
 test.describe('chrome extension', () => {
     test('should allow user to sign up for Email Protection', async ({page, context}) => {

--- a/integration-test/tests/login-form.android.spec.js
+++ b/integration-test/tests/login-form.android.spec.js
@@ -1,8 +1,9 @@
 import {constants} from '../helpers/mocks.js'
-import {createAutofillScript, forwardConsoleMessages, withAndroidContext} from '../helpers/harness.js'
+import {createAutofillScript, forwardConsoleMessages} from '../helpers/harness.js'
 import {loginPage, loginPageWithFormInModal, loginPageWithText} from '../helpers/pages.js'
 import {androidStringReplacements, createAndroidMocks} from '../helpers/mocks.android.js'
 import {test as base} from '@playwright/test'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  * @typedef {import('../../src/deviceApiCalls/__generated__/validators-ts').GetAutofillDataResponse} GetAutofillDataResponse
@@ -13,7 +14,7 @@ import {test as base} from '@playwright/test'
 /**
  *  Tests for email autofill on android tooltipHandler
  */
-const test = withAndroidContext(base)
+const test = testContext(base)
 
 /**
  * @param {import("@playwright/test").Page} page

--- a/integration-test/tests/login-form.ios.spec.js
+++ b/integration-test/tests/login-form.ios.spec.js
@@ -1,7 +1,7 @@
 import {constants} from '../helpers/mocks.js'
 import {
     forwardConsoleMessages,
-    withIOSContext, withIOSFeatureToggles
+    withIOSFeatureToggles
 } from '../helpers/harness.js'
 import {
     loginPage,
@@ -13,11 +13,12 @@ import {
 import {test as base} from '@playwright/test'
 import {createWebkitMocks} from '../helpers/mocks.webkit.js'
 import {createAvailableInputTypes} from '../helpers/utils.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for email autofill on android tooltipHandler
  */
-const test = withIOSContext(base)
+const test = testContext(base)
 
 /**
  * @param {import("@playwright/test").Page} page

--- a/integration-test/tests/login-form.windows.spec.js
+++ b/integration-test/tests/login-form.windows.spec.js
@@ -1,15 +1,15 @@
 import {constants} from '../helpers/mocks.js'
 import {
     createAutofillScript,
-    forwardConsoleMessages,
-    withWindowsContext
+    forwardConsoleMessages
 } from '../helpers/harness.js'
 import {loginPage, overlayPage} from '../helpers/pages.js'
 import {test as base} from '@playwright/test'
 import {createWindowsMocks} from '../helpers/mocks.windows.js'
 import {createAvailableInputTypes} from '../helpers/utils.js'
+import {testContext} from '../helpers/test-context.js'
 
-const test = withWindowsContext(base)
+const test = testContext(base)
 
 test.describe('Auto-fill a login form on windows', () => {
     test.describe('when `inputType_credentials` is true', () => {

--- a/integration-test/tests/messaging.windows.spec.js
+++ b/integration-test/tests/messaging.windows.spec.js
@@ -1,16 +1,16 @@
 import {
     createAutofillScript,
-    forwardConsoleMessages,
-    withWindowsContext
+    forwardConsoleMessages
 } from '../helpers/harness.js'
 import {test as base, expect} from '@playwright/test'
 import {signupPage} from '../helpers/pages.js'
 import {createWindowsMocks} from '../helpers/mocks.windows.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for autofill scenarios on Windows
  */
-const test = withWindowsContext(base)
+const test = testContext(base)
 
 test.describe('Windows secure messaging', () => {
     test.describe('When autofill script runs', () => {

--- a/integration-test/tests/remote-config.windows.spec.js
+++ b/integration-test/tests/remote-config.windows.spec.js
@@ -1,13 +1,13 @@
 import {
     createAutofillScript,
-    forwardConsoleMessages,
-    withWindowsContext
+    forwardConsoleMessages
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
 import {loginPage} from '../helpers/pages.js'
 import {createWindowsMocks} from '../helpers/mocks.windows.js'
+import {testContext} from '../helpers/test-context.js'
 
-const test = withWindowsContext(base)
+const test = testContext(base)
 
 test.describe('Remote config on windows', () => {
     test.describe('when autofill is disabled remotely', () => {

--- a/integration-test/tests/save-prompts.android.spec.js
+++ b/integration-test/tests/save-prompts.android.spec.js
@@ -1,17 +1,17 @@
 import {
     createAutofillScript,
-    forwardConsoleMessages,
-    withAndroidContext
+    forwardConsoleMessages
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
 import {loginPage, loginPageWithPoorForm, signupPage} from '../helpers/pages.js'
 import {androidStringReplacements, createAndroidMocks} from '../helpers/mocks.android.js'
 import {constants} from '../helpers/mocks.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for email autofill on ios tooltipHandler
  */
-const test = withAndroidContext(base)
+const test = testContext(base)
 
 test.describe('Android Save prompts', () => {
     test.describe('When saving credentials is enabled ✅ (default)', () => {

--- a/integration-test/tests/save-prompts.ios.spec.js
+++ b/integration-test/tests/save-prompts.ios.spec.js
@@ -1,16 +1,17 @@
 import {
     forwardConsoleMessages,
-    withIOSContext, withIOSFeatureToggles
+    withIOSFeatureToggles
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
 import {loginPage, loginPageWithPoorForm, signupPage} from '../helpers/pages.js'
 import {createWebkitMocks} from '../helpers/mocks.webkit.js'
 import {constants} from '../helpers/mocks.js'
+import {testContext} from '../helpers/test-context.js'
 
 /**
  *  Tests for email autofill on ios tooltipHandler
  */
-const test = withIOSContext(base)
+const test = testContext(base)
 
 test.describe('iOS Save prompts', () => {
     test.describe('and saving credentials disabled ❌', () => {

--- a/integration-test/tests/save-prompts.windows.spec.js
+++ b/integration-test/tests/save-prompts.windows.spec.js
@@ -1,14 +1,14 @@
 import {
     createAutofillScript,
-    forwardConsoleMessages,
-    withWindowsContext
+    forwardConsoleMessages
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
 import {signupPage} from '../helpers/pages.js'
 import {constants} from '../helpers/mocks.js'
 import {createWindowsMocks} from '../helpers/mocks.windows.js'
+import {testContext} from '../helpers/test-context.js'
 
-const test = withWindowsContext(base)
+const test = testContext(base)
 
 test.describe('Save prompts on windows', () => {
     test.describe('When saving credentials is enabled ✅ (default)', () => {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -67,9 +67,12 @@ const config = {
         },
         {
             name: 'android',
-            testMatch: /.*android.spec.js/,
+            testMatch: [
+                /.*android.spec.js/
+            ],
             use: {
-                ...devices['Pixel 5']
+                ...devices['Pixel 5'],
+                userAgent: 'Mozilla/5.0 (Linux; Android 12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 DuckDuckGo/7 Mobile Safari/537.36'
             }
         },
         // {
@@ -79,8 +82,20 @@ const config = {
         //   },
         // },
         {
-            name: 'webkit',
-            testMatch: /.*(ios|macos).spec.js/,
+            name: 'ios',
+            testMatch: [
+                /.*ios.spec.js/
+            ],
+            use: {
+                ...devices['iPhone 12'],
+                userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
+            }
+        },
+        {
+            name: 'macos',
+            testMatch: [
+                /.*macos.spec.js/
+            ],
             use: {
                 ...devices['Desktop Safari']
             }


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/0/1204998354790815/f

## Description

- Moved some playwright config into the 'correct' place, this enables us to simplify the harness creation - and will help towards the goal of re-usable cross-platform tests (to remove some duplication)
- Uses a single `testContext` now - this makes it easy to see what's different per platform and to share functionality, such as appending JSON mocks to the test output
- No functional changes here to Autofill, just splitting up a bigger PR into easy-to-review chunks :)
 
<img width="1000" alt="Screenshot 2023-07-10 at 10 48 39" src="https://github.com/duckduckgo/duckduckgo-autofill/assets/1643522/70b9b296-0b35-4871-8874-3d75cc563d01">

<img width="676" alt="Screenshot 2023-07-10 at 10 53 03" src="https://github.com/duckduckgo/duckduckgo-autofill/assets/1643522/034286df-6608-4c70-bb9e-cfd6a2c7f87a">



## Steps to test
