### PR TITLE
tests: remove platform specific mock parsing

### DIFF
--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -1,6 +1,6 @@
 import { constants } from './mocks.js'
 import { expect } from '@playwright/test'
-import {mockedCalls} from './harness.js'
+import {mockedCalls, payloadsOnly} from './harness.js'
 import {addTopAutofillMouseFocus, clickOnIcon} from './utils.js'
 
 const ATTR_AUTOFILL = 'data-ddg-autofill'
@@ -102,19 +102,12 @@ export function signupPage (page) {
         },
         /**
          * @param {number} times
-         * @param {Platform} platform
          * @return {Promise<void>}
          */
-        async assertPasswordWasSuggestedTimes (times = 1, platform) {
-            const calls = await mockedCalls(page, ['getAutofillData'])
-            const suggested = calls.filter(call => {
-                let json
-                if (platform === 'android') {
-                    // @ts-expect-error - on Android this is a string
-                    json = JSON.parse(call[1])
-                } else {
-                    json = call[1]
-                }
+        async assertPasswordWasSuggestedTimes (times = 1) {
+            const calls = await mockedCalls(page, {names: ['getAutofillData']})
+            const payloads = payloadsOnly(calls)
+            const suggested = payloads.filter(json => {
                 return Boolean(json.generatedPassword)
             })
             expect(suggested.length).toBe(times)
@@ -189,7 +182,7 @@ export function signupPage (page) {
          * @param {import('../../src/deviceApiCalls/__generated__/validators-ts').SendJSPixelParams[]} pixels
          */
         async assertPixelsFired (pixels) {
-            const calls = await mockedCalls(page, ['sendJSPixel'])
+            const calls = await mockedCalls(page, {names: ['sendJSPixel']})
             expect(calls.length).toBeGreaterThanOrEqual(1)
             const firedPixels = calls.map(([_, {pixelName, params}]) => params ? ({pixelName, params}) : ({pixelName}))
             expect(firedPixels).toEqual(pixels)
@@ -223,25 +216,19 @@ export function signupPage (page) {
         },
         /**
          * @param {Omit<CredentialsObject, "id">} credentials
-         * @param {Platform} platform
          * @returns {Promise<void>}
          */
-        async assertWasPromptedToSave (credentials, platform) {
-            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
-            const mockCalls = calls.find(([name]) => name === 'storeFormData')
-            let [, sent] = mockCalls
-            if (platform === 'android') {
-                expect(typeof sent).toBe('string')
-                sent = JSON.parse(sent)
-            }
-            expect(sent.credentials).toEqual(credentials)
+        async assertWasPromptedToSave (credentials) {
+            const calls = await mockedCalls(page, { names: ['storeFormData'] })
+            const payloads = payloadsOnly(calls)
+            expect(payloads[0].credentials).toEqual(credentials)
         },
         /**
          * @param {Omit<CredentialsObject, "id">} credentials
          * @returns {Promise<void>}
          */
         async assertWasPromptedToSaveWindows (credentials) {
-            const calls = await mockedCalls(page, ['storeFormData'])
+            const calls = await mockedCalls(page, { names: ['storeFormData'] })
             expect(calls.length).toBeGreaterThanOrEqual(1)
             const [, sent] = calls[0]
             // @ts-expect-error
@@ -251,7 +238,7 @@ export function signupPage (page) {
          * @returns {Promise<void>}
          */
         async assertWasNotPromptedToSaveWindows () {
-            const calls = await mockedCalls(page, ['storeFormData'], false)
+            const calls = await mockedCalls(page, { names: ['storeFormData'], minCount: 0 })
 
             expect(calls.length).toBe(0)
         },
@@ -373,7 +360,7 @@ export function loginPage (page, opts = {}) {
             const updatedButton = await page.waitForSelector(`button:has-text("${constants.fields.email.personalAddress}")`)
             expect(updatedButton).toBeDefined()
             await updatedButton.click()
-            const autofillCalls = await mockedCalls(page, ['pmHandlerGetAutofillCredentials'], true)
+            const autofillCalls = await mockedCalls(page, {names: ['pmHandlerGetAutofillCredentials']})
             expect(autofillCalls).toHaveLength(1)
         },
         /**
@@ -410,7 +397,7 @@ export function loginPage (page, opts = {}) {
          * @returns {Promise<void>}
          */
         async promptWasShown (platform = 'android') {
-            const calls = await mockedCalls(page, ['getAutofillData'])
+            const calls = await mockedCalls(page, {names: ['getAutofillData']})
             expect(calls.length).toBeGreaterThan(0)
             const [, sent] = calls[0]
             let params
@@ -435,7 +422,7 @@ export function loginPage (page, opts = {}) {
          * @returns {Promise<void>}
          */
         async assertParentOpened () {
-            const credsCalls = await mockedCalls(page, ['getSelectedCredentials'], true)
+            const credsCalls = await mockedCalls(page, { names: ['getSelectedCredentials'] })
             // @ts-expect-error
             const hasSucceeded = credsCalls.some((call) => call[2]?.some(({type}) => type === 'ok'))
             expect(hasSucceeded).toBe(true)
@@ -461,8 +448,7 @@ export function loginPage (page, opts = {}) {
         },
         async shouldNotPromptToSave () {
             let mockCalls = []
-            mockCalls = await mockedCalls(page, ['storeFormData'], false)
-
+            mockCalls = await mockedCalls(page, { names: ['storeFormData'], minCount: 0 })
             expect(mockCalls.length).toBe(0)
         },
         /**
@@ -503,30 +489,19 @@ export function loginPage (page, opts = {}) {
         },
         /**
          * @param {Record<string, any>} data
-         * @param {Platform} [platform]
          */
-        async assertWasPromptedToSave (data, platform = 'ios') {
-            const calls = await page.evaluate('window.__playwright_autofill.mocks.calls')
-            const mockCalls = calls.filter(([name]) => name === 'storeFormData')
-            expect(mockCalls).toHaveLength(1)
-            const [, sent] = mockCalls[0]
-            const expected = {
-                credentials: data,
-                trigger: 'formSubmission'
-            }
-            if (platform === 'ios' || platform === 'macos') {
-                expected.messageHandling = {secret: 'PLACEHOLDER_SECRET'}
-                return expect(sent).toEqual(expected)
-            }
-            if (platform === 'android') {
-                expect(JSON.parse(sent)).toEqual(expected)
-            }
+        async assertWasPromptedToSave (data) {
+            const calls = await mockedCalls(page, { names: ['storeFormData'] })
+            const payloads = payloadsOnly(calls)
+
+            expect(payloads[0].credentials).toEqual(data)
+            expect(payloads[0].trigger).toEqual('formSubmission')
         },
         /**
          * @returns {Promise<void>}
          */
         async assertClickMessage () {
-            const calls = await mockedCalls(page, ['showAutofillParent'])
+            const calls = await mockedCalls(page, { names: ['showAutofillParent'] })
             expect(calls.length).toBe(1)
 
             // each call is captured as a tuple like this: [name, params, response], which is why
@@ -535,7 +510,7 @@ export function loginPage (page, opts = {}) {
             expect(call1[1].wasFromClick).toBe(true)
         },
         async assertFocusMessage () {
-            const calls = await mockedCalls(page, ['showAutofillParent'])
+            const calls = await mockedCalls(page, { names: ['showAutofillParent'] })
             expect(calls.length).toBe(1)
 
             // each call is captured as a tuple like this: [name, params, response], which is why
@@ -559,7 +534,7 @@ export function loginPage (page, opts = {}) {
             expect(count).toBe(0)
         },
         async assertNoPixelFired () {
-            const mockCalls = await mockedCalls(page, ['sendJSPixel'], false)
+            const mockCalls = await mockedCalls(page, { names: ['sendJSPixel'], minCount: 0 })
             expect(mockCalls).toHaveLength(0)
         }
     }
@@ -716,13 +691,13 @@ export function emailAutofillPage (page) {
          * @param {import('../../src/deviceApiCalls/__generated__/validators-ts').SendJSPixelParams[]} pixels
          */
         async assertPixelsFired (pixels) {
-            const calls = await mockedCalls(page, ['sendJSPixel'])
+            const calls = await mockedCalls(page, { names: ['sendJSPixel'] })
             expect(calls.length).toBeGreaterThanOrEqual(1)
             const firedPixels = calls.map(([_, {pixelName, params}]) => params ? ({pixelName, params}) : ({pixelName}))
             expect(firedPixels).toEqual(pixels)
         },
         async assertNoPixelsFired () {
-            const calls = await mockedCalls(page, ['sendJSPixel'], false)
+            const calls = await mockedCalls(page, { names: ['sendJSPixel'], minCount: 0 })
             expect(calls.length).toBe(0)
         },
         async assertExtensionPixelsCaptured (expectedPixels) {
@@ -773,13 +748,13 @@ export function overlayPage (page) {
          * @params {string} callName
          */
         async doesNotCloseParentAfterCall (callName) {
-            const callNameCalls = await mockedCalls(page, [callName], true)
+            const callNameCalls = await mockedCalls(page, {names: [callName]})
             expect(callNameCalls.length).toBeGreaterThanOrEqual(1)
-            const closeAutofillParentCalls = await mockedCalls(page, ['closeAutofillParent'], false)
+            const closeAutofillParentCalls = await mockedCalls(page, {names: ['closeAutofillParent'], minCount: 0})
             expect(closeAutofillParentCalls.length).toBe(0)
         },
         async assertCloseAutofillParent () {
-            const closeAutofillParentCalls = await mockedCalls(page, ['closeAutofillParent'], true)
+            const closeAutofillParentCalls = await mockedCalls(page, {names: ['closeAutofillParent']})
             expect(closeAutofillParentCalls.length).toBe(1)
         },
         /**

--- a/integration-test/tests/email-autofill.android.spec.js
+++ b/integration-test/tests/email-autofill.android.spec.js
@@ -142,11 +142,11 @@ test.describe('android', () => {
 
             // should not prompt again on second password field (which will be untouched)
             await signup.clickIntoPasswordConfirmationField()
-            await signup.assertPasswordWasSuggestedTimes(1, 'android')
+            await signup.assertPasswordWasSuggestedTimes(1)
 
             // SHOULD prompt again if icon clicked though, since that's explicit opt-in
             await signup.clickDirectlyOnPasswordIcon()
-            await signup.assertPasswordWasSuggestedTimes(2, 'android')
+            await signup.assertPasswordWasSuggestedTimes(2)
         })
     })
 })

--- a/integration-test/tests/incontext-signup.macos.spec.js
+++ b/integration-test/tests/incontext-signup.macos.spec.js
@@ -38,7 +38,7 @@ test.describe('macos', () => {
         await incontextSignup.getEmailProtection()
 
         // Confirm message passed to native
-        const startCall = await mockedCalls(page, ['startEmailProtectionSignup'])
+        const startCall = await mockedCalls(page, {names: ['startEmailProtectionSignup']})
         expect(startCall.length).toBe(1)
 
         // Confirm pixels triggered

--- a/integration-test/tests/login-form.android.spec.js
+++ b/integration-test/tests/login-form.android.spec.js
@@ -150,7 +150,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                 await login.clickIntoPasswordInput()
                 await login.assertPasswordFilled(password)
                 await login.assertFormNotSubmittedAutomatically()
-                await login.assertWasPromptedToSave({username, password}, 'android')
+                await login.assertWasPromptedToSave({username, password})
             })
         })
         test.describe('but I dont have saved credentials', () => {

--- a/integration-test/tests/login-form.ios.spec.js
+++ b/integration-test/tests/login-form.ios.spec.js
@@ -172,7 +172,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                 await login.clickIntoPasswordInput()
                 await login.assertPasswordFilled(password)
                 await login.assertFormNotSubmittedAutomatically()
-                await login.assertWasPromptedToSave({username, password}, 'ios')
+                await login.assertWasPromptedToSave({username, password})
             })
         })
         test.describe('but I dont have saved credentials', () => {

--- a/integration-test/tests/login-form.macos.spec.js
+++ b/integration-test/tests/login-form.macos.spec.js
@@ -404,7 +404,7 @@ test.describe('Auto-fill a login form on macOS', () => {
                 await overlay.clickButtonWithText('Bitwarden is locked')
                 await overlay.doesNotCloseParentAfterCall('askToUnlockProvider')
 
-                const autofillCalls = await mockedCalls(page, ['setSize'], true)
+                const autofillCalls = await mockedCalls(page, {names: ['setSize'], minCount: 1})
                 expect(autofillCalls.length).toBeGreaterThanOrEqual(1)
             })
 

--- a/integration-test/tests/save-prompts.android.spec.js
+++ b/integration-test/tests/save-prompts.android.spec.js
@@ -41,7 +41,7 @@ test.describe('Android Save prompts', () => {
                 .applyTo(page)
 
             await signup.enterCredentials(credentials)
-            await signup.assertWasPromptedToSave(credentials, 'android')
+            await signup.assertWasPromptedToSave(credentials)
         })
         test.describe('Prompting to save from a login form', () => {
             /** @param {import("@playwright/test").Page} page */
@@ -72,13 +72,13 @@ test.describe('Android Save prompts', () => {
                     password: '123456'
                 }
                 await login.submitLoginForm(credentials)
-                await login.assertWasPromptedToSave(credentials, 'android')
+                await login.assertWasPromptedToSave(credentials)
             })
             test('with password only (should prompt)', async ({page}) => {
                 const { login } = await setup(page)
                 const credentials = { password: '123456' }
                 await login.submitPasswordOnlyForm(credentials)
-                await login.assertWasPromptedToSave(credentials, 'android')
+                await login.assertWasPromptedToSave(credentials)
             })
             test('with username only (should NOT prompt)', async ({page}) => {
                 const { login } = await setup(page)
@@ -164,7 +164,7 @@ test.describe('Android Save prompts', () => {
             const login = await setup(page)
 
             await page.click('"Log in"')
-            await login.assertWasPromptedToSave(credentials, 'android')
+            await login.assertWasPromptedToSave(credentials)
         })
         test('should not prompt if the out-of-form button does not match the form type', async ({page}) => {
             const login = await setup(page)
@@ -179,7 +179,7 @@ test.describe('Android Save prompts', () => {
             await login.shouldNotPromptToSave()
 
             await page.press('#password', 'Enter')
-            await login.assertWasPromptedToSave(credentials, 'android')
+            await login.assertWasPromptedToSave(credentials)
         })
     })
 })

--- a/integration-test/tests/save-prompts.ios.spec.js
+++ b/integration-test/tests/save-prompts.ios.spec.js
@@ -73,7 +73,7 @@ test.describe('iOS Save prompts', () => {
             const signup = signupPage(page)
             await signup.navigate()
             await signup.enterCredentials(credentials)
-            await signup.assertWasPromptedToSave(credentials, 'ios')
+            await signup.assertWasPromptedToSave(credentials)
         })
         test.describe('Prompting to save from a login form', () => {
             /**

--- a/integration-test/tests/save-prompts.macos.spec.js
+++ b/integration-test/tests/save-prompts.macos.spec.js
@@ -34,7 +34,7 @@ test.describe('macos', () => {
             const signup = signupPage(page)
             await signup.navigate()
             await signup.enterCredentials(credentials)
-            await signup.assertWasPromptedToSave(credentials, 'macos')
+            await signup.assertWasPromptedToSave(credentials)
         })
         test.describe('Prompting to save from a login form', () => {
             test('username+password (should prompt)', async ({page}) => {


### PR DESCRIPTION
**Reviewer:** @GioSensation @alistairjcbrown 
**Asana:** https://app.asana.com/0/0/1204998354790819/f

## Description

More overdue cleanup. I had let platform-specific logic leak into more places, this reverses it and is another step in the direction of shared tests :)


## Steps to test
