### PR TITLE
Speed up tests and other perf improvements

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15323,6 +15323,8 @@ class DefaultScanner {
 
   /** @type {boolean} A flag to indicate the whole page will be re-scanned */
 
+  /** @type {boolean} Indicates whether we called stopScanning */
+
   /**
    * @param {import("./DeviceInterface/InterfacePrototype").default} device
    * @param {ScannerOptions} options
@@ -15339,6 +15341,8 @@ class DefaultScanner {
     _defineProperty(this, "activeInput", null);
 
     _defineProperty(this, "rescanAll", false);
+
+    _defineProperty(this, "stopped", false);
 
     _defineProperty(this, "mutObs", new MutationObserver(mutationList => {
       /** @type {HTMLElement[]} */
@@ -15476,6 +15480,8 @@ class DefaultScanner {
   stopScanner(reason) {
     var _this$device$activeFo;
 
+    this.stopped = true;
+
     if ((0, _autofillUtils.shouldLog)()) {
       for (var _len2 = arguments.length, rest = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
         rest[_key2 - 1] = arguments[_key2];
@@ -15487,6 +15493,7 @@ class DefaultScanner {
     const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
 
     clearTimeout(this.debounceTimer);
+    this.changedElements.clear();
     this.mutObs.disconnect();
     this.forms.forEach(form => {
       form.destroy();
@@ -15540,6 +15547,7 @@ class DefaultScanner {
 
 
   addInput(input) {
+    if (this.stopped) return;
     const parentForm = this.getParentForm(input);
     const seenFormElements = [...this.forms.keys()]; // Note that el.contains returns true for el itself
 

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -161,7 +161,7 @@ class Messaging {
   }
   /**
    * Send a 'fire-and-forget' message.
-   * @throws
+   * @throws {Error}
    * {@link MissingHandler}
    *
    * @example
@@ -181,7 +181,7 @@ class Messaging {
   }
   /**
    * Send a request, and wait for a response
-   * @throws
+   * @throws {Error}
    * {@link MissingHandler}
    *
    * @example
@@ -8147,15 +8147,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
     return null;
   }
 
-  removeAutofillUIFromPage() {
-    var _this$activeForm2;
-
-    super.removeAutofillUIFromPage();
-    (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.removeAllDecorations();
-  }
-
   async resetAutofillUI(callback) {
-    this.removeAutofillUIFromPage();
+    this.removeAutofillUIFromPage('Resetting autofill.');
     await this.setupAutofill();
     if (callback) await callback();
     this.uiController = this.createUIController();
@@ -8193,7 +8186,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
     switch (this.getActiveTooltipType()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
-          var _this$activeForm3;
+          var _this$activeForm2;
 
           this._scannerCleanup = this.scanner.init();
           this.addLogoutListener(() => {
@@ -8208,12 +8201,12 @@ class ExtensionInterface extends _InterfacePrototype.default {
             }
           });
 
-          if ((_this$activeForm3 = this.activeForm) !== null && _this$activeForm3 !== void 0 && _this$activeForm3.activeInput) {
-            var _this$activeForm4;
+          if ((_this$activeForm2 = this.activeForm) !== null && _this$activeForm2 !== void 0 && _this$activeForm2.activeInput) {
+            var _this$activeForm3;
 
             this.attachTooltip({
               form: this.activeForm,
-              input: (_this$activeForm4 = this.activeForm) === null || _this$activeForm4 === void 0 ? void 0 : _this$activeForm4.activeInput,
+              input: (_this$activeForm3 = this.activeForm) === null || _this$activeForm3 === void 0 ? void 0 : _this$activeForm3.activeInput,
               click: null,
               trigger: 'postSignup',
               triggerMetaData: {
@@ -8449,7 +8442,7 @@ class InterfacePrototype {
 
   /** @type {boolean} */
 
-  /** @type {(()=>void) | null} */
+  /** @type {((reason, ...rest) => void) | null} */
 
   /**
    * @param {GlobalConfig} config
@@ -8523,12 +8516,16 @@ class InterfacePrototype {
   createUIController() {
     return new _NativeUIController.NativeUIController();
   }
+  /**
+   * @param {string} reason
+   */
 
-  removeAutofillUIFromPage() {
+
+  removeAutofillUIFromPage(reason) {
     var _this$uiController, _this$_scannerCleanup;
 
     (_this$uiController = this.uiController) === null || _this$uiController === void 0 ? void 0 : _this$uiController.destroy();
-    (_this$_scannerCleanup = this._scannerCleanup) === null || _this$_scannerCleanup === void 0 ? void 0 : _this$_scannerCleanup.call(this);
+    (_this$_scannerCleanup = this._scannerCleanup) === null || _this$_scannerCleanup === void 0 ? void 0 : _this$_scannerCleanup.call(this, reason);
   }
 
   get hasLocalAddresses() {
@@ -8768,7 +8765,7 @@ class InterfacePrototype {
   postInit() {
     const cleanup = this.scanner.init();
     this.addLogoutListener(() => {
-      cleanup();
+      cleanup('Logged out');
 
       if (this.globalConfig.isDDGDomain) {
         (0, _autofillUtils.notifyWebApp)({
@@ -10220,6 +10217,10 @@ class Form {
     return this.formAnalyzer.isHybrid;
   }
 
+  get isCCForm() {
+    return this.formAnalyzer.isCCForm();
+  }
+
   logFormInfo() {
     if (!(0, _autofillUtils.shouldLog)()) return;
     console.log("Form type: %c".concat(this.getFormType()), 'font-weight: bold');
@@ -10476,6 +10477,7 @@ class Form {
   destroy() {
     this.removeAllDecorations();
     this.removeTooltip();
+    this.forgetAllInputs();
     this.mutObs.disconnect();
     this.matching.clear();
     this.intObs = null;
@@ -10578,6 +10580,7 @@ class Form {
     const opts = {
       isLogin: this.isLogin,
       isHybrid: this.isHybrid,
+      isCCForm: this.isCCForm,
       hasCredentials: Boolean((_this$device$settings = this.device.settings.availableInputTypes.credentials) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.username),
       supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
     };
@@ -11030,6 +11033,8 @@ class FormAnalyzer {
 
     _defineProperty(this, "matching", void 0);
 
+    _defineProperty(this, "_isCCForm", undefined);
+
     this.form = form;
     this.matching = matching || new _matching.Matching(_matchingConfiguration.matchingConfiguration);
     /**
@@ -11307,6 +11312,52 @@ class FormAnalyzer {
     }
 
     return this;
+  }
+  /** @type {undefined|boolean} */
+
+
+  /**
+   * Tries to infer if it's a credit card form
+   * @returns {boolean}
+   */
+  isCCForm() {
+    var _formEl$textContent;
+
+    const formEl = this.form;
+    if (this._isCCForm !== undefined) return this._isCCForm;
+    const ccFieldSelector = this.matching.joinCssSelectors('cc');
+
+    if (!ccFieldSelector) {
+      this._isCCForm = false;
+      return this._isCCForm;
+    }
+
+    const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
+
+    if (hasCCSelectorChild) {
+      this._isCCForm = true;
+      return this._isCCForm;
+    } // Read form attributes to find a signal
+
+
+    const hasCCAttribute = [...formEl.attributes].some(_ref3 => {
+      let {
+        name,
+        value
+      } = _ref3;
+      return /(credit|payment).?card/i.test("".concat(name, "=").concat(value));
+    });
+
+    if (hasCCAttribute) {
+      this._isCCForm = true;
+      return this._isCCForm;
+    } // Match form textContent against common cc fields (includes hidden labels)
+
+
+    const textMatches = (_formEl$textContent = formEl.textContent) === null || _formEl$textContent === void 0 ? void 0 : _formEl$textContent.match(/(credit|payment).?card(.?number)?|ccv|security.?code|cvv|cvc|csc/ig); // We check for more than one to minimise false positives
+
+    this._isCCForm = Boolean(textMatches && textMatches.length > 1);
+    return this._isCCForm;
   }
 
 }
@@ -13755,7 +13806,7 @@ class Matching {
     this.setActiveElementStrings(input, formEl); // // For CC forms we run aggressive matches, so we want to make sure we only
     // // run them on actual CC forms to avoid false positives and expensive loops
 
-    if (this.isCCForm(formEl)) {
+    if (opts.isCCForm) {
       const subtype = this.subtypeFromMatchers('cc', input);
 
       if (subtype && isValidCreditCardSubtype(subtype)) {
@@ -13806,6 +13857,7 @@ class Matching {
    * @typedef {{
    *   isLogin?: boolean,
    *   isHybrid?: boolean,
+   *   isCCForm?: boolean,
    *   hasCredentials?: boolean,
    *   supportsIdentitiesAutofill?: boolean
    * }} SetInputTypeOpts
@@ -14138,39 +14190,6 @@ class Matching {
   forInput(input, form) {
     this.setActiveElementStrings(input, form);
     return this;
-  }
-  /**
-   * Tries to infer if it's a credit card form
-   * @param {HTMLElement} formEl
-   * @returns {boolean}
-   */
-
-
-  isCCForm(formEl) {
-    var _formEl$textContent;
-
-    const ccFieldSelector = this.joinCssSelectors('cc');
-
-    if (!ccFieldSelector) {
-      return false;
-    }
-
-    const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
-
-    if (hasCCSelectorChild) return true; // Read form attributes to find a signal
-
-    const hasCCAttribute = [...formEl.attributes].some(_ref => {
-      let {
-        name,
-        value
-      } = _ref;
-      return /(credit|payment).?card/i.test("".concat(name, "=").concat(value));
-    });
-    if (hasCCAttribute) return true; // Match form textContent against common cc fields (includes hidden labels)
-
-    const textMatches = (_formEl$textContent = formEl.textContent) === null || _formEl$textContent === void 0 ? void 0 : _formEl$textContent.match(/(credit|payment).?card(.?number)?|ccv|security.?code|cvv|cvc|csc/ig); // We check for more than one to minimise false positives
-
-    return Boolean(textMatches && textMatches.length > 1);
   }
   /**
    * @type {MatchingConfiguration}
@@ -14780,7 +14799,7 @@ class InContextSignup {
     };
 
     if (options.shouldHideTooltip) {
-      this.device.removeAutofillUIFromPage();
+      this.device.removeAutofillUIFromPage('Email Protection in-context signup dismissed.');
       this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
     }
 
@@ -15251,7 +15270,7 @@ const {
 /**
  * @typedef {{
  *     forms: Map<HTMLElement, import("./Form/Form").Form>;
- *     init(): ()=> void;
+ *     init(): (reason, ...rest)=> void;
  *     enqueue(elements: (HTMLElement|Document)[]): void;
  *     findEligibleInputs(context): Scanner;
  *     options: ScannerOptions;
@@ -15365,11 +15384,13 @@ class DefaultScanner {
    * Call this to scan once and then watch for changes.
    *
    * Call the returned function to remove listeners.
-   * @returns {() => void}
+   * @returns {(reason: string, ...rest) => void}
    */
 
 
   init() {
+    var _this = this;
+
     if (this.device.globalConfig.isExtension) {
       this.device.deviceApi.notify(new _deviceApiCalls.AddDebugFlagCall({
         flag: 'autofill'
@@ -15385,20 +15406,12 @@ class DefaultScanner {
       setTimeout(() => this.scanAndObserve(), delay);
     }
 
-    return () => {
-      var _this$device$activeFo;
+    return function (reason) {
+      for (var _len = arguments.length, rest = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        rest[_key - 1] = arguments[_key];
+      }
 
-      const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
-
-      clearTimeout(this.debounceTimer);
-      this.mutObs.disconnect();
-      this.forms.forEach(form => {
-        form.resetAllInputs();
-        form.removeAllDecorations();
-      });
-      this.forms.clear(); // Bring the user back to the input they were interacting with
-
-      activeInput === null || activeInput === void 0 ? void 0 : activeInput.focus();
+      _this.stopScanner(reason, ...rest);
     };
   }
   /**
@@ -15436,6 +15449,7 @@ class DefaultScanner {
       const inputs = context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR);
 
       if (inputs.length > this.options.maxInputsPerPage) {
+        this.stopScanner('Too many input fields in the given context, stop scanning', context);
         return this;
       }
 
@@ -15443,6 +15457,35 @@ class DefaultScanner {
     }
 
     return this;
+  }
+  /**
+   * Stops scanning, switches off the mutation observer and clears all forms
+   * @param {string} reason
+   * @param {...any} rest
+   */
+
+
+  stopScanner(reason) {
+    var _this$device$activeFo;
+
+    if ((0, _autofillUtils.shouldLog)()) {
+      for (var _len2 = arguments.length, rest = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+        rest[_key2 - 1] = arguments[_key2];
+      }
+
+      console.log(reason, ...rest);
+    }
+
+    const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
+
+    clearTimeout(this.debounceTimer);
+    this.mutObs.disconnect();
+    this.forms.forEach(form => {
+      form.destroy();
+    });
+    this.forms.clear(); // Bring the user back to the input they were interacting with
+
+    activeInput === null || activeInput === void 0 ? void 0 : activeInput.focus();
   }
   /**
    * @param {HTMLElement|HTMLInputElement|HTMLSelectElement} input
@@ -15489,9 +15532,10 @@ class DefaultScanner {
 
 
   addInput(input) {
-    const parentForm = this.getParentForm(input); // Note that el.contains returns true for el itself
+    const parentForm = this.getParentForm(input);
+    const seenFormElements = [...this.forms.keys()]; // Note that el.contains returns true for el itself
 
-    const previouslyFoundParent = [...this.forms.keys()].find(form => form.contains(parentForm));
+    const previouslyFoundParent = seenFormElements.find(form => form.contains(parentForm));
 
     if (previouslyFoundParent) {
       if (parentForm instanceof HTMLFormElement && parentForm !== previouslyFoundParent) {
@@ -15505,7 +15549,7 @@ class DefaultScanner {
       }
     } else {
       // if this form is an ancestor of an existing form, remove that before adding this
-      const childForm = [...this.forms.keys()].find(form => parentForm.contains(form));
+      const childForm = seenFormElements.find(form => parentForm.contains(form));
 
       if (childForm) {
         var _this$forms$get2;
@@ -15518,9 +15562,7 @@ class DefaultScanner {
       if (this.forms.size < this.options.maxFormsPerPage) {
         this.forms.set(parentForm, new _Form.Form(parentForm, input, this.device, this.matching, this.shouldAutoprompt));
       } else {
-        if ((0, _autofillUtils.shouldLog)()) {
-          console.log('The page has too many forms, stop adding them.');
-        }
+        this.stopScanner('The page has too many forms, stop adding them.');
       }
     }
   }
@@ -18164,7 +18206,15 @@ const getText = el => {
     return (0, _matching.removeExcessWhitespace)(el.alt || el.value || el.title || el.name);
   }
 
-  return (0, _matching.removeExcessWhitespace)(Array.from(el.childNodes).reduce((text, child) => child instanceof Text ? text + ' ' + child.textContent : text, ''));
+  let text = '';
+
+  for (const childNode of el.childNodes) {
+    if (childNode instanceof Text) {
+      text += ' ' + childNode.textContent;
+    }
+  }
+
+  return (0, _matching.removeExcessWhitespace)(text);
 };
 /**
  * Check if hostname is a local address
@@ -18299,9 +18349,8 @@ var _autofillUtils = require("./autofill-utils.js");
 (() => {
   if ((0, _autofillUtils.shouldLog)()) {
     console.log('DuckDuckGo Autofill Active');
-  }
+  } // if (!window.isSecureContext) return false
 
-  if (!window.isSecureContext) return false;
 
   try {
     const startupAutofill = () => {

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -14359,7 +14359,8 @@ function getInputSubtype(input) {
 
 const removeExcessWhitespace = function () {
   let string = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-  return (string || '').replace(/\n/g, ' ').replace(/\s{2,}/g, ' ').trim();
+  if (!string) return '';
+  return string.replace(/\n/g, ' ').replace(/\s{2,}/g, ' ').trim();
 };
 /**
  * Get text from all explicit labels
@@ -15426,17 +15427,10 @@ class DefaultScanner {
   scanAndObserve() {
     var _window$performance, _window$performance$m, _window$performance2, _window$performance2$;
 
-    (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : (_window$performance$m = _window$performance.mark) === null || _window$performance$m === void 0 ? void 0 : _window$performance$m.call(_window$performance, 'scanner:init:start');
+    (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : (_window$performance$m = _window$performance.mark) === null || _window$performance$m === void 0 ? void 0 : _window$performance$m.call(_window$performance, 'initial_scanner:init:start');
     this.findEligibleInputs(document);
-    (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : (_window$performance2$ = _window$performance2.mark) === null || _window$performance2$ === void 0 ? void 0 : _window$performance2$.call(_window$performance2, 'scanner:init:end');
-
-    if ((0, _autofillUtils.shouldLogPerformance)()) {
-      var _window$performance3;
-
-      const measurement = (_window$performance3 = window.performance) === null || _window$performance3 === void 0 ? void 0 : _window$performance3.measure('scanner:init', 'scanner:init:start', 'scanner:init:end');
-      console.log("Initial scan took ".concat(Math.round(measurement === null || measurement === void 0 ? void 0 : measurement.duration), "ms"));
-    }
-
+    (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : (_window$performance2$ = _window$performance2.mark) === null || _window$performance2$ === void 0 ? void 0 : _window$performance2$.call(_window$performance2, 'initial_scanner:init:end');
+    (0, _autofillUtils.logPerformance)('initial_scanner');
     this.mutObs.observe(document.documentElement, {
       childList: true,
       subtree: true
@@ -15510,10 +15504,13 @@ class DefaultScanner {
 
   getParentForm(input) {
     if (input instanceof HTMLInputElement || input instanceof HTMLSelectElement) {
-      // Use input.form unless it encloses most of the DOM
-      // In that case we proceed to identify more precise wrappers
-      if (input.form && !(0, _autofillUtils.isFormLikelyToBeUsedAsPageWrapper)(input.form)) {
-        return input.form;
+      if (input.form) {
+        // Use input.form unless it encloses most of the DOM
+        // In that case we proceed to identify more precise wrappers
+        if (this.forms.has(input.form) || // If we've added the form we've already checked that it's not a page wrapper
+        !(0, _autofillUtils.isFormLikelyToBeUsedAsPageWrapper)(input.form)) {
+          return input.form;
+        }
       }
     }
 
@@ -15549,28 +15546,53 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    const seenFormElements = [...this.forms.keys()]; // Note that el.contains returns true for el itself
 
-    const previouslyFoundParent = seenFormElements.find(form => form.contains(parentForm));
+    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+      var _this$forms$get;
+
+      // We've met the form, add the input
+      (_this$forms$get = this.forms.get(parentForm)) === null || _this$forms$get === void 0 ? void 0 : _this$forms$get.addInput(input);
+      return;
+    } // Check if the forms we've seen are either disconnected,
+    // or are parent/child of the currently-found form
+
+
+    let previouslyFoundParent, childForm;
+
+    for (const [formEl] of this.forms) {
+      // Remove disconnected forms to avoid leaks
+      if (!formEl.isConnected) {
+        this.forms.delete(formEl);
+        continue;
+      }
+
+      if (formEl.contains(parentForm)) {
+        previouslyFoundParent = formEl;
+        break;
+      }
+
+      if (parentForm.contains(formEl)) {
+        childForm = formEl;
+        break;
+      }
+    }
 
     if (previouslyFoundParent) {
       if (parentForm instanceof HTMLFormElement && parentForm !== previouslyFoundParent) {
         // If we had a prior parent but this is an explicit form, the previous was a false positive
         this.forms.delete(previouslyFoundParent);
       } else {
-        var _this$forms$get;
+        var _this$forms$get2;
 
         // If we've already met the form or a descendant, add the input
-        (_this$forms$get = this.forms.get(previouslyFoundParent)) === null || _this$forms$get === void 0 ? void 0 : _this$forms$get.addInput(input);
+        (_this$forms$get2 = this.forms.get(previouslyFoundParent)) === null || _this$forms$get2 === void 0 ? void 0 : _this$forms$get2.addInput(input);
       }
     } else {
       // if this form is an ancestor of an existing form, remove that before adding this
-      const childForm = seenFormElements.find(form => parentForm.contains(form));
-
       if (childForm) {
-        var _this$forms$get2;
+        var _this$forms$get3;
 
-        (_this$forms$get2 = this.forms.get(childForm)) === null || _this$forms$get2 === void 0 ? void 0 : _this$forms$get2.destroy();
+        (_this$forms$get3 = this.forms.get(childForm)) === null || _this$forms$get3 === void 0 ? void 0 : _this$forms$get3.destroy();
         this.forms.delete(childForm);
       } // Only add the form if below the limit of forms per page
 
@@ -15604,9 +15626,14 @@ class DefaultScanner {
 
     clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => {
+      var _window$performance3, _window$performance3$, _window$performance4, _window$performance4$;
+
+      (_window$performance3 = window.performance) === null || _window$performance3 === void 0 ? void 0 : (_window$performance3$ = _window$performance3.mark) === null || _window$performance3$ === void 0 ? void 0 : _window$performance3$.call(_window$performance3, 'scanner:init:start');
       this.processChangedElements();
       this.changedElements.clear();
       this.rescanAll = false;
+      (_window$performance4 = window.performance) === null || _window$performance4 === void 0 ? void 0 : (_window$performance4$ = _window$performance4.mark) === null || _window$performance4$ === void 0 ? void 0 : _window$performance4$.call(_window$performance4, 'scanner:init:end');
+      (0, _autofillUtils.logPerformance)('scanner');
     }, this.options.debounceTimePeriod);
   }
   /**
@@ -17784,6 +17811,7 @@ exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedCon
 exports.isLocalNetwork = isLocalNetwork;
 exports.isPotentiallyViewable = void 0;
 exports.isValidTLD = isValidTLD;
+exports.logPerformance = logPerformance;
 exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = void 0;
 exports.shouldLog = shouldLog;
 exports.shouldLogPerformance = shouldLogPerformance;
@@ -18204,23 +18232,28 @@ const buttonMatchesFormType = (el, formObj) => {
     return true;
   }
 };
+
+exports.buttonMatchesFormType = buttonMatchesFormType;
+const buttonInputTypes = ['submit', 'button'];
 /**
  * Get the text of an element
  * @param {Element} el
  * @returns {string}
  */
 
-
-exports.buttonMatchesFormType = buttonMatchesFormType;
-
 const getText = el => {
   // for buttons, we don't care about descendants, just get the whole text as is
   // this is important in order to give proper attribution of the text to the button
   if (el instanceof HTMLButtonElement) return (0, _matching.removeExcessWhitespace)(el.textContent);
-  if (el instanceof HTMLInputElement && ['submit', 'button'].includes(el.type)) return el.value;
 
-  if (el instanceof HTMLInputElement && el.type === 'image') {
-    return (0, _matching.removeExcessWhitespace)(el.alt || el.value || el.title || el.name);
+  if (el instanceof HTMLInputElement) {
+    if (buttonInputTypes.includes(el.type)) {
+      return el.value;
+    }
+
+    if (el.type === 'image') {
+      return (0, _matching.removeExcessWhitespace)(el.alt || el.value || el.title || el.name);
+    }
   }
 
   let text = '';
@@ -18309,6 +18342,16 @@ function readDebugSetting(setting) {
     return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem(setting)) === 'true';
   } catch (e) {
     return false;
+  }
+}
+
+function logPerformance(markName) {
+  if (shouldLogPerformance()) {
+    var _window$performance, _window$performance2;
+
+    const measurement = (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : _window$performance.measure("".concat(markName, ":init"), "".concat(markName, ":init:start"), "".concat(markName, ":init:end"));
+    console.log("".concat(markName, " took ").concat(Math.round(measurement === null || measurement === void 0 ? void 0 : measurement.duration), "ms"));
+    (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : _window$performance2.clearMarks();
   }
 }
 /**

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -11323,8 +11323,8 @@ class FormAnalyzer {
   isCCForm() {
     var _formEl$textContent;
 
-    const formEl = this.form;
     if (this._isCCForm !== undefined) return this._isCCForm;
+    const formEl = this.form;
     const ccFieldSelector = this.matching.joinCssSelectors('cc');
 
     if (!ccFieldSelector) {

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15425,6 +15425,14 @@ class DefaultScanner {
     (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : (_window$performance$m = _window$performance.mark) === null || _window$performance$m === void 0 ? void 0 : _window$performance$m.call(_window$performance, 'scanner:init:start');
     this.findEligibleInputs(document);
     (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : (_window$performance2$ = _window$performance2.mark) === null || _window$performance2$ === void 0 ? void 0 : _window$performance2$.call(_window$performance2, 'scanner:init:end');
+
+    if ((0, _autofillUtils.shouldLogPerformance)()) {
+      var _window$performance3;
+
+      const measurement = (_window$performance3 = window.performance) === null || _window$performance3 === void 0 ? void 0 : _window$performance3.measure('scanner:init', 'scanner:init:start', 'scanner:init:end');
+      console.log("Initial scan took ".concat(Math.round(measurement === null || measurement === void 0 ? void 0 : measurement.duration), "ms"));
+    }
+
     this.mutObs.observe(document.documentElement, {
       childList: true,
       subtree: true
@@ -17770,6 +17778,7 @@ exports.isPotentiallyViewable = void 0;
 exports.isValidTLD = isValidTLD;
 exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = void 0;
 exports.shouldLog = shouldLog;
+exports.shouldLogPerformance = shouldLogPerformance;
 exports.truncateFromMiddle = truncateFromMiddle;
 exports.wasAutofilledByChrome = void 0;
 exports.whenIdle = whenIdle;
@@ -18258,7 +18267,7 @@ const wasAutofilledByChrome = input => {
   }
 };
 /**
- * Checks if we should log debug info to the console
+ * Checks if we should log form analysis debug info to the console
  * @returns {boolean}
  */
 
@@ -18266,11 +18275,30 @@ const wasAutofilledByChrome = input => {
 exports.wasAutofilledByChrome = wasAutofilledByChrome;
 
 function shouldLog() {
+  return readDebugSetting('ddg-autofill-debug');
+}
+/**
+ * Checks if we should log performance info to the console
+ * @returns {boolean}
+ */
+
+
+function shouldLogPerformance() {
+  return readDebugSetting('ddg-autofill-perf');
+}
+/**
+ * Check if a sessionStorage item is set to 'true'
+ * @param setting
+ * @returns {boolean}
+ */
+
+
+function readDebugSetting(setting) {
   // sessionStorage throws in invalid schemes like data: and file:
   try {
     var _window$sessionStorag;
 
-    return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem('ddg-autofill-debug')) === 'true';
+    return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem(setting)) === 'true';
   } catch (e) {
     return false;
   }

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -161,7 +161,7 @@ class Messaging {
   }
   /**
    * Send a 'fire-and-forget' message.
-   * @throws {Error}
+   * @throws
    * {@link MissingHandler}
    *
    * @example
@@ -181,7 +181,7 @@ class Messaging {
   }
   /**
    * Send a request, and wait for a response
-   * @throws {Error}
+   * @throws
    * {@link MissingHandler}
    *
    * @example
@@ -18349,8 +18349,9 @@ var _autofillUtils = require("./autofill-utils.js");
 (() => {
   if ((0, _autofillUtils.shouldLog)()) {
     console.log('DuckDuckGo Autofill Active');
-  } // if (!window.isSecureContext) return false
+  }
 
+  if (!window.isSecureContext) return false;
 
   try {
     const startupAutofill = () => {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -161,7 +161,7 @@ class Messaging {
   }
   /**
    * Send a 'fire-and-forget' message.
-   * @throws {Error}
+   * @throws
    * {@link MissingHandler}
    *
    * @example
@@ -181,7 +181,7 @@ class Messaging {
   }
   /**
    * Send a request, and wait for a response
-   * @throws {Error}
+   * @throws
    * {@link MissingHandler}
    *
    * @example
@@ -14673,8 +14673,9 @@ var _autofillUtils = require("./autofill-utils.js");
 (() => {
   if ((0, _autofillUtils.shouldLog)()) {
     console.log('DuckDuckGo Autofill Active');
-  } // if (!window.isSecureContext) return false
+  }
 
+  if (!window.isSecureContext) return false;
 
   try {
     const startupAutofill = () => {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -11749,6 +11749,14 @@ class DefaultScanner {
     (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : (_window$performance$m = _window$performance.mark) === null || _window$performance$m === void 0 ? void 0 : _window$performance$m.call(_window$performance, 'scanner:init:start');
     this.findEligibleInputs(document);
     (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : (_window$performance2$ = _window$performance2.mark) === null || _window$performance2$ === void 0 ? void 0 : _window$performance2$.call(_window$performance2, 'scanner:init:end');
+
+    if ((0, _autofillUtils.shouldLogPerformance)()) {
+      var _window$performance3;
+
+      const measurement = (_window$performance3 = window.performance) === null || _window$performance3 === void 0 ? void 0 : _window$performance3.measure('scanner:init', 'scanner:init:start', 'scanner:init:end');
+      console.log("Initial scan took ".concat(Math.round(measurement === null || measurement === void 0 ? void 0 : measurement.duration), "ms"));
+    }
+
     this.mutObs.observe(document.documentElement, {
       childList: true,
       subtree: true
@@ -14094,6 +14102,7 @@ exports.isPotentiallyViewable = void 0;
 exports.isValidTLD = isValidTLD;
 exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = void 0;
 exports.shouldLog = shouldLog;
+exports.shouldLogPerformance = shouldLogPerformance;
 exports.truncateFromMiddle = truncateFromMiddle;
 exports.wasAutofilledByChrome = void 0;
 exports.whenIdle = whenIdle;
@@ -14582,7 +14591,7 @@ const wasAutofilledByChrome = input => {
   }
 };
 /**
- * Checks if we should log debug info to the console
+ * Checks if we should log form analysis debug info to the console
  * @returns {boolean}
  */
 
@@ -14590,11 +14599,30 @@ const wasAutofilledByChrome = input => {
 exports.wasAutofilledByChrome = wasAutofilledByChrome;
 
 function shouldLog() {
+  return readDebugSetting('ddg-autofill-debug');
+}
+/**
+ * Checks if we should log performance info to the console
+ * @returns {boolean}
+ */
+
+
+function shouldLogPerformance() {
+  return readDebugSetting('ddg-autofill-perf');
+}
+/**
+ * Check if a sessionStorage item is set to 'true'
+ * @param setting
+ * @returns {boolean}
+ */
+
+
+function readDebugSetting(setting) {
   // sessionStorage throws in invalid schemes like data: and file:
   try {
     var _window$sessionStorag;
 
-    return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem('ddg-autofill-debug')) === 'true';
+    return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem(setting)) === 'true';
   } catch (e) {
     return false;
   }

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -11647,6 +11647,8 @@ class DefaultScanner {
 
   /** @type {boolean} A flag to indicate the whole page will be re-scanned */
 
+  /** @type {boolean} Indicates whether we called stopScanning */
+
   /**
    * @param {import("./DeviceInterface/InterfacePrototype").default} device
    * @param {ScannerOptions} options
@@ -11663,6 +11665,8 @@ class DefaultScanner {
     _defineProperty(this, "activeInput", null);
 
     _defineProperty(this, "rescanAll", false);
+
+    _defineProperty(this, "stopped", false);
 
     _defineProperty(this, "mutObs", new MutationObserver(mutationList => {
       /** @type {HTMLElement[]} */
@@ -11800,6 +11804,8 @@ class DefaultScanner {
   stopScanner(reason) {
     var _this$device$activeFo;
 
+    this.stopped = true;
+
     if ((0, _autofillUtils.shouldLog)()) {
       for (var _len2 = arguments.length, rest = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
         rest[_key2 - 1] = arguments[_key2];
@@ -11811,6 +11817,7 @@ class DefaultScanner {
     const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
 
     clearTimeout(this.debounceTimer);
+    this.changedElements.clear();
     this.mutObs.disconnect();
     this.forms.forEach(form => {
       form.destroy();
@@ -11864,6 +11871,7 @@ class DefaultScanner {
 
 
   addInput(input) {
+    if (this.stopped) return;
     const parentForm = this.getParentForm(input);
     const seenFormElements = [...this.forms.keys()]; // Note that el.contains returns true for el itself
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -7647,8 +7647,8 @@ class FormAnalyzer {
   isCCForm() {
     var _formEl$textContent;
 
-    const formEl = this.form;
     if (this._isCCForm !== undefined) return this._isCCForm;
+    const formEl = this.form;
     const ccFieldSelector = this.matching.joinCssSelectors('cc');
 
     if (!ccFieldSelector) {

--- a/docs/runtime.windows.md
+++ b/docs/runtime.windows.md
@@ -1,6 +1,6 @@
 ## Links 
 
-- [Privacy Test Pages, Form Submissions](https://privacy-test-pages.glitch.me/autofill/form-submission.html)
+- [Privacy Test Pages, Form Submissions](https://privacy-test-pages.site/autofill/form-submission.html)
 
 ## `getRuntimeConfiguration()`
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
     testEnvironment: './jest-test-environment.js',
 
     // Indicates whether each individual test should be reported during the run
-    verbose: true,
+    verbose: false,
 
     // ensure snapshots are in a JSON format
     snapshotFormat: {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -111,3 +111,18 @@ Object.defineProperty(window.HTMLElement.prototype, 'offsetHeight', {
         return this._jsdomMockOffsetHeight || 0
     }
 })
+
+// getComputedStyle is super slow on jsdom, by providing this mock we speed tests up significantly
+const defaultStyle = {
+    display: 'block',
+    visibility: 'visible',
+    opacity: '1',
+    paddingRight: '10'
+}
+const mockGetComputedStyle = (el) => {
+    return {
+        getPropertyValue: (prop) => el.style?.[prop] || defaultStyle[prop]
+    }
+}
+// @ts-ignore
+jest.spyOn(window, 'getComputedStyle').mockImplementation(mockGetComputedStyle)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -121,6 +121,7 @@ const defaultStyle = {
 }
 const mockGetComputedStyle = (el) => {
     return {
+        // since we don't load stylesheets in the tests, the style prop is all the css applied, so it's a safe fallback
         getPropertyValue: (prop) => el.style?.[prop] || defaultStyle[prop]
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "copy-assets": "node scripts/copy-assets.js",
-    "open-test-extension": "npx web-ext run -t chromium -u https://privacy-test-pages.glitch.me/ -s integration-test/extension",
+    "open-test-extension": "npx web-ext run -t chromium -u https://privacy-test-pages.site/ -s integration-test/extension",
     "schema:generate": "node scripts/api-call-generator.js",
     "test": "npm run test:unit && npm run lint && tsc",
     "test:clean-tree": "npm run build && sh scripts/check-for-changes.sh",

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -57,13 +57,8 @@ class ExtensionInterface extends InterfacePrototype {
         return null
     }
 
-    removeAutofillUIFromPage () {
-        super.removeAutofillUIFromPage()
-        this.activeForm?.removeAllDecorations()
-    }
-
     async resetAutofillUI (callback) {
-        this.removeAutofillUIFromPage()
+        this.removeAutofillUIFromPage('Resetting autofill.')
 
         await this.setupAutofill()
 

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -73,7 +73,7 @@ class InterfacePrototype {
     /** @type {boolean} */
     isInitializationStarted;
 
-    /** @type {(()=>void) | null} */
+    /** @type {((reason, ...rest) => void) | null} */
     _scannerCleanup = null
 
     /**
@@ -102,9 +102,12 @@ class InterfacePrototype {
         return new NativeUIController()
     }
 
-    removeAutofillUIFromPage () {
+    /**
+     * @param {string} reason
+     */
+    removeAutofillUIFromPage (reason) {
         this.uiController?.destroy()
-        this._scannerCleanup?.()
+        this._scannerCleanup?.(reason)
     }
 
     get hasLocalAddresses () {
@@ -332,7 +335,7 @@ class InterfacePrototype {
     postInit () {
         const cleanup = this.scanner.init()
         this.addLogoutListener(() => {
-            cleanup()
+            cleanup('Logged out')
             if (this.globalConfig.isDDGDomain) {
                 notifyWebApp({ deviceSignedIn: {value: false} })
             }

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -128,6 +128,9 @@ class Form {
     get isHybrid () {
         return this.formAnalyzer.isHybrid
     }
+    get isCCForm () {
+        return this.formAnalyzer.isCCForm()
+    }
 
     logFormInfo () {
         if (!shouldLog()) return
@@ -451,6 +454,7 @@ class Form {
         const opts = {
             isLogin: this.isLogin,
             isHybrid: this.isHybrid,
+            isCCForm: this.isCCForm,
             hasCredentials: Boolean(this.device.settings.availableInputTypes.credentials?.username),
             supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
         }

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -355,6 +355,7 @@ class Form {
     destroy () {
         this.removeAllDecorations()
         this.removeTooltip()
+        this.forgetAllInputs()
         this.mutObs.disconnect()
         this.matching.clear()
         this.intObs = null

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -285,9 +285,9 @@ class FormAnalyzer {
      * @returns {boolean}
      */
     isCCForm () {
-        const formEl = this.form
         if (this._isCCForm !== undefined) return this._isCCForm
 
+        const formEl = this.form
         const ccFieldSelector = this.matching.joinCssSelectors('cc')
         if (!ccFieldSelector) {
             this._isCCForm = false

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -277,6 +277,45 @@ class FormAnalyzer {
         }
         return this
     }
+
+    /** @type {undefined|boolean} */
+    _isCCForm = undefined
+    /**
+     * Tries to infer if it's a credit card form
+     * @returns {boolean}
+     */
+    isCCForm () {
+        const formEl = this.form
+        if (this._isCCForm !== undefined) return this._isCCForm
+
+        const ccFieldSelector = this.matching.joinCssSelectors('cc')
+        if (!ccFieldSelector) {
+            this._isCCForm = false
+            return this._isCCForm
+        }
+        const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector)
+        // If the form contains one of the specific selectors, we have high confidence
+        if (hasCCSelectorChild) {
+            this._isCCForm = true
+            return this._isCCForm
+        }
+
+        // Read form attributes to find a signal
+        const hasCCAttribute = [...formEl.attributes].some(({name, value}) =>
+            /(credit|payment).?card/i.test(`${name}=${value}`)
+        )
+        if (hasCCAttribute) {
+            this._isCCForm = true
+            return this._isCCForm
+        }
+
+        // Match form textContent against common cc fields (includes hidden labels)
+        const textMatches = formEl.textContent?.match(/(credit|payment).?card(.?number)?|ccv|security.?code|cvv|cvc|csc/ig)
+
+        // We check for more than one to minimise false positives
+        this._isCCForm = Boolean(textMatches && textMatches.length > 1)
+        return this._isCCForm
+    }
 }
 
 export default FormAnalyzer

--- a/src/Form/input-classifiers.test.js
+++ b/src/Form/input-classifiers.test.js
@@ -13,6 +13,9 @@ import {createAvailableInputTypes} from '../../integration-test/helpers/utils.js
  * @type {object[]}
  */
 const testCases = JSON.parse(fs.readFileSync(path.join(__dirname, 'test-cases/index.json')).toString('utf-8'))
+testCases.forEach(testCase => {
+    testCase.testContent = fs.readFileSync(path.resolve(__dirname, './test-cases', testCase.html), 'utf-8')
+})
 
 /**
  * @param {HTMLInputElement} el
@@ -147,15 +150,16 @@ describe.each(testCases)('Test $html fields', (testCase) => {
         expectedSubmitFalsePositives = 0,
         expectedSubmitFalseNegatives = 0,
         title = '__test__',
-        hasExtraWrappers = true
+        hasExtraWrappers = true,
+        testContent
     } = testCase
 
     const testTextString = expectedFailures.length > 0
         ? `should contain ${expectedFailures.length} known failure(s): ${JSON.stringify(expectedFailures)}`
         : `should NOT contain failures`
 
-    it(testTextString, () => {
-        const testContent = fs.readFileSync(path.resolve(__dirname, './test-cases', html), 'utf-8')
+    it.concurrent(testTextString, async () => {
+        document.body.innerHTML = ''
 
         let baseWrapper = document.body
 

--- a/src/Form/matching.js
+++ b/src/Form/matching.js
@@ -734,7 +734,9 @@ function getInputSubtype (input) {
  * @return {string}
  */
 const removeExcessWhitespace = (string = '') => {
-    return (string || '')
+    if (!string) return ''
+
+    return (string)
         .replace(/\n/g, ' ')
         .replace(/\s{2,}/g, ' ').trim()
 }

--- a/src/Form/matching.js
+++ b/src/Form/matching.js
@@ -223,7 +223,7 @@ class Matching {
 
         // // For CC forms we run aggressive matches, so we want to make sure we only
         // // run them on actual CC forms to avoid false positives and expensive loops
-        if (this.isCCForm(formEl)) {
+        if (opts.isCCForm) {
             const subtype = this.subtypeFromMatchers('cc', input)
             if (subtype && isValidCreditCardSubtype(subtype)) {
                 return `creditCards.${subtype}`
@@ -278,6 +278,7 @@ class Matching {
      * @typedef {{
      *   isLogin?: boolean,
      *   isHybrid?: boolean,
+     *   isCCForm?: boolean,
      *   hasCredentials?: boolean,
      *   supportsIdentitiesAutofill?: boolean
      * }} SetInputTypeOpts
@@ -558,32 +559,6 @@ class Matching {
     forInput (input, form) {
         this.setActiveElementStrings(input, form)
         return this
-    }
-    /**
-     * Tries to infer if it's a credit card form
-     * @param {HTMLElement} formEl
-     * @returns {boolean}
-     */
-    isCCForm (formEl) {
-        const ccFieldSelector = this.joinCssSelectors('cc')
-        if (!ccFieldSelector) {
-            return false
-        }
-        const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector)
-        // If the form contains one of the specific selectors, we have high confidence
-        if (hasCCSelectorChild) return true
-
-        // Read form attributes to find a signal
-        const hasCCAttribute = [...formEl.attributes].some(({name, value}) =>
-            /(credit|payment).?card/i.test(`${name}=${value}`)
-        )
-        if (hasCCAttribute) return true
-
-        // Match form textContent against common cc fields (includes hidden labels)
-        const textMatches = formEl.textContent?.match(/(credit|payment).?card(.?number)?|ccv|security.?code|cvv|cvc|csc/ig)
-
-        // We check for more than one to minimise false positives
-        return Boolean(textMatches && textMatches.length > 1)
     }
 
     /**

--- a/src/Form/matching.test.js
+++ b/src/Form/matching.test.js
@@ -92,9 +92,21 @@ describe('matching', () => {
         { html: `<input placeholder="captcha-password" />`, subtype: 'unknown' },
         { html: `<input placeholder="username" />`, subtype: 'credentials.username' },
         { html: `<input name="username-search" />`, subtype: 'unknown' },
-        { html: `<input name="cc-name" />`, subtype: 'creditCards.cardName' },
-        { html: `<input name="accountholdername" /><!-- second input is to trigger cc type --><input name="cc-number"/>`, subtype: 'creditCards.cardName' },
-        { html: `<input name="Срок действия карты" /><!-- second input is to trigger cc type --><input name="cc-number"/>`, subtype: 'creditCards.expirationMonth' },
+        {
+            html: `<input name="cc-name" />`,
+            subtype: 'creditCards.cardName',
+            opts: {isCCForm: true}
+        },
+        {
+            html: `<input name="accountholdername" /><!-- second input is to trigger cc type --><input name="cc-number"/>`,
+            subtype: 'creditCards.cardName',
+            opts: {isCCForm: true}
+        },
+        {
+            html: `<input name="Срок действия карты" /><!-- second input is to trigger cc type --><input name="cc-number"/>`,
+            subtype: 'creditCards.expirationMonth',
+            opts: {isCCForm: true}
+        },
         { html: `<input placeholder="ZIP code" autocomplete="shipping postal-code" type="text" name="checkout[shipping_address][zip]"/>`, subtype: 'identities.addressPostalCode' },
         { html: `<input autocomplete="on" id="address_line2" name="address_line2" type="text">`, subtype: 'identities.addressStreet2' },
         { html: `<input name="ADDRESS_LINE_1" type="text" aria-required="true" aria-describedby="ariaId_29" aria-labelledby="ariaId_30" autocomplete="off-street-address" aria-autocomplete="list">`, subtype: 'identities.addressStreet' },

--- a/src/InContextSignup.js
+++ b/src/InContextSignup.js
@@ -110,7 +110,7 @@ export class InContextSignup {
 
     onIncontextSignupDismissed (options = { shouldHideTooltip: true }) {
         if (options.shouldHideTooltip) {
-            this.device.removeAutofillUIFromPage()
+            this.device.removeAutofillUIFromPage('Email Protection in-context signup dismissed.')
             this.device.deviceApi.notify(new CloseAutofillParentCall(null))
         }
         this.permanentlyDismissedAt = new Date().getTime()

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -180,10 +180,15 @@ class DefaultScanner {
      */
     getParentForm (input) {
         if (input instanceof HTMLInputElement || input instanceof HTMLSelectElement) {
-            // Use input.form unless it encloses most of the DOM
-            // In that case we proceed to identify more precise wrappers
-            if (input.form && !isFormLikelyToBeUsedAsPageWrapper(input.form)) {
-                return input.form
+            if (input.form) {
+                // Use input.form unless it encloses most of the DOM
+                // In that case we proceed to identify more precise wrappers
+                if (
+                    this.forms.has(input.form) || // If we've added the form we've already checked that it's not a page wrapper
+                    !isFormLikelyToBeUsedAsPageWrapper(input.form)
+                ) {
+                    return input.form
+                }
             }
         }
 

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -2,7 +2,7 @@ import { Form } from './Form/Form.js'
 import { SUBMIT_BUTTON_SELECTOR, FORM_INPUTS_SELECTOR } from './Form/selectors-css.js'
 import { constants } from './constants.js'
 import { createMatching } from './Form/matching.js'
-import {isFormLikelyToBeUsedAsPageWrapper, shouldLog, shouldLogPerformance} from './autofill-utils.js'
+import {logPerformance, isFormLikelyToBeUsedAsPageWrapper, shouldLog} from './autofill-utils.js'
 import { AddDebugFlagCall } from './deviceApiCalls/__generated__/deviceApiCalls.js'
 
 const {
@@ -117,13 +117,10 @@ class DefaultScanner {
      * Scan the page and begin observing changes
      */
     scanAndObserve () {
-        window.performance?.mark?.('scanner:init:start')
+        window.performance?.mark?.('initial_scanner:init:start')
         this.findEligibleInputs(document)
-        window.performance?.mark?.('scanner:init:end')
-        if (shouldLogPerformance()) {
-            const measurement = window.performance?.measure('scanner:init', 'scanner:init:start', 'scanner:init:end')
-            console.log(`Initial scan took ${Math.round(measurement?.duration)}ms`)
-        }
+        window.performance?.mark?.('initial_scanner:init:end')
+        logPerformance('initial_scanner')
         this.mutObs.observe(document.documentElement, { childList: true, subtree: true })
     }
 
@@ -270,9 +267,12 @@ class DefaultScanner {
 
         clearTimeout(this.debounceTimer)
         this.debounceTimer = setTimeout(() => {
+            window.performance?.mark?.('scanner:init:start')
             this.processChangedElements()
             this.changedElements.clear()
             this.rescanAll = false
+            window.performance?.mark?.('scanner:init:end')
+            logPerformance('scanner')
         }, this.options.debounceTimePeriod)
     }
 

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -66,6 +66,8 @@ class DefaultScanner {
     activeInput = null;
     /** @type {boolean} A flag to indicate the whole page will be re-scanned */
     rescanAll = false;
+    /** @type {boolean} Indicates whether we called stopScanning */
+    stopped = false
 
     /**
      * @param {import("./DeviceInterface/InterfacePrototype").default} device
@@ -153,6 +155,8 @@ class DefaultScanner {
      * @param {...any} rest
      */
     stopScanner (reason, ...rest) {
+        this.stopped = true
+
         if (shouldLog()) {
             console.log(reason, ...rest)
         }
@@ -161,6 +165,7 @@ class DefaultScanner {
 
         // remove Dax, listeners, timers, and observers
         clearTimeout(this.debounceTimer)
+        this.changedElements.clear()
         this.mutObs.disconnect()
 
         this.forms.forEach(form => {
@@ -212,6 +217,8 @@ class DefaultScanner {
      * @param {HTMLInputElement|HTMLSelectElement} input
      */
     addInput (input) {
+        if (this.stopped) return
+
         const parentForm = this.getParentForm(input)
         const seenFormElements = [...this.forms.keys()]
 

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -196,9 +196,10 @@ class DefaultScanner {
      */
     addInput (input) {
         const parentForm = this.getParentForm(input)
+        const seenFormElements = [...this.forms.keys()]
 
         // Note that el.contains returns true for el itself
-        const previouslyFoundParent = [...this.forms.keys()].find((form) => form.contains(parentForm))
+        const previouslyFoundParent = seenFormElements.find((form) => form.contains(parentForm))
 
         if (previouslyFoundParent) {
             if (parentForm instanceof HTMLFormElement && parentForm !== previouslyFoundParent) {
@@ -210,7 +211,7 @@ class DefaultScanner {
             }
         } else {
             // if this form is an ancestor of an existing form, remove that before adding this
-            const childForm = [...this.forms.keys()].find((form) => parentForm.contains(form))
+            const childForm = seenFormElements.find((form) => parentForm.contains(form))
             if (childForm) {
                 this.forms.get(childForm)?.destroy()
                 this.forms.delete(childForm)

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -2,7 +2,7 @@ import { Form } from './Form/Form.js'
 import { SUBMIT_BUTTON_SELECTOR, FORM_INPUTS_SELECTOR } from './Form/selectors-css.js'
 import { constants } from './constants.js'
 import { createMatching } from './Form/matching.js'
-import {isFormLikelyToBeUsedAsPageWrapper, shouldLog} from './autofill-utils.js'
+import {isFormLikelyToBeUsedAsPageWrapper, shouldLog, shouldLogPerformance} from './autofill-utils.js'
 import { AddDebugFlagCall } from './deviceApiCalls/__generated__/deviceApiCalls.js'
 
 const {
@@ -118,6 +118,10 @@ class DefaultScanner {
         window.performance?.mark?.('scanner:init:start')
         this.findEligibleInputs(document)
         window.performance?.mark?.('scanner:init:end')
+        if (shouldLogPerformance()) {
+            const measurement = window.performance?.measure('scanner:init', 'scanner:init:start', 'scanner:init:end')
+            console.log(`Initial scan took ${Math.round(measurement?.duration)}ms`)
+        }
         this.mutObs.observe(document.documentElement, { childList: true, subtree: true })
     }
 

--- a/src/__snapshots__/Scanner.test.js.snap
+++ b/src/__snapshots__/Scanner.test.js.snap
@@ -212,7 +212,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-01"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-01"
         type="text"
       />
@@ -223,7 +222,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-02"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-02"
         type="text"
       />
@@ -234,7 +232,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-03"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-03"
         type="text"
       />
@@ -245,7 +242,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-04"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-04"
         type="text"
       />
@@ -256,7 +252,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-05"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-05"
         type="text"
       />
@@ -273,6 +268,7 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-01"
     >
       <input
+        data-ddg-inputtype="unknown"
         id="input-01"
         type="text"
       />
@@ -283,6 +279,7 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-02"
     >
       <input
+        data-ddg-inputtype="unknown"
         id="input-02"
         type="text"
       />
@@ -293,6 +290,7 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-03"
     >
       <input
+        data-ddg-inputtype="unknown"
         id="input-03"
         type="text"
       />
@@ -303,6 +301,7 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-04"
     >
       <input
+        data-ddg-inputtype="unknown"
         id="input-04"
         type="text"
       />
@@ -313,6 +312,7 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-05"
     >
       <input
+        data-ddg-inputtype="unknown"
         id="input-05"
         type="text"
       />
@@ -336,7 +336,6 @@ exports[`performance should stop scanning if page grows above maximum inputs 1`]
       for="input-01"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-01"
         type="text"
       />
@@ -347,7 +346,6 @@ exports[`performance should stop scanning if page grows above maximum inputs 1`]
       for="input-02"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-02"
         type="text"
       />
@@ -358,7 +356,6 @@ exports[`performance should stop scanning if page grows above maximum inputs 1`]
       for="input-03"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-03"
         type="text"
       />
@@ -369,7 +366,6 @@ exports[`performance should stop scanning if page grows above maximum inputs 1`]
       for="input-04"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-04"
         type="text"
       />
@@ -380,7 +376,6 @@ exports[`performance should stop scanning if page grows above maximum inputs 1`]
       for="input-05"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-05"
         type="text"
       />

--- a/src/__snapshots__/Scanner.test.js.snap
+++ b/src/__snapshots__/Scanner.test.js.snap
@@ -268,7 +268,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-01"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-01"
         type="text"
       />
@@ -279,7 +278,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-02"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-02"
         type="text"
       />
@@ -290,7 +288,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-03"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-03"
         type="text"
       />
@@ -301,7 +298,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-04"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-04"
         type="text"
       />
@@ -312,7 +308,6 @@ exports[`performance should stop scanning if page grows above maximum forms 1`] 
       for="input-05"
     >
       <input
-        data-ddg-inputtype="unknown"
         id="input-05"
         type="text"
       />

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -349,10 +349,14 @@ const getText = (el) => {
         return removeExcessWhitespace(el.alt || el.value || el.title || el.name)
     }
 
-    return removeExcessWhitespace(
-        Array.from(el.childNodes).reduce((text, child) =>
-            child instanceof Text ? text + ' ' + child.textContent : text, '')
-    )
+    let text = ''
+    for (const childNode of el.childNodes) {
+        if (childNode instanceof Text) {
+            text += ' ' + childNode.textContent
+        }
+    }
+
+    return removeExcessWhitespace(text)
 }
 
 /**

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -430,6 +430,14 @@ function readDebugSetting (setting) {
     }
 }
 
+function logPerformance (markName) {
+    if (shouldLogPerformance()) {
+        const measurement = window.performance?.measure(`${markName}:init`, `${markName}:init:start`, `${markName}:init:end`)
+        console.log(`${markName} took ${Math.round(measurement?.duration)}ms`)
+        window.performance?.clearMarks()
+    }
+}
+
 /**
  *
  * @param {Function} callback
@@ -508,6 +516,7 @@ export {
     wasAutofilledByChrome,
     shouldLog,
     shouldLogPerformance,
+    logPerformance,
     whenIdle,
     truncateFromMiddle,
     isFormLikelyToBeUsedAsPageWrapper

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -401,13 +401,30 @@ const wasAutofilledByChrome = (input) => {
 }
 
 /**
- * Checks if we should log debug info to the console
+ * Checks if we should log form analysis debug info to the console
  * @returns {boolean}
  */
 function shouldLog () {
+    return readDebugSetting('ddg-autofill-debug')
+}
+
+/**
+ * Checks if we should log performance info to the console
+ * @returns {boolean}
+ */
+function shouldLogPerformance () {
+    return readDebugSetting('ddg-autofill-perf')
+}
+
+/**
+ * Check if a sessionStorage item is set to 'true'
+ * @param setting
+ * @returns {boolean}
+ */
+function readDebugSetting (setting) {
     // sessionStorage throws in invalid schemes like data: and file:
     try {
-        return window.sessionStorage?.getItem('ddg-autofill-debug') === 'true'
+        return window.sessionStorage?.getItem(setting) === 'true'
     } catch (e) {
         return false
     }
@@ -490,6 +507,7 @@ export {
     isValidTLD,
     wasAutofilledByChrome,
     shouldLog,
+    shouldLogPerformance,
     whenIdle,
     truncateFromMiddle,
     isFormLikelyToBeUsedAsPageWrapper

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -334,6 +334,7 @@ const buttonMatchesFormType = (el, formObj) => {
     }
 }
 
+const buttonInputTypes = ['submit', 'button']
 /**
  * Get the text of an element
  * @param {Element} el
@@ -344,9 +345,14 @@ const getText = (el) => {
     // this is important in order to give proper attribution of the text to the button
     if (el instanceof HTMLButtonElement) return removeExcessWhitespace(el.textContent)
 
-    if (el instanceof HTMLInputElement && ['submit', 'button'].includes(el.type)) return el.value
-    if (el instanceof HTMLInputElement && el.type === 'image') {
-        return removeExcessWhitespace(el.alt || el.value || el.title || el.name)
+    if (el instanceof HTMLInputElement) {
+        if (buttonInputTypes.includes(el.type)) {
+            return el.value
+        }
+
+        if (el.type === 'image') {
+            return removeExcessWhitespace(el.alt || el.value || el.title || el.name)
+        }
     }
 
     let text = ''

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15323,6 +15323,8 @@ class DefaultScanner {
 
   /** @type {boolean} A flag to indicate the whole page will be re-scanned */
 
+  /** @type {boolean} Indicates whether we called stopScanning */
+
   /**
    * @param {import("./DeviceInterface/InterfacePrototype").default} device
    * @param {ScannerOptions} options
@@ -15339,6 +15341,8 @@ class DefaultScanner {
     _defineProperty(this, "activeInput", null);
 
     _defineProperty(this, "rescanAll", false);
+
+    _defineProperty(this, "stopped", false);
 
     _defineProperty(this, "mutObs", new MutationObserver(mutationList => {
       /** @type {HTMLElement[]} */
@@ -15476,6 +15480,8 @@ class DefaultScanner {
   stopScanner(reason) {
     var _this$device$activeFo;
 
+    this.stopped = true;
+
     if ((0, _autofillUtils.shouldLog)()) {
       for (var _len2 = arguments.length, rest = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
         rest[_key2 - 1] = arguments[_key2];
@@ -15487,6 +15493,7 @@ class DefaultScanner {
     const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
 
     clearTimeout(this.debounceTimer);
+    this.changedElements.clear();
     this.mutObs.disconnect();
     this.forms.forEach(form => {
       form.destroy();
@@ -15540,6 +15547,7 @@ class DefaultScanner {
 
 
   addInput(input) {
+    if (this.stopped) return;
     const parentForm = this.getParentForm(input);
     const seenFormElements = [...this.forms.keys()]; // Note that el.contains returns true for el itself
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -161,7 +161,7 @@ class Messaging {
   }
   /**
    * Send a 'fire-and-forget' message.
-   * @throws
+   * @throws {Error}
    * {@link MissingHandler}
    *
    * @example
@@ -181,7 +181,7 @@ class Messaging {
   }
   /**
    * Send a request, and wait for a response
-   * @throws
+   * @throws {Error}
    * {@link MissingHandler}
    *
    * @example
@@ -8147,15 +8147,8 @@ class ExtensionInterface extends _InterfacePrototype.default {
     return null;
   }
 
-  removeAutofillUIFromPage() {
-    var _this$activeForm2;
-
-    super.removeAutofillUIFromPage();
-    (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.removeAllDecorations();
-  }
-
   async resetAutofillUI(callback) {
-    this.removeAutofillUIFromPage();
+    this.removeAutofillUIFromPage('Resetting autofill.');
     await this.setupAutofill();
     if (callback) await callback();
     this.uiController = this.createUIController();
@@ -8193,7 +8186,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
     switch (this.getActiveTooltipType()) {
       case TOOLTIP_TYPES.EmailProtection:
         {
-          var _this$activeForm3;
+          var _this$activeForm2;
 
           this._scannerCleanup = this.scanner.init();
           this.addLogoutListener(() => {
@@ -8208,12 +8201,12 @@ class ExtensionInterface extends _InterfacePrototype.default {
             }
           });
 
-          if ((_this$activeForm3 = this.activeForm) !== null && _this$activeForm3 !== void 0 && _this$activeForm3.activeInput) {
-            var _this$activeForm4;
+          if ((_this$activeForm2 = this.activeForm) !== null && _this$activeForm2 !== void 0 && _this$activeForm2.activeInput) {
+            var _this$activeForm3;
 
             this.attachTooltip({
               form: this.activeForm,
-              input: (_this$activeForm4 = this.activeForm) === null || _this$activeForm4 === void 0 ? void 0 : _this$activeForm4.activeInput,
+              input: (_this$activeForm3 = this.activeForm) === null || _this$activeForm3 === void 0 ? void 0 : _this$activeForm3.activeInput,
               click: null,
               trigger: 'postSignup',
               triggerMetaData: {
@@ -8449,7 +8442,7 @@ class InterfacePrototype {
 
   /** @type {boolean} */
 
-  /** @type {(()=>void) | null} */
+  /** @type {((reason, ...rest) => void) | null} */
 
   /**
    * @param {GlobalConfig} config
@@ -8523,12 +8516,16 @@ class InterfacePrototype {
   createUIController() {
     return new _NativeUIController.NativeUIController();
   }
+  /**
+   * @param {string} reason
+   */
 
-  removeAutofillUIFromPage() {
+
+  removeAutofillUIFromPage(reason) {
     var _this$uiController, _this$_scannerCleanup;
 
     (_this$uiController = this.uiController) === null || _this$uiController === void 0 ? void 0 : _this$uiController.destroy();
-    (_this$_scannerCleanup = this._scannerCleanup) === null || _this$_scannerCleanup === void 0 ? void 0 : _this$_scannerCleanup.call(this);
+    (_this$_scannerCleanup = this._scannerCleanup) === null || _this$_scannerCleanup === void 0 ? void 0 : _this$_scannerCleanup.call(this, reason);
   }
 
   get hasLocalAddresses() {
@@ -8768,7 +8765,7 @@ class InterfacePrototype {
   postInit() {
     const cleanup = this.scanner.init();
     this.addLogoutListener(() => {
-      cleanup();
+      cleanup('Logged out');
 
       if (this.globalConfig.isDDGDomain) {
         (0, _autofillUtils.notifyWebApp)({
@@ -10220,6 +10217,10 @@ class Form {
     return this.formAnalyzer.isHybrid;
   }
 
+  get isCCForm() {
+    return this.formAnalyzer.isCCForm();
+  }
+
   logFormInfo() {
     if (!(0, _autofillUtils.shouldLog)()) return;
     console.log("Form type: %c".concat(this.getFormType()), 'font-weight: bold');
@@ -10476,6 +10477,7 @@ class Form {
   destroy() {
     this.removeAllDecorations();
     this.removeTooltip();
+    this.forgetAllInputs();
     this.mutObs.disconnect();
     this.matching.clear();
     this.intObs = null;
@@ -10578,6 +10580,7 @@ class Form {
     const opts = {
       isLogin: this.isLogin,
       isHybrid: this.isHybrid,
+      isCCForm: this.isCCForm,
       hasCredentials: Boolean((_this$device$settings = this.device.settings.availableInputTypes.credentials) === null || _this$device$settings === void 0 ? void 0 : _this$device$settings.username),
       supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
     };
@@ -11030,6 +11033,8 @@ class FormAnalyzer {
 
     _defineProperty(this, "matching", void 0);
 
+    _defineProperty(this, "_isCCForm", undefined);
+
     this.form = form;
     this.matching = matching || new _matching.Matching(_matchingConfiguration.matchingConfiguration);
     /**
@@ -11307,6 +11312,52 @@ class FormAnalyzer {
     }
 
     return this;
+  }
+  /** @type {undefined|boolean} */
+
+
+  /**
+   * Tries to infer if it's a credit card form
+   * @returns {boolean}
+   */
+  isCCForm() {
+    var _formEl$textContent;
+
+    const formEl = this.form;
+    if (this._isCCForm !== undefined) return this._isCCForm;
+    const ccFieldSelector = this.matching.joinCssSelectors('cc');
+
+    if (!ccFieldSelector) {
+      this._isCCForm = false;
+      return this._isCCForm;
+    }
+
+    const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
+
+    if (hasCCSelectorChild) {
+      this._isCCForm = true;
+      return this._isCCForm;
+    } // Read form attributes to find a signal
+
+
+    const hasCCAttribute = [...formEl.attributes].some(_ref3 => {
+      let {
+        name,
+        value
+      } = _ref3;
+      return /(credit|payment).?card/i.test("".concat(name, "=").concat(value));
+    });
+
+    if (hasCCAttribute) {
+      this._isCCForm = true;
+      return this._isCCForm;
+    } // Match form textContent against common cc fields (includes hidden labels)
+
+
+    const textMatches = (_formEl$textContent = formEl.textContent) === null || _formEl$textContent === void 0 ? void 0 : _formEl$textContent.match(/(credit|payment).?card(.?number)?|ccv|security.?code|cvv|cvc|csc/ig); // We check for more than one to minimise false positives
+
+    this._isCCForm = Boolean(textMatches && textMatches.length > 1);
+    return this._isCCForm;
   }
 
 }
@@ -13755,7 +13806,7 @@ class Matching {
     this.setActiveElementStrings(input, formEl); // // For CC forms we run aggressive matches, so we want to make sure we only
     // // run them on actual CC forms to avoid false positives and expensive loops
 
-    if (this.isCCForm(formEl)) {
+    if (opts.isCCForm) {
       const subtype = this.subtypeFromMatchers('cc', input);
 
       if (subtype && isValidCreditCardSubtype(subtype)) {
@@ -13806,6 +13857,7 @@ class Matching {
    * @typedef {{
    *   isLogin?: boolean,
    *   isHybrid?: boolean,
+   *   isCCForm?: boolean,
    *   hasCredentials?: boolean,
    *   supportsIdentitiesAutofill?: boolean
    * }} SetInputTypeOpts
@@ -14138,39 +14190,6 @@ class Matching {
   forInput(input, form) {
     this.setActiveElementStrings(input, form);
     return this;
-  }
-  /**
-   * Tries to infer if it's a credit card form
-   * @param {HTMLElement} formEl
-   * @returns {boolean}
-   */
-
-
-  isCCForm(formEl) {
-    var _formEl$textContent;
-
-    const ccFieldSelector = this.joinCssSelectors('cc');
-
-    if (!ccFieldSelector) {
-      return false;
-    }
-
-    const hasCCSelectorChild = formEl.matches(ccFieldSelector) || formEl.querySelector(ccFieldSelector); // If the form contains one of the specific selectors, we have high confidence
-
-    if (hasCCSelectorChild) return true; // Read form attributes to find a signal
-
-    const hasCCAttribute = [...formEl.attributes].some(_ref => {
-      let {
-        name,
-        value
-      } = _ref;
-      return /(credit|payment).?card/i.test("".concat(name, "=").concat(value));
-    });
-    if (hasCCAttribute) return true; // Match form textContent against common cc fields (includes hidden labels)
-
-    const textMatches = (_formEl$textContent = formEl.textContent) === null || _formEl$textContent === void 0 ? void 0 : _formEl$textContent.match(/(credit|payment).?card(.?number)?|ccv|security.?code|cvv|cvc|csc/ig); // We check for more than one to minimise false positives
-
-    return Boolean(textMatches && textMatches.length > 1);
   }
   /**
    * @type {MatchingConfiguration}
@@ -14780,7 +14799,7 @@ class InContextSignup {
     };
 
     if (options.shouldHideTooltip) {
-      this.device.removeAutofillUIFromPage();
+      this.device.removeAutofillUIFromPage('Email Protection in-context signup dismissed.');
       this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
     }
 
@@ -15251,7 +15270,7 @@ const {
 /**
  * @typedef {{
  *     forms: Map<HTMLElement, import("./Form/Form").Form>;
- *     init(): ()=> void;
+ *     init(): (reason, ...rest)=> void;
  *     enqueue(elements: (HTMLElement|Document)[]): void;
  *     findEligibleInputs(context): Scanner;
  *     options: ScannerOptions;
@@ -15365,11 +15384,13 @@ class DefaultScanner {
    * Call this to scan once and then watch for changes.
    *
    * Call the returned function to remove listeners.
-   * @returns {() => void}
+   * @returns {(reason: string, ...rest) => void}
    */
 
 
   init() {
+    var _this = this;
+
     if (this.device.globalConfig.isExtension) {
       this.device.deviceApi.notify(new _deviceApiCalls.AddDebugFlagCall({
         flag: 'autofill'
@@ -15385,20 +15406,12 @@ class DefaultScanner {
       setTimeout(() => this.scanAndObserve(), delay);
     }
 
-    return () => {
-      var _this$device$activeFo;
+    return function (reason) {
+      for (var _len = arguments.length, rest = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        rest[_key - 1] = arguments[_key];
+      }
 
-      const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
-
-      clearTimeout(this.debounceTimer);
-      this.mutObs.disconnect();
-      this.forms.forEach(form => {
-        form.resetAllInputs();
-        form.removeAllDecorations();
-      });
-      this.forms.clear(); // Bring the user back to the input they were interacting with
-
-      activeInput === null || activeInput === void 0 ? void 0 : activeInput.focus();
+      _this.stopScanner(reason, ...rest);
     };
   }
   /**
@@ -15436,6 +15449,7 @@ class DefaultScanner {
       const inputs = context.querySelectorAll(_selectorsCss.FORM_INPUTS_SELECTOR);
 
       if (inputs.length > this.options.maxInputsPerPage) {
+        this.stopScanner('Too many input fields in the given context, stop scanning', context);
         return this;
       }
 
@@ -15443,6 +15457,35 @@ class DefaultScanner {
     }
 
     return this;
+  }
+  /**
+   * Stops scanning, switches off the mutation observer and clears all forms
+   * @param {string} reason
+   * @param {...any} rest
+   */
+
+
+  stopScanner(reason) {
+    var _this$device$activeFo;
+
+    if ((0, _autofillUtils.shouldLog)()) {
+      for (var _len2 = arguments.length, rest = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+        rest[_key2 - 1] = arguments[_key2];
+      }
+
+      console.log(reason, ...rest);
+    }
+
+    const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
+
+    clearTimeout(this.debounceTimer);
+    this.mutObs.disconnect();
+    this.forms.forEach(form => {
+      form.destroy();
+    });
+    this.forms.clear(); // Bring the user back to the input they were interacting with
+
+    activeInput === null || activeInput === void 0 ? void 0 : activeInput.focus();
   }
   /**
    * @param {HTMLElement|HTMLInputElement|HTMLSelectElement} input
@@ -15489,9 +15532,10 @@ class DefaultScanner {
 
 
   addInput(input) {
-    const parentForm = this.getParentForm(input); // Note that el.contains returns true for el itself
+    const parentForm = this.getParentForm(input);
+    const seenFormElements = [...this.forms.keys()]; // Note that el.contains returns true for el itself
 
-    const previouslyFoundParent = [...this.forms.keys()].find(form => form.contains(parentForm));
+    const previouslyFoundParent = seenFormElements.find(form => form.contains(parentForm));
 
     if (previouslyFoundParent) {
       if (parentForm instanceof HTMLFormElement && parentForm !== previouslyFoundParent) {
@@ -15505,7 +15549,7 @@ class DefaultScanner {
       }
     } else {
       // if this form is an ancestor of an existing form, remove that before adding this
-      const childForm = [...this.forms.keys()].find(form => parentForm.contains(form));
+      const childForm = seenFormElements.find(form => parentForm.contains(form));
 
       if (childForm) {
         var _this$forms$get2;
@@ -15518,9 +15562,7 @@ class DefaultScanner {
       if (this.forms.size < this.options.maxFormsPerPage) {
         this.forms.set(parentForm, new _Form.Form(parentForm, input, this.device, this.matching, this.shouldAutoprompt));
       } else {
-        if ((0, _autofillUtils.shouldLog)()) {
-          console.log('The page has too many forms, stop adding them.');
-        }
+        this.stopScanner('The page has too many forms, stop adding them.');
       }
     }
   }
@@ -18164,7 +18206,15 @@ const getText = el => {
     return (0, _matching.removeExcessWhitespace)(el.alt || el.value || el.title || el.name);
   }
 
-  return (0, _matching.removeExcessWhitespace)(Array.from(el.childNodes).reduce((text, child) => child instanceof Text ? text + ' ' + child.textContent : text, ''));
+  let text = '';
+
+  for (const childNode of el.childNodes) {
+    if (childNode instanceof Text) {
+      text += ' ' + childNode.textContent;
+    }
+  }
+
+  return (0, _matching.removeExcessWhitespace)(text);
 };
 /**
  * Check if hostname is a local address
@@ -18299,9 +18349,8 @@ var _autofillUtils = require("./autofill-utils.js");
 (() => {
   if ((0, _autofillUtils.shouldLog)()) {
     console.log('DuckDuckGo Autofill Active');
-  }
+  } // if (!window.isSecureContext) return false
 
-  if (!window.isSecureContext) return false;
 
   try {
     const startupAutofill = () => {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -14359,7 +14359,8 @@ function getInputSubtype(input) {
 
 const removeExcessWhitespace = function () {
   let string = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-  return (string || '').replace(/\n/g, ' ').replace(/\s{2,}/g, ' ').trim();
+  if (!string) return '';
+  return string.replace(/\n/g, ' ').replace(/\s{2,}/g, ' ').trim();
 };
 /**
  * Get text from all explicit labels
@@ -15426,17 +15427,10 @@ class DefaultScanner {
   scanAndObserve() {
     var _window$performance, _window$performance$m, _window$performance2, _window$performance2$;
 
-    (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : (_window$performance$m = _window$performance.mark) === null || _window$performance$m === void 0 ? void 0 : _window$performance$m.call(_window$performance, 'scanner:init:start');
+    (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : (_window$performance$m = _window$performance.mark) === null || _window$performance$m === void 0 ? void 0 : _window$performance$m.call(_window$performance, 'initial_scanner:init:start');
     this.findEligibleInputs(document);
-    (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : (_window$performance2$ = _window$performance2.mark) === null || _window$performance2$ === void 0 ? void 0 : _window$performance2$.call(_window$performance2, 'scanner:init:end');
-
-    if ((0, _autofillUtils.shouldLogPerformance)()) {
-      var _window$performance3;
-
-      const measurement = (_window$performance3 = window.performance) === null || _window$performance3 === void 0 ? void 0 : _window$performance3.measure('scanner:init', 'scanner:init:start', 'scanner:init:end');
-      console.log("Initial scan took ".concat(Math.round(measurement === null || measurement === void 0 ? void 0 : measurement.duration), "ms"));
-    }
-
+    (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : (_window$performance2$ = _window$performance2.mark) === null || _window$performance2$ === void 0 ? void 0 : _window$performance2$.call(_window$performance2, 'initial_scanner:init:end');
+    (0, _autofillUtils.logPerformance)('initial_scanner');
     this.mutObs.observe(document.documentElement, {
       childList: true,
       subtree: true
@@ -15510,10 +15504,13 @@ class DefaultScanner {
 
   getParentForm(input) {
     if (input instanceof HTMLInputElement || input instanceof HTMLSelectElement) {
-      // Use input.form unless it encloses most of the DOM
-      // In that case we proceed to identify more precise wrappers
-      if (input.form && !(0, _autofillUtils.isFormLikelyToBeUsedAsPageWrapper)(input.form)) {
-        return input.form;
+      if (input.form) {
+        // Use input.form unless it encloses most of the DOM
+        // In that case we proceed to identify more precise wrappers
+        if (this.forms.has(input.form) || // If we've added the form we've already checked that it's not a page wrapper
+        !(0, _autofillUtils.isFormLikelyToBeUsedAsPageWrapper)(input.form)) {
+          return input.form;
+        }
       }
     }
 
@@ -15549,28 +15546,53 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    const seenFormElements = [...this.forms.keys()]; // Note that el.contains returns true for el itself
 
-    const previouslyFoundParent = seenFormElements.find(form => form.contains(parentForm));
+    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+      var _this$forms$get;
+
+      // We've met the form, add the input
+      (_this$forms$get = this.forms.get(parentForm)) === null || _this$forms$get === void 0 ? void 0 : _this$forms$get.addInput(input);
+      return;
+    } // Check if the forms we've seen are either disconnected,
+    // or are parent/child of the currently-found form
+
+
+    let previouslyFoundParent, childForm;
+
+    for (const [formEl] of this.forms) {
+      // Remove disconnected forms to avoid leaks
+      if (!formEl.isConnected) {
+        this.forms.delete(formEl);
+        continue;
+      }
+
+      if (formEl.contains(parentForm)) {
+        previouslyFoundParent = formEl;
+        break;
+      }
+
+      if (parentForm.contains(formEl)) {
+        childForm = formEl;
+        break;
+      }
+    }
 
     if (previouslyFoundParent) {
       if (parentForm instanceof HTMLFormElement && parentForm !== previouslyFoundParent) {
         // If we had a prior parent but this is an explicit form, the previous was a false positive
         this.forms.delete(previouslyFoundParent);
       } else {
-        var _this$forms$get;
+        var _this$forms$get2;
 
         // If we've already met the form or a descendant, add the input
-        (_this$forms$get = this.forms.get(previouslyFoundParent)) === null || _this$forms$get === void 0 ? void 0 : _this$forms$get.addInput(input);
+        (_this$forms$get2 = this.forms.get(previouslyFoundParent)) === null || _this$forms$get2 === void 0 ? void 0 : _this$forms$get2.addInput(input);
       }
     } else {
       // if this form is an ancestor of an existing form, remove that before adding this
-      const childForm = seenFormElements.find(form => parentForm.contains(form));
-
       if (childForm) {
-        var _this$forms$get2;
+        var _this$forms$get3;
 
-        (_this$forms$get2 = this.forms.get(childForm)) === null || _this$forms$get2 === void 0 ? void 0 : _this$forms$get2.destroy();
+        (_this$forms$get3 = this.forms.get(childForm)) === null || _this$forms$get3 === void 0 ? void 0 : _this$forms$get3.destroy();
         this.forms.delete(childForm);
       } // Only add the form if below the limit of forms per page
 
@@ -15604,9 +15626,14 @@ class DefaultScanner {
 
     clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => {
+      var _window$performance3, _window$performance3$, _window$performance4, _window$performance4$;
+
+      (_window$performance3 = window.performance) === null || _window$performance3 === void 0 ? void 0 : (_window$performance3$ = _window$performance3.mark) === null || _window$performance3$ === void 0 ? void 0 : _window$performance3$.call(_window$performance3, 'scanner:init:start');
       this.processChangedElements();
       this.changedElements.clear();
       this.rescanAll = false;
+      (_window$performance4 = window.performance) === null || _window$performance4 === void 0 ? void 0 : (_window$performance4$ = _window$performance4.mark) === null || _window$performance4$ === void 0 ? void 0 : _window$performance4$.call(_window$performance4, 'scanner:init:end');
+      (0, _autofillUtils.logPerformance)('scanner');
     }, this.options.debounceTimePeriod);
   }
   /**
@@ -17784,6 +17811,7 @@ exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedCon
 exports.isLocalNetwork = isLocalNetwork;
 exports.isPotentiallyViewable = void 0;
 exports.isValidTLD = isValidTLD;
+exports.logPerformance = logPerformance;
 exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = void 0;
 exports.shouldLog = shouldLog;
 exports.shouldLogPerformance = shouldLogPerformance;
@@ -18204,23 +18232,28 @@ const buttonMatchesFormType = (el, formObj) => {
     return true;
   }
 };
+
+exports.buttonMatchesFormType = buttonMatchesFormType;
+const buttonInputTypes = ['submit', 'button'];
 /**
  * Get the text of an element
  * @param {Element} el
  * @returns {string}
  */
 
-
-exports.buttonMatchesFormType = buttonMatchesFormType;
-
 const getText = el => {
   // for buttons, we don't care about descendants, just get the whole text as is
   // this is important in order to give proper attribution of the text to the button
   if (el instanceof HTMLButtonElement) return (0, _matching.removeExcessWhitespace)(el.textContent);
-  if (el instanceof HTMLInputElement && ['submit', 'button'].includes(el.type)) return el.value;
 
-  if (el instanceof HTMLInputElement && el.type === 'image') {
-    return (0, _matching.removeExcessWhitespace)(el.alt || el.value || el.title || el.name);
+  if (el instanceof HTMLInputElement) {
+    if (buttonInputTypes.includes(el.type)) {
+      return el.value;
+    }
+
+    if (el.type === 'image') {
+      return (0, _matching.removeExcessWhitespace)(el.alt || el.value || el.title || el.name);
+    }
   }
 
   let text = '';
@@ -18309,6 +18342,16 @@ function readDebugSetting(setting) {
     return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem(setting)) === 'true';
   } catch (e) {
     return false;
+  }
+}
+
+function logPerformance(markName) {
+  if (shouldLogPerformance()) {
+    var _window$performance, _window$performance2;
+
+    const measurement = (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : _window$performance.measure("".concat(markName, ":init"), "".concat(markName, ":init:start"), "".concat(markName, ":init:end"));
+    console.log("".concat(markName, " took ").concat(Math.round(measurement === null || measurement === void 0 ? void 0 : measurement.duration), "ms"));
+    (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : _window$performance2.clearMarks();
   }
 }
 /**

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -11323,8 +11323,8 @@ class FormAnalyzer {
   isCCForm() {
     var _formEl$textContent;
 
-    const formEl = this.form;
     if (this._isCCForm !== undefined) return this._isCCForm;
+    const formEl = this.form;
     const ccFieldSelector = this.matching.joinCssSelectors('cc');
 
     if (!ccFieldSelector) {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15425,6 +15425,14 @@ class DefaultScanner {
     (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : (_window$performance$m = _window$performance.mark) === null || _window$performance$m === void 0 ? void 0 : _window$performance$m.call(_window$performance, 'scanner:init:start');
     this.findEligibleInputs(document);
     (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : (_window$performance2$ = _window$performance2.mark) === null || _window$performance2$ === void 0 ? void 0 : _window$performance2$.call(_window$performance2, 'scanner:init:end');
+
+    if ((0, _autofillUtils.shouldLogPerformance)()) {
+      var _window$performance3;
+
+      const measurement = (_window$performance3 = window.performance) === null || _window$performance3 === void 0 ? void 0 : _window$performance3.measure('scanner:init', 'scanner:init:start', 'scanner:init:end');
+      console.log("Initial scan took ".concat(Math.round(measurement === null || measurement === void 0 ? void 0 : measurement.duration), "ms"));
+    }
+
     this.mutObs.observe(document.documentElement, {
       childList: true,
       subtree: true
@@ -17770,6 +17778,7 @@ exports.isPotentiallyViewable = void 0;
 exports.isValidTLD = isValidTLD;
 exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = void 0;
 exports.shouldLog = shouldLog;
+exports.shouldLogPerformance = shouldLogPerformance;
 exports.truncateFromMiddle = truncateFromMiddle;
 exports.wasAutofilledByChrome = void 0;
 exports.whenIdle = whenIdle;
@@ -18258,7 +18267,7 @@ const wasAutofilledByChrome = input => {
   }
 };
 /**
- * Checks if we should log debug info to the console
+ * Checks if we should log form analysis debug info to the console
  * @returns {boolean}
  */
 
@@ -18266,11 +18275,30 @@ const wasAutofilledByChrome = input => {
 exports.wasAutofilledByChrome = wasAutofilledByChrome;
 
 function shouldLog() {
+  return readDebugSetting('ddg-autofill-debug');
+}
+/**
+ * Checks if we should log performance info to the console
+ * @returns {boolean}
+ */
+
+
+function shouldLogPerformance() {
+  return readDebugSetting('ddg-autofill-perf');
+}
+/**
+ * Check if a sessionStorage item is set to 'true'
+ * @param setting
+ * @returns {boolean}
+ */
+
+
+function readDebugSetting(setting) {
   // sessionStorage throws in invalid schemes like data: and file:
   try {
     var _window$sessionStorag;
 
-    return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem('ddg-autofill-debug')) === 'true';
+    return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem(setting)) === 'true';
   } catch (e) {
     return false;
   }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -161,7 +161,7 @@ class Messaging {
   }
   /**
    * Send a 'fire-and-forget' message.
-   * @throws {Error}
+   * @throws
    * {@link MissingHandler}
    *
    * @example
@@ -181,7 +181,7 @@ class Messaging {
   }
   /**
    * Send a request, and wait for a response
-   * @throws {Error}
+   * @throws
    * {@link MissingHandler}
    *
    * @example
@@ -18349,8 +18349,9 @@ var _autofillUtils = require("./autofill-utils.js");
 (() => {
   if ((0, _autofillUtils.shouldLog)()) {
     console.log('DuckDuckGo Autofill Active');
-  } // if (!window.isSecureContext) return false
+  }
 
+  if (!window.isSecureContext) return false;
 
   try {
     const startupAutofill = () => {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -161,7 +161,7 @@ class Messaging {
   }
   /**
    * Send a 'fire-and-forget' message.
-   * @throws {Error}
+   * @throws
    * {@link MissingHandler}
    *
    * @example
@@ -181,7 +181,7 @@ class Messaging {
   }
   /**
    * Send a request, and wait for a response
-   * @throws {Error}
+   * @throws
    * {@link MissingHandler}
    *
    * @example
@@ -14673,8 +14673,9 @@ var _autofillUtils = require("./autofill-utils.js");
 (() => {
   if ((0, _autofillUtils.shouldLog)()) {
     console.log('DuckDuckGo Autofill Active');
-  } // if (!window.isSecureContext) return false
+  }
 
+  if (!window.isSecureContext) return false;
 
   try {
     const startupAutofill = () => {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -11749,6 +11749,14 @@ class DefaultScanner {
     (_window$performance = window.performance) === null || _window$performance === void 0 ? void 0 : (_window$performance$m = _window$performance.mark) === null || _window$performance$m === void 0 ? void 0 : _window$performance$m.call(_window$performance, 'scanner:init:start');
     this.findEligibleInputs(document);
     (_window$performance2 = window.performance) === null || _window$performance2 === void 0 ? void 0 : (_window$performance2$ = _window$performance2.mark) === null || _window$performance2$ === void 0 ? void 0 : _window$performance2$.call(_window$performance2, 'scanner:init:end');
+
+    if ((0, _autofillUtils.shouldLogPerformance)()) {
+      var _window$performance3;
+
+      const measurement = (_window$performance3 = window.performance) === null || _window$performance3 === void 0 ? void 0 : _window$performance3.measure('scanner:init', 'scanner:init:start', 'scanner:init:end');
+      console.log("Initial scan took ".concat(Math.round(measurement === null || measurement === void 0 ? void 0 : measurement.duration), "ms"));
+    }
+
     this.mutObs.observe(document.documentElement, {
       childList: true,
       subtree: true
@@ -14094,6 +14102,7 @@ exports.isPotentiallyViewable = void 0;
 exports.isValidTLD = isValidTLD;
 exports.setValue = exports.sendAndWaitForAnswer = exports.safeExecute = exports.removeInlineStyles = exports.notifyWebApp = void 0;
 exports.shouldLog = shouldLog;
+exports.shouldLogPerformance = shouldLogPerformance;
 exports.truncateFromMiddle = truncateFromMiddle;
 exports.wasAutofilledByChrome = void 0;
 exports.whenIdle = whenIdle;
@@ -14582,7 +14591,7 @@ const wasAutofilledByChrome = input => {
   }
 };
 /**
- * Checks if we should log debug info to the console
+ * Checks if we should log form analysis debug info to the console
  * @returns {boolean}
  */
 
@@ -14590,11 +14599,30 @@ const wasAutofilledByChrome = input => {
 exports.wasAutofilledByChrome = wasAutofilledByChrome;
 
 function shouldLog() {
+  return readDebugSetting('ddg-autofill-debug');
+}
+/**
+ * Checks if we should log performance info to the console
+ * @returns {boolean}
+ */
+
+
+function shouldLogPerformance() {
+  return readDebugSetting('ddg-autofill-perf');
+}
+/**
+ * Check if a sessionStorage item is set to 'true'
+ * @param setting
+ * @returns {boolean}
+ */
+
+
+function readDebugSetting(setting) {
   // sessionStorage throws in invalid schemes like data: and file:
   try {
     var _window$sessionStorag;
 
-    return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem('ddg-autofill-debug')) === 'true';
+    return ((_window$sessionStorag = window.sessionStorage) === null || _window$sessionStorag === void 0 ? void 0 : _window$sessionStorag.getItem(setting)) === 'true';
   } catch (e) {
     return false;
   }

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -11647,6 +11647,8 @@ class DefaultScanner {
 
   /** @type {boolean} A flag to indicate the whole page will be re-scanned */
 
+  /** @type {boolean} Indicates whether we called stopScanning */
+
   /**
    * @param {import("./DeviceInterface/InterfacePrototype").default} device
    * @param {ScannerOptions} options
@@ -11663,6 +11665,8 @@ class DefaultScanner {
     _defineProperty(this, "activeInput", null);
 
     _defineProperty(this, "rescanAll", false);
+
+    _defineProperty(this, "stopped", false);
 
     _defineProperty(this, "mutObs", new MutationObserver(mutationList => {
       /** @type {HTMLElement[]} */
@@ -11800,6 +11804,8 @@ class DefaultScanner {
   stopScanner(reason) {
     var _this$device$activeFo;
 
+    this.stopped = true;
+
     if ((0, _autofillUtils.shouldLog)()) {
       for (var _len2 = arguments.length, rest = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
         rest[_key2 - 1] = arguments[_key2];
@@ -11811,6 +11817,7 @@ class DefaultScanner {
     const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput; // remove Dax, listeners, timers, and observers
 
     clearTimeout(this.debounceTimer);
+    this.changedElements.clear();
     this.mutObs.disconnect();
     this.forms.forEach(form => {
       form.destroy();
@@ -11864,6 +11871,7 @@ class DefaultScanner {
 
 
   addInput(input) {
+    if (this.stopped) return;
     const parentForm = this.getParentForm(input);
     const seenFormElements = [...this.forms.keys()]; // Note that el.contains returns true for el itself
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -7647,8 +7647,8 @@ class FormAnalyzer {
   isCCForm() {
     var _formEl$textContent;
 
-    const formEl = this.form;
     if (this._isCCForm !== undefined) return this._isCCForm;
+    const formEl = this.form;
     const ccFieldSelector = this.matching.joinCssSelectors('cc');
 
     if (!ccFieldSelector) {


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/1198964220583541/1203781196578953/f

## Description
A few improvements to speed up test execution and performance in general. In summary:
- Mock `getComputedStyles` in jsdom (60% test speed up 🎉).
- Memoize `isCCForm`: we were calling this for every single input field instead of per-form. This sped things up further, not only in the tests, but also in the real world. Most pages wouldn't see much difference because we have bailouts when there are tons of fields, but in test environments like in #258 (with bailouts switched off) this yielded a massive 80+% reduction in execution time.
- Disconnect main `MutationObserver` when we reach the failsafe threshold. Even when we stop adding forms we still do some work, especially in pages like Asana where there's no form so all fields would trigger the expensive search for a form container. This change disconnects the observer altogether, so we no longer incur that extra cost after bailing.

## Steps to test
All test suites passing, but much faster! 🎉