### PR TITLE
Update email protection copy to align with mobile

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8598,14 +8598,14 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Blocks email trackers'
+        title: 'Block email trackers'
       });
     }
 
     newIdentities.push({
       id: 'privateAddress',
       emailAddress: privateAddress,
-      title: 'Blocks email trackers and hides your address'
+      title: 'Block email trackers & hide address'
     });
     return [...identities, ...newIdentities];
   }
@@ -16051,7 +16051,7 @@ class EmailHTMLTooltip extends _HTMLTooltip.default {
   render(device) {
     this.device = device;
     this.addresses = device.getLocalAddresses();
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\" hidden>\n    <div class=\"tooltip tooltip--email\">\n        <button class=\"tooltip__button tooltip__button--email js-use-personal\">\n            <span class=\"tooltip__button--email__primary-text\">\n                Use <span class=\"js-address\">").concat((0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress)), "</span>\n            </span>\n            <span class=\"tooltip__button--email__secondary-text\">Blocks email trackers</span>\n        </button>\n        <button class=\"tooltip__button tooltip__button--email js-use-private\">\n            <span class=\"tooltip__button--email__primary-text\">Generate a Private Duck Address</span>\n            <span class=\"tooltip__button--email__secondary-text\">Blocks email trackers and hides your address</span>\n        </button>\n    </div>\n    <div class=\"tooltip--email__caret\"></div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\" hidden>\n    <div class=\"tooltip tooltip--email\">\n        <button class=\"tooltip__button tooltip__button--email js-use-personal\">\n            <span class=\"tooltip__button--email__primary-text\">\n                Use <span class=\"js-address\">").concat((0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress)), "</span>\n            </span>\n            <span class=\"tooltip__button--email__secondary-text\">Block email trackers</span>\n        </button>\n        <button class=\"tooltip__button tooltip__button--email js-use-private\">\n            <span class=\"tooltip__button--email__primary-text\">Generate a Private Duck Address</span>\n            <span class=\"tooltip__button--email__secondary-text\">Block email trackers & hide address</span>\n        </button>\n    </div>\n    <div class=\"tooltip--email__caret\"></div>\n</div>");
     this.wrapper = this.shadow.querySelector('.wrapper');
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4922,14 +4922,14 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Blocks email trackers'
+        title: 'Block email trackers'
       });
     }
 
     newIdentities.push({
       id: 'privateAddress',
       emailAddress: privateAddress,
-      title: 'Blocks email trackers and hides your address'
+      title: 'Block email trackers & hide address'
     });
     return [...identities, ...newIdentities];
   }
@@ -12375,7 +12375,7 @@ class EmailHTMLTooltip extends _HTMLTooltip.default {
   render(device) {
     this.device = device;
     this.addresses = device.getLocalAddresses();
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\" hidden>\n    <div class=\"tooltip tooltip--email\">\n        <button class=\"tooltip__button tooltip__button--email js-use-personal\">\n            <span class=\"tooltip__button--email__primary-text\">\n                Use <span class=\"js-address\">").concat((0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress)), "</span>\n            </span>\n            <span class=\"tooltip__button--email__secondary-text\">Blocks email trackers</span>\n        </button>\n        <button class=\"tooltip__button tooltip__button--email js-use-private\">\n            <span class=\"tooltip__button--email__primary-text\">Generate a Private Duck Address</span>\n            <span class=\"tooltip__button--email__secondary-text\">Blocks email trackers and hides your address</span>\n        </button>\n    </div>\n    <div class=\"tooltip--email__caret\"></div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\" hidden>\n    <div class=\"tooltip tooltip--email\">\n        <button class=\"tooltip__button tooltip__button--email js-use-personal\">\n            <span class=\"tooltip__button--email__primary-text\">\n                Use <span class=\"js-address\">").concat((0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress)), "</span>\n            </span>\n            <span class=\"tooltip__button--email__secondary-text\">Block email trackers</span>\n        </button>\n        <button class=\"tooltip__button tooltip__button--email js-use-private\">\n            <span class=\"tooltip__button--email__primary-text\">Generate a Private Duck Address</span>\n            <span class=\"tooltip__button--email__secondary-text\">Block email trackers & hide address</span>\n        </button>\n    </div>\n    <div class=\"tooltip--email__caret\"></div>\n</div>");
     this.wrapper = this.shadow.querySelector('.wrapper');
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -113,7 +113,7 @@ export function signupPage (page) {
          * @param {string} address
          */
         async selectPrivateAddress (address) {
-            await page.getByRole('button', { name: `Generate Private Duck Address ${address} Blocks email trackers and hides your address` })
+            await page.getByRole('button', { name: `Generate Private Duck Address ${address} Block email trackers & hide address` })
                 .click({force: true})
         }
         /**

--- a/integration-test/tests/email-autofill.extension.spec.js
+++ b/integration-test/tests/email-autofill.extension.spec.js
@@ -25,8 +25,8 @@ test.describe('chrome extension', () => {
         await emailPage.clickIntoInput()
 
         // buttons, unique to the extension
-        const personalAddressBtn = await page.locator(`text=Use ${personalAddress} Blocks email trackers`)
-        const privateAddressBtn = await page.locator(`text=Generate a Private Duck Address Blocks email trackers and hides your address`)
+        const personalAddressBtn = await page.locator(`text=Use ${personalAddress} Block email trackers`)
+        const privateAddressBtn = await page.locator(`text=Generate a Private Duck Address Block email trackers & hide address`)
 
         // click first option
         await personalAddressBtn.click({timeout: 500})

--- a/integration-test/tests/email-autofill.macos.spec.js
+++ b/integration-test/tests/email-autofill.macos.spec.js
@@ -41,7 +41,7 @@ test.describe('macos', () => {
         await emailPage.clickIntoInput()
 
         // these are mac specific - different to the extension because they use different tooltips (currently)
-        const personalAddressBtn = await page.locator(`button:has-text("${personalAddress} Blocks email trackers")`)
+        const personalAddressBtn = await page.locator(`button:has-text("${personalAddress} Block email trackers")`)
         const privateAddressBtn = await page.locator(`button:has-text("Generate Private Duck Address 0@duck.com")`)
 
         // select the first option

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -163,14 +163,14 @@ class InterfacePrototype {
             newIdentities.push({
                 id: 'personalAddress',
                 emailAddress: personalAddress,
-                title: 'Blocks email trackers'
+                title: 'Block email trackers'
             })
         }
 
         newIdentities.push({
             id: 'privateAddress',
             emailAddress: privateAddress,
-            title: 'Blocks email trackers and hides your address'
+            title: 'Block email trackers & hide address'
         })
 
         return [...identities, ...newIdentities]

--- a/src/UI/EmailHTMLTooltip.js
+++ b/src/UI/EmailHTMLTooltip.js
@@ -17,11 +17,11 @@ ${this.options.css}
             <span class="tooltip__button--email__primary-text">
                 Use <span class="js-address">${formatDuckAddress(escapeXML(this.addresses.personalAddress))}</span>
             </span>
-            <span class="tooltip__button--email__secondary-text">Blocks email trackers</span>
+            <span class="tooltip__button--email__secondary-text">Block email trackers</span>
         </button>
         <button class="tooltip__button tooltip__button--email js-use-private">
             <span class="tooltip__button--email__primary-text">Generate a Private Duck Address</span>
-            <span class="tooltip__button--email__secondary-text">Blocks email trackers and hides your address</span>
+            <span class="tooltip__button--email__secondary-text">Block email trackers & hide address</span>
         </button>
     </div>
     <div class="tooltip--email__caret"></div>

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8598,14 +8598,14 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Blocks email trackers'
+        title: 'Block email trackers'
       });
     }
 
     newIdentities.push({
       id: 'privateAddress',
       emailAddress: privateAddress,
-      title: 'Blocks email trackers and hides your address'
+      title: 'Block email trackers & hide address'
     });
     return [...identities, ...newIdentities];
   }
@@ -16051,7 +16051,7 @@ class EmailHTMLTooltip extends _HTMLTooltip.default {
   render(device) {
     this.device = device;
     this.addresses = device.getLocalAddresses();
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\" hidden>\n    <div class=\"tooltip tooltip--email\">\n        <button class=\"tooltip__button tooltip__button--email js-use-personal\">\n            <span class=\"tooltip__button--email__primary-text\">\n                Use <span class=\"js-address\">").concat((0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress)), "</span>\n            </span>\n            <span class=\"tooltip__button--email__secondary-text\">Blocks email trackers</span>\n        </button>\n        <button class=\"tooltip__button tooltip__button--email js-use-private\">\n            <span class=\"tooltip__button--email__primary-text\">Generate a Private Duck Address</span>\n            <span class=\"tooltip__button--email__secondary-text\">Blocks email trackers and hides your address</span>\n        </button>\n    </div>\n    <div class=\"tooltip--email__caret\"></div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\" hidden>\n    <div class=\"tooltip tooltip--email\">\n        <button class=\"tooltip__button tooltip__button--email js-use-personal\">\n            <span class=\"tooltip__button--email__primary-text\">\n                Use <span class=\"js-address\">").concat((0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress)), "</span>\n            </span>\n            <span class=\"tooltip__button--email__secondary-text\">Block email trackers</span>\n        </button>\n        <button class=\"tooltip__button tooltip__button--email js-use-private\">\n            <span class=\"tooltip__button--email__primary-text\">Generate a Private Duck Address</span>\n            <span class=\"tooltip__button--email__secondary-text\">Block email trackers & hide address</span>\n        </button>\n    </div>\n    <div class=\"tooltip--email__caret\"></div>\n</div>");
     this.wrapper = this.shadow.querySelector('.wrapper');
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4922,14 +4922,14 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Blocks email trackers'
+        title: 'Block email trackers'
       });
     }
 
     newIdentities.push({
       id: 'privateAddress',
       emailAddress: privateAddress,
-      title: 'Blocks email trackers and hides your address'
+      title: 'Block email trackers & hide address'
     });
     return [...identities, ...newIdentities];
   }
@@ -12375,7 +12375,7 @@ class EmailHTMLTooltip extends _HTMLTooltip.default {
   render(device) {
     this.device = device;
     this.addresses = device.getLocalAddresses();
-    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\" hidden>\n    <div class=\"tooltip tooltip--email\">\n        <button class=\"tooltip__button tooltip__button--email js-use-personal\">\n            <span class=\"tooltip__button--email__primary-text\">\n                Use <span class=\"js-address\">").concat((0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress)), "</span>\n            </span>\n            <span class=\"tooltip__button--email__secondary-text\">Blocks email trackers</span>\n        </button>\n        <button class=\"tooltip__button tooltip__button--email js-use-private\">\n            <span class=\"tooltip__button--email__primary-text\">Generate a Private Duck Address</span>\n            <span class=\"tooltip__button--email__secondary-text\">Blocks email trackers and hides your address</span>\n        </button>\n    </div>\n    <div class=\"tooltip--email__caret\"></div>\n</div>");
+    this.shadow.innerHTML = "\n".concat(this.options.css, "\n<div class=\"wrapper wrapper--email\" hidden>\n    <div class=\"tooltip tooltip--email\">\n        <button class=\"tooltip__button tooltip__button--email js-use-personal\">\n            <span class=\"tooltip__button--email__primary-text\">\n                Use <span class=\"js-address\">").concat((0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress)), "</span>\n            </span>\n            <span class=\"tooltip__button--email__secondary-text\">Block email trackers</span>\n        </button>\n        <button class=\"tooltip__button tooltip__button--email js-use-private\">\n            <span class=\"tooltip__button--email__primary-text\">Generate a Private Duck Address</span>\n            <span class=\"tooltip__button--email__secondary-text\">Block email trackers & hide address</span>\n        </button>\n    </div>\n    <div class=\"tooltip--email__caret\"></div>\n</div>");
     this.wrapper = this.shadow.querySelector('.wrapper');
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/0/1205067378042752/f

## Description
Update Email Protection copy to align with mobile copy

## Steps to test
1. Add to device of choice (extension or desktop app)
2. Log in to Email Protection - https://duckduckgo.com/email
3. Go to https://duckduckgo.com/newsletter
4. Review updated copy in autofill

### Chrome extension
<img width="630" alt="image" src="https://github.com/duckduckgo/duckduckgo-autofill/assets/635903/e8101fe0-aa98-4efb-ae40-1cab026f9c9f">

### macOS browser
![image](https://github.com/duckduckgo/duckduckgo-autofill/assets/635903/9c86b3cc-8d68-4e75-b74b-984cd4c6b2cb)
