### PR TITLE
tests: decouple 'login helpers' from navigating to separate tests

### DIFF
--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -718,36 +718,3 @@ export function overlayPage (page) {
         }
     }
 }
-
-/**
- * A wrapper around interactions for `integration-test/pages/signup.html`
- *
- * @param {import("@playwright/test").Page} page
- * @param {ServerWrapper} server
- */
-export function loginAndSignup (page, server) {
-    // style lookup helpers
-    const usernameStyleAttr = () => page.locator(constants.fields.username.selectors.credential).getAttribute('style')
-    const emailStyleAttr = () => page.locator(constants.fields.email.selectors.identity).getAttribute('style')
-    const firstPasswordStyleAttr = () => page.locator('#login-password' + constants.fields.password.selectors.credential).getAttribute('style')
-
-    return {
-        async navigate () {
-            await page.goto(server.urlForPath(constants.pages['login+setup']))
-        },
-        async assertIdentitiesWereNotDecorated () {
-            const style = await emailStyleAttr()
-            expect(style).toBeNull()
-        },
-        async assertUsernameAndPasswordWereDecoratedWithIcon () {
-            expect(await usernameStyleAttr()).toContain('data:image/svg+xml;base64,')
-            expect(await firstPasswordStyleAttr()).toContain('data:image/svg+xml;base64,')
-        },
-        async assertNoDecorations () {
-            const usernameAttr = await usernameStyleAttr()
-            expect(usernameAttr).toBeNull()
-
-            expect(await firstPasswordStyleAttr()).toBeNull()
-        }
-    }
-}

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -281,8 +281,12 @@ export function signupPage (page) {
 export function loginPage (page, opts = {}) {
     const { overlay = false, clickLabel = false } = opts
     return {
-        async navigate () {
-            await page.goto(constants.pages['login'])
+        /**
+         * @param {keyof typeof constants.pages} [to] - any key matching in `constants.pages`
+         * @return {Promise<void>}
+         */
+        async navigate (to = 'login') {
+            await page.goto(constants.pages[to])
         },
         async clickIntoUsernameInput () {
             const usernameField = page.locator('#email').first()
@@ -561,54 +565,6 @@ export function loginPage (page, opts = {}) {
         async assertNoPixelFired () {
             const mockCalls = await mockedCalls(page, ['sendJSPixel'], false)
             expect(mockCalls).toHaveLength(0)
-        }
-    }
-}
-
-/**
- * A wrapper around interactions for `integration-test/pages/login.html`
- *
- * @param {import("@playwright/test").Page} page
- * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
- */
-export function loginPageWithText (page, opts) {
-    const originalLoginPage = loginPage(page, opts)
-    return {
-        ...originalLoginPage,
-        async navigate () {
-            await page.goto(constants.pages['loginWithText'])
-        }
-    }
-}
-
-/**
- * A wrapper around interactions for `integration-test/pages/login-poor-form.html`
- *
- * @param {import("@playwright/test").Page} page
- * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
- */
-export function loginPageWithPoorForm (page, opts) {
-    const originalLoginPage = loginPage(page, opts)
-    return {
-        ...originalLoginPage,
-        async navigate () {
-            await page.goto(constants.pages['loginWithPoorForm'])
-        }
-    }
-}
-
-/**
- * A wrapper around interactions for `integration-test/pages/login-in-modal.html`
- *
- * @param {import("@playwright/test").Page} page
- * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
- */
-export function loginPageWithFormInModal (page, opts) {
-    const originalLoginPage = loginPage(page, opts)
-    return {
-        ...originalLoginPage,
-        async navigate () {
-            await page.goto(constants.pages['loginWithFormInModal'])
         },
         async openDialog () {
             const button = await page.waitForSelector(`button:has-text("Click here to Login")`)
@@ -628,44 +584,9 @@ export function loginPageWithFormInModal (page, opts) {
         },
         async clickOutsideTheDialog () {
             await page.click('#random-text')
-        }
-    }
-}
-
-/**
- * A wrapper around interactions for `integration-test/pages/login-covered.html`
- *
- * @param {import("@playwright/test").Page} page
- * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
- */
-export function loginPageCovered (page, opts) {
-    const originalLoginPage = loginPage(page, opts)
-    return {
-        ...originalLoginPage,
-        async navigate () {
-            await page.goto(constants.pages['loginCovered'])
         },
         async closeCookieDialog () {
             await page.click('button:has-text("Accept all cookies")')
-        }
-    }
-}
-
-/**
- * A wrapper around interactions for `integration-test/pages/login-multistep.html`
- *
- * @param {import("@playwright/test").Page} page
- * @param {{overlay?: boolean, clickLabel?: boolean}} [opts]
- */
-export function loginPageMultistep (page, opts) {
-    const originalLoginPage = loginPage(page, opts)
-    return {
-        ...originalLoginPage,
-        async navigate () {
-            await page.goto(constants.pages['loginMultistep'])
-        },
-        async clickContinue () {
-            await page.click('button:has-text("Continue")')
         }
     }
 }

--- a/integration-test/tests/login-form.android.spec.js
+++ b/integration-test/tests/login-form.android.spec.js
@@ -1,6 +1,6 @@
 import {constants} from '../helpers/mocks.js'
 import {createAutofillScript, forwardConsoleMessages} from '../helpers/harness.js'
-import {loginPage, loginPageWithFormInModal, loginPageWithText} from '../helpers/pages.js'
+import {loginPage} from '../helpers/pages.js'
 import {androidStringReplacements, createAndroidMocks} from '../helpers/mocks.android.js'
 import {test as base} from '@playwright/test'
 import {testContext} from '../helpers/test-context.js'
@@ -22,25 +22,14 @@ const test = testContext(base)
  * @param {Partial<AutofillFeatureToggles>} opts.featureToggles
  * @param {Partial<AvailableInputTypes>} [opts.availableInputTypes]
  * @param {CredentialsMock} [opts.credentials]
- * @param {'standard' | 'withExtraText' | 'withModal'} [opts.pageType]
+ * @param {keyof typeof constants.pages} [opts.pageType]
  */
 async function testLoginPage (page, opts) {
     // enable in-terminal exceptions
     await forwardConsoleMessages(page)
 
-    let login
-    switch (opts.pageType) {
-    case 'withExtraText':
-        login = loginPageWithText(page)
-        break
-    case 'withModal':
-        login = loginPageWithFormInModal(page)
-        break
-    default:
-        login = loginPage(page)
-        break
-    }
-    await login.navigate()
+    const login = loginPage(page);
+    await login.navigate(opts.pageType)
 
     // android specific mocks
     const mocks = createAndroidMocks()
@@ -90,7 +79,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                         inputType_credentials: true
                     },
                     credentials,
-                    pageType: 'withExtraText'
+                    pageType: 'loginWithText'
                 })
                 await login.fieldsContainIcons()
                 await login.clickIntoUsernameInput()
@@ -103,7 +92,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                         inputType_credentials: true
                     },
                     credentials,
-                    pageType: 'withExtraText'
+                    pageType: 'loginWithText'
                 })
                 await login.fieldsContainIcons()
                 await login.promptWasNotShown()
@@ -116,7 +105,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                         inputType_credentials: true
                     },
                     credentials,
-                    pageType: 'withModal'
+                    pageType: 'loginWithFormInModal'
                 })
                 await login.promptWasNotShown()
                 await login.assertDialogClose()
@@ -138,7 +127,7 @@ test.describe('Feature: auto-filling a login form on Android', () => {
                         ...credentials,
                         username: ''
                     },
-                    pageType: 'withExtraText'
+                    pageType: 'loginWithText'
                 })
 
                 const {username, password} = credentials

--- a/integration-test/tests/login-form.android.spec.js
+++ b/integration-test/tests/login-form.android.spec.js
@@ -28,7 +28,7 @@ async function testLoginPage (page, opts) {
     // enable in-terminal exceptions
     await forwardConsoleMessages(page)
 
-    const login = loginPage(page);
+    const login = loginPage(page)
     await login.navigate(opts.pageType)
 
     // android specific mocks

--- a/integration-test/tests/login-form.ios.spec.js
+++ b/integration-test/tests/login-form.ios.spec.js
@@ -4,7 +4,7 @@ import {
     withIOSFeatureToggles
 } from '../helpers/harness.js'
 import {
-    loginPage,
+    loginPage
 } from '../helpers/pages.js'
 import {test as base} from '@playwright/test'
 import {createWebkitMocks} from '../helpers/mocks.webkit.js'

--- a/integration-test/tests/login-form.ios.spec.js
+++ b/integration-test/tests/login-form.ios.spec.js
@@ -5,10 +5,6 @@ import {
 } from '../helpers/harness.js'
 import {
     loginPage,
-    loginPageCovered,
-    loginPageMultistep,
-    loginPageWithFormInModal,
-    loginPageWithText
 } from '../helpers/pages.js'
 import {test as base} from '@playwright/test'
 import {createWebkitMocks} from '../helpers/mocks.webkit.js'
@@ -26,7 +22,7 @@ const test = testContext(base)
  * @param {Partial<import('../../src/deviceApiCalls/__generated__/validators-ts').AutofillFeatureToggles>} opts.featureToggles
  * @param {Partial<import('../../src/deviceApiCalls/__generated__/validators-ts').AvailableInputTypes>} [opts.availableInputTypes]
  * @param {CredentialsMock} [opts.credentials]
- * @param {'standard' | 'withExtraText' | 'withModal' | 'covered' | 'multistep'} [opts.pageType]
+ * @param {keyof typeof constants.pages} [opts.pageType]
  */
 async function testLoginPage (page, opts) {
     // enable in-terminal exceptions
@@ -44,26 +40,9 @@ async function testLoginPage (page, opts) {
 
     await withIOSFeatureToggles(page, opts.featureToggles)
 
-    let login
-    switch (opts.pageType) {
-    case 'withExtraText':
-        login = loginPageWithText(page)
-        break
-    case 'withModal':
-        login = loginPageWithFormInModal(page)
-        break
-    case 'covered':
-        login = loginPageCovered(page)
-        break
-    case 'multistep':
-        login = loginPageMultistep(page)
-        break
-    default:
-        login = loginPage(page)
-        break
-    }
+    const login = loginPage(page)
+    await login.navigate(opts.pageType)
 
-    await login.navigate()
     return {login}
 }
 
@@ -94,7 +73,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                         inputType_credentials: true
                     },
                     credentials,
-                    pageType: 'withExtraText'
+                    pageType: 'loginWithText'
                 })
                 await login.promptWasNotShown()
                 await login.fieldsContainIcons()
@@ -108,7 +87,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                         inputType_credentials: true
                     },
                     credentials,
-                    pageType: 'covered'
+                    pageType: 'loginCovered'
                 })
                 await login.fieldsContainIcons()
                 await login.promptWasNotShown()
@@ -123,7 +102,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                         inputType_credentials: true
                     },
                     credentials,
-                    pageType: 'multistep'
+                    pageType: 'loginMultistep'
                 })
                 await login.promptWasShown('ios')
                 await login.assertUsernameFilled(personalAddress)
@@ -138,7 +117,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                         inputType_credentials: true
                     },
                     credentials,
-                    pageType: 'withModal'
+                    pageType: 'loginWithFormInModal'
                 })
                 await login.promptWasNotShown()
                 await login.assertDialogClose()
@@ -160,7 +139,7 @@ test.describe('Auto-fill a login form on iOS', () => {
                         ...credentials,
                         username: ''
                     },
-                    pageType: 'withExtraText'
+                    pageType: 'loginWithText'
                 })
 
                 const {username, password} = credentials

--- a/integration-test/tests/login-form.macos.spec.js
+++ b/integration-test/tests/login-form.macos.spec.js
@@ -47,7 +47,7 @@ async function testLoginPage (page, opts = {}) {
         .platform('macos')
         .applyTo(page)
 
-    const login = loginPage(page, {overlay, clickLabel});
+    const login = loginPage(page, {overlay, clickLabel})
     await login.navigate(pageType)
     await page.waitForTimeout(200)
 

--- a/integration-test/tests/save-prompts.android.spec.js
+++ b/integration-test/tests/save-prompts.android.spec.js
@@ -3,7 +3,7 @@ import {
     forwardConsoleMessages
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
-import {loginPage, loginPageWithPoorForm, signupPage} from '../helpers/pages.js'
+import {loginPage, signupPage} from '../helpers/pages.js'
 import {androidStringReplacements, createAndroidMocks} from '../helpers/mocks.android.js'
 import {constants} from '../helpers/mocks.js'
 import {testContext} from '../helpers/test-context.js'
@@ -134,8 +134,8 @@ test.describe('Android Save prompts', () => {
          */
         async function setup (page) {
             await forwardConsoleMessages(page)
-            const login = loginPageWithPoorForm(page)
-            await login.navigate()
+            const login = loginPage(page)
+            await login.navigate('loginWithPoorForm')
 
             await createAndroidMocks()
                 .applyTo(page)

--- a/integration-test/tests/save-prompts.ios.spec.js
+++ b/integration-test/tests/save-prompts.ios.spec.js
@@ -3,7 +3,7 @@ import {
     withIOSFeatureToggles
 } from '../helpers/harness.js'
 import {test as base} from '@playwright/test'
-import {loginPage, loginPageWithPoorForm, signupPage} from '../helpers/pages.js'
+import {loginPage, signupPage} from '../helpers/pages.js'
 import {createWebkitMocks} from '../helpers/mocks.webkit.js'
 import {constants} from '../helpers/mocks.js'
 import {testContext} from '../helpers/test-context.js'
@@ -131,8 +131,8 @@ test.describe('iOS Save prompts', () => {
                 await withIOSFeatureToggles(page, {
                     credentials_saving: true
                 })
-                const login = loginPageWithPoorForm(page)
-                await login.navigate()
+                const login = loginPage(page)
+                await login.navigate('loginWithPoorForm')
 
                 await page.type('#password', credentials.password)
                 await page.type('#email', credentials.username)


### PR DESCRIPTION
**Reviewer:** @GioSensation @alistairjcbrown 
**Asana:** 

## Description

- removes additional page wrappers, in favour of a strongly typed 'navigate(pageType)' call instead
- removed the string values from some test helpers - not using the constants object directly as types with `keyof typeof constants.pages`

** before **
```js
export function loginPageWithPoorForm (page, opts) {
    const originalLoginPage = loginPage(page, opts)
    return {
        ...originalLoginPage,
        async navigate () {
            await page.goto(constants.pages['loginWithPoorForm'])
        }
    }
}
```

**after**

```js
const login = loginPage(page, opts);
await login.navigate('loginWithPoorForm') // where 'loginWithPoorForm' must be a key in `constants.pages`
```



## Steps to test
