### PR TITLE
deps: remove deprecated content-scope-utils

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -58,715 +58,6 @@ function processConfig(data, userList, preferences) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-var _messaging = require("./messaging.js");
-
-Object.keys(_messaging).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _messaging[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _messaging[key];
-    }
-  });
-});
-
-},{"./messaging.js":3}],3:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.MissingHandler = exports.MessagingTransport = exports.Messaging = void 0;
-Object.defineProperty(exports, "WebkitMessagingConfig", {
-  enumerable: true,
-  get: function () {
-    return _webkit.WebkitMessagingConfig;
-  }
-});
-Object.defineProperty(exports, "WindowsMessagingConfig", {
-  enumerable: true,
-  get: function () {
-    return _windows.WindowsMessagingConfig;
-  }
-});
-
-var _windows = require("./messaging/windows.js");
-
-var _webkit = require("./messaging/webkit.js");
-
-/**
- * @module Messaging
- *
- * @description
- *
- * An abstraction for communications between JavaScript and host platforms.
- *
- * 1) First you construct your platform-specific configuration (eg: {@link WebkitMessagingConfig})
- * 2) Then use that to get an instance of the Messaging utility which allows
- * you to send and receive data in a unified way
- * 3) Each platform implements {@link MessagingTransport} along with its own Configuration
- *     - For example, to learn what configuration is required for Webkit, see: {@link "Webkit Messaging".WebkitMessagingConfig}
- *     - Or, to learn about how messages are sent and received in Webkit, see {@link "Webkit Messaging".WebkitMessagingTransport}
- *
- * @example Webkit Messaging
- *
- * ```js
- * import { Messaging, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
- *
- * // This config would be injected into the UserScript
- * const injectedConfig = {
- *   hasModernWebkitAPI: true,
- *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
- *   secret: "dax",
- * };
- *
- * // Then use that config to construct platform-specific configuration
- * const config = new WebkitMessagingConfig(injectedConfig);
- *
- * // finally, get an instance of Messaging and start sending messages in a unified way 🚀
- * const messaging = new Messaging(config);
- * messaging.notify("hello world!", {foo: "bar"})
- *
- * ```
- *
- * @example Windows Messaging
- *
- * ```js
- * import { Messaging, WindowsMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
- *
- * // Messaging on Windows is namespaced, so you can create multiple messaging instances
- * const autofillConfig  = new WindowsMessagingConfig({ featureName: "Autofill" });
- * const debugConfig     = new WindowsMessagingConfig({ featureName: "Debugging" });
- *
- * const autofillMessaging = new Messaging(autofillConfig);
- * const debugMessaging    = new Messaging(debugConfig);
- *
- * // Now send messages to both features as needed 🚀
- * autofillMessaging.notify("storeFormData", { "username": "dax" })
- * debugMessaging.notify("pageLoad", { time: window.performance.now() })
- * ```
- */
-
-/**
- * @implements {MessagingTransport}
- */
-class Messaging {
-  /**
-   * @param {WebkitMessagingConfig | WindowsMessagingConfig} config
-   */
-  constructor(config) {
-    this.transport = getTransport(config);
-  }
-  /**
-   * Send a 'fire-and-forget' message.
-   * @throws
-   * {@link MissingHandler}
-   *
-   * @example
-   *
-   * ```
-   * const messaging = new Messaging(config)
-   * messaging.notify("foo", {bar: "baz"})
-   * ```
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
-
-
-  notify(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    this.transport.notify(name, data);
-  }
-  /**
-   * Send a request, and wait for a response
-   * @throws
-   * {@link MissingHandler}
-   *
-   * @example
-   * ```
-   * const messaging = new Messaging(config)
-   * const response = await messaging.request("foo", {bar: "baz"})
-   * ```
-   *
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
-
-
-  request(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    return this.transport.request(name, data);
-  }
-
-}
-/**
- * @interface
- */
-
-
-exports.Messaging = Messaging;
-
-class MessagingTransport {
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @returns {void}
-   */
-  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  notify(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    throw new Error("must implement 'notify'");
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
-  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-  request(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    throw new Error('must implement');
-  }
-
-}
-/**
- * @param {WebkitMessagingConfig | WindowsMessagingConfig} config
- * @returns {MessagingTransport}
- */
-
-
-exports.MessagingTransport = MessagingTransport;
-
-function getTransport(config) {
-  if (config instanceof _webkit.WebkitMessagingConfig) {
-    return new _webkit.WebkitMessagingTransport(config);
-  }
-
-  if (config instanceof _windows.WindowsMessagingConfig) {
-    return new _windows.WindowsMessagingTransport(config);
-  }
-
-  throw new Error('unreachable');
-}
-/**
- * Thrown when a handler cannot be found
- */
-
-
-class MissingHandler extends Error {
-  /**
-   * @param {string} message
-   * @param {string} handlerName
-   */
-  constructor(message, handlerName) {
-    super(message);
-    this.handlerName = handlerName;
-  }
-
-}
-/**
- * Some re-exports for convenience
- */
-
-
-exports.MissingHandler = MissingHandler;
-
-},{"./messaging/webkit.js":4,"./messaging/windows.js":5}],4:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.WebkitMessagingTransport = exports.WebkitMessagingConfig = exports.SecureMessagingParams = void 0;
-
-var _messaging = require("../messaging.js");
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-/**
- * @example
- * On macOS 11+, this will just call through to `window.webkit.messageHandlers.x.postMessage`
- *
- * Eg: for a `foo` message defined in Swift that accepted the payload `{"bar": "baz"}`, the following
- * would occur:
- *
- * ```js
- * const json = await window.webkit.messageHandlers.foo.postMessage({ bar: "baz" });
- * const response = JSON.parse(json)
- * ```
- *
- * @example
- * On macOS 10 however, the process is a little more involved. A method will be appended to `window`
- * that allows the response to be delivered there instead. It's not exactly this, but you can visualize the flow
- * as being something along the lines of:
- *
- * ```js
- * // add the window method
- * window["_0123456"] = (response) => {
- *    // decrypt `response` and deliver the result to the caller here
- *    // then remove the temporary method
- *    delete window["_0123456"]
- * };
- *
- * // send the data + `messageHanding` values
- * window.webkit.messageHandlers.foo.postMessage({
- *   bar: "baz",
- *   messagingHandling: {
- *     methodName: "_0123456",
- *     secret: "super-secret",
- *     key: [1, 2, 45, 2],
- *     iv: [34, 4, 43],
- *   }
- * });
- *
- * // later in swift, the following JavaScript snippet will be executed
- * (() => {
- *   window["_0123456"]({
- *     ciphertext: [12, 13, 4],
- *     tag: [3, 5, 67, 56]
- *   })
- * })()
- * ```
- * @implements {MessagingTransport}
- */
-class WebkitMessagingTransport {
-  /** @type {WebkitMessagingConfig} */
-
-  /**
-   * @param {WebkitMessagingConfig} config
-   */
-  constructor(config) {
-    _defineProperty(this, "config", void 0);
-
-    _defineProperty(this, "globals", void 0);
-
-    _defineProperty(this, "algoObj", {
-      name: 'AES-GCM',
-      length: 256
-    });
-
-    this.config = config;
-    this.globals = captureGlobals();
-
-    if (!this.config.hasModernWebkitAPI) {
-      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-    }
-  }
-  /**
-   * Sends message to the webkit layer (fire and forget)
-   * @param {String} handler
-   * @param {*} data
-   * @internal
-   */
-
-
-  wkSend(handler) {
-    var _this$globals$window$, _this$globals$window$2;
-
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    if (!(handler in this.globals.window.webkit.messageHandlers)) {
-      throw new _messaging.MissingHandler("Missing webkit handler: '".concat(handler, "'"), handler);
-    }
-
-    const outgoing = { ...data,
-      messageHandling: { ...data.messageHandling,
-        secret: this.config.secret
-      }
-    };
-
-    if (!this.config.hasModernWebkitAPI) {
-      if (!(handler in this.globals.capturedWebkitHandlers)) {
-        throw new _messaging.MissingHandler("cannot continue, method ".concat(handler, " not captured on macos < 11"), handler);
-      } else {
-        return this.globals.capturedWebkitHandlers[handler](outgoing);
-      }
-    }
-
-    return (_this$globals$window$ = (_this$globals$window$2 = this.globals.window.webkit.messageHandlers[handler]).postMessage) === null || _this$globals$window$ === void 0 ? void 0 : _this$globals$window$.call(_this$globals$window$2, outgoing);
-  }
-  /**
-   * Sends message to the webkit layer and waits for the specified response
-   * @param {String} handler
-   * @param {*} data
-   * @returns {Promise<*>}
-   * @internal
-   */
-
-
-  async wkSendAndWait(handler) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    if (this.config.hasModernWebkitAPI) {
-      const response = await this.wkSend(handler, data);
-      return this.globals.JSONparse(response || '{}');
-    }
-
-    try {
-      const randMethodName = this.createRandMethodName();
-      const key = await this.createRandKey();
-      const iv = this.createRandIv();
-      const {
-        ciphertext,
-        tag
-      } = await new this.globals.Promise((
-      /** @type {any} */
-      resolve) => {
-        this.generateRandomMethod(randMethodName, resolve);
-        data.messageHandling = new SecureMessagingParams({
-          methodName: randMethodName,
-          secret: this.config.secret,
-          key: this.globals.Arrayfrom(key),
-          iv: this.globals.Arrayfrom(iv)
-        });
-        this.wkSend(handler, data);
-      });
-      const cipher = new this.globals.Uint8Array([...ciphertext, ...tag]);
-      const decrypted = await this.decrypt(cipher, key, iv);
-      return this.globals.JSONparse(decrypted || '{}');
-    } catch (e) {
-      // re-throw when the error is just a 'MissingHandler'
-      if (e instanceof _messaging.MissingHandler) {
-        throw e;
-      } else {
-        console.error('decryption failed', e);
-        console.error(e);
-        return {
-          error: e
-        };
-      }
-    }
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
-
-
-  notify(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    this.wkSend(name, data);
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-  request(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    return this.wkSendAndWait(name, data);
-  }
-  /**
-   * Generate a random method name and adds it to the global scope
-   * The native layer will use this method to send the response
-   * @param {string | number} randomMethodName
-   * @param {Function} callback
-   */
-
-
-  generateRandomMethod(randomMethodName, callback) {
-    var _this = this;
-
-    this.globals.ObjectDefineProperty(this.globals.window, randomMethodName, {
-      enumerable: false,
-      // configurable, To allow for deletion later
-      configurable: true,
-      writable: false,
-
-      /**
-       * @param {any[]} args
-       */
-      value: function () {
-        callback(...arguments); // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
-
-        delete _this.globals.window[randomMethodName];
-      }
-    });
-  }
-
-  randomString() {
-    return '' + this.globals.getRandomValues(new this.globals.Uint32Array(1))[0];
-  }
-
-  createRandMethodName() {
-    return '_' + this.randomString();
-  }
-  /**
-   * @type {{name: string, length: number}}
-   */
-
-
-  /**
-   * @returns {Promise<Uint8Array>}
-   */
-  async createRandKey() {
-    const key = await this.globals.generateKey(this.algoObj, true, ['encrypt', 'decrypt']);
-    const exportedKey = await this.globals.exportKey('raw', key);
-    return new this.globals.Uint8Array(exportedKey);
-  }
-  /**
-   * @returns {Uint8Array}
-   */
-
-
-  createRandIv() {
-    return this.globals.getRandomValues(new this.globals.Uint8Array(12));
-  }
-  /**
-   * @param {BufferSource} ciphertext
-   * @param {BufferSource} key
-   * @param {Uint8Array} iv
-   * @returns {Promise<string>}
-   */
-
-
-  async decrypt(ciphertext, key, iv) {
-    const cryptoKey = await this.globals.importKey('raw', key, 'AES-GCM', false, ['decrypt']);
-    const algo = {
-      name: 'AES-GCM',
-      iv
-    };
-    let decrypted = await this.globals.decrypt(algo, cryptoKey, ciphertext);
-    let dec = new this.globals.TextDecoder();
-    return dec.decode(decrypted);
-  }
-  /**
-   * When required (such as on macos 10.x), capture the `postMessage` method on
-   * each webkit messageHandler
-   *
-   * @param {string[]} handlerNames
-   */
-
-
-  captureWebkitHandlers(handlerNames) {
-    const handlers = window.webkit.messageHandlers;
-    if (!handlers) throw new _messaging.MissingHandler('window.webkit.messageHandlers was absent', 'all');
-
-    for (let webkitMessageHandlerName of handlerNames) {
-      var _handlers$webkitMessa;
-
-      if (typeof ((_handlers$webkitMessa = handlers[webkitMessageHandlerName]) === null || _handlers$webkitMessa === void 0 ? void 0 : _handlers$webkitMessa.postMessage) === 'function') {
-        var _handlers$webkitMessa2;
-
-        /**
-         * `bind` is used here to ensure future calls to the captured
-         * `postMessage` have the correct `this` context
-         */
-        const original = handlers[webkitMessageHandlerName];
-        const bound = (_handlers$webkitMessa2 = handlers[webkitMessageHandlerName].postMessage) === null || _handlers$webkitMessa2 === void 0 ? void 0 : _handlers$webkitMessa2.bind(original);
-        this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-        delete handlers[webkitMessageHandlerName].postMessage;
-      }
-    }
-  }
-
-}
-/**
- * Use this configuration to create an instance of {@link Messaging} for WebKit
- *
- * ```js
- * import { fromConfig, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
- *
- * const config = new WebkitMessagingConfig({
- *   hasModernWebkitAPI: true,
- *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
- *   secret: "dax",
- * });
- *
- * const messaging = new Messaging(config)
- * const resp = await messaging.request("debugConfig")
- * ```
- */
-
-
-exports.WebkitMessagingTransport = WebkitMessagingTransport;
-
-class WebkitMessagingConfig {
-  /**
-   * @param {object} params
-   * @param {boolean} params.hasModernWebkitAPI
-   * @param {string[]} params.webkitMessageHandlerNames
-   * @param {string} params.secret
-   */
-  constructor(params) {
-    /**
-     * Whether or not the current WebKit Platform supports secure messaging
-     * by default (eg: macOS 11+)
-     */
-    this.hasModernWebkitAPI = params.hasModernWebkitAPI;
-    /**
-     * A list of WebKit message handler names that a user script can send
-     */
-
-    this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-    /**
-     * A string provided by native platforms to be sent with future outgoing
-     * messages
-     */
-
-    this.secret = params.secret;
-  }
-
-}
-/**
- * This is the additional payload that gets appended to outgoing messages.
- * It's used in the Swift side to encrypt the response that comes back
- */
-
-
-exports.WebkitMessagingConfig = WebkitMessagingConfig;
-
-class SecureMessagingParams {
-  /**
-   * @param {object} params
-   * @param {string} params.methodName
-   * @param {string} params.secret
-   * @param {number[]} params.key
-   * @param {number[]} params.iv
-   */
-  constructor(params) {
-    /**
-     * The method that's been appended to `window` to be called later
-     */
-    this.methodName = params.methodName;
-    /**
-     * The secret used to ensure message sender validity
-     */
-
-    this.secret = params.secret;
-    /**
-     * The CipherKey as number[]
-     */
-
-    this.key = params.key;
-    /**
-     * The Initial Vector as number[]
-     */
-
-    this.iv = params.iv;
-  }
-
-}
-/**
- * Capture some globals used for messaging handling to prevent page
- * scripts from tampering with this
- */
-
-
-exports.SecureMessagingParams = SecureMessagingParams;
-
-function captureGlobals() {
-  // Creat base with null prototype
-  return {
-    window,
-    // Methods must be bound to their interface, otherwise they throw Illegal invocation
-    encrypt: window.crypto.subtle.encrypt.bind(window.crypto.subtle),
-    decrypt: window.crypto.subtle.decrypt.bind(window.crypto.subtle),
-    generateKey: window.crypto.subtle.generateKey.bind(window.crypto.subtle),
-    exportKey: window.crypto.subtle.exportKey.bind(window.crypto.subtle),
-    importKey: window.crypto.subtle.importKey.bind(window.crypto.subtle),
-    getRandomValues: window.crypto.getRandomValues.bind(window.crypto),
-    TextEncoder,
-    TextDecoder,
-    Uint8Array,
-    Uint16Array,
-    Uint32Array,
-    JSONstringify: window.JSON.stringify,
-    JSONparse: window.JSON.parse,
-    Arrayfrom: window.Array.from,
-    Promise: window.Promise,
-    ObjectDefineProperty: window.Object.defineProperty,
-    addEventListener: window.addEventListener.bind(window),
-
-    /** @type {Record<string, any>} */
-    capturedWebkitHandlers: {}
-  };
-}
-
-},{"../messaging.js":3}],5:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.WindowsMessagingTransport = exports.WindowsMessagingConfig = void 0;
-
-var _messaging = require("../messaging.js");
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-/**
- * @implements {MessagingTransport}
- */
-class WindowsMessagingTransport {
-  /**
-   * @param {WindowsMessagingConfig} config
-   */
-  constructor(config) {
-    _defineProperty(this, "config", void 0);
-
-    this.config = config;
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-  notify(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    throw new Error('todo: implement notify for windows');
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @param {{signal?: AbortSignal}} opts
-   * @return {Promise<any>}
-   */
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-  request(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    let opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-    throw new Error('todo: implement request for windows');
-  }
-
-}
-
-exports.WindowsMessagingTransport = WindowsMessagingTransport;
-
-class WindowsMessagingConfig {
-  /**
-   * @param {object} params
-   * @param {string} params.featureName
-   */
-  constructor(params) {
-    this.featureName = params.featureName;
-  }
-
-}
-
-exports.WindowsMessagingConfig = WindowsMessagingConfig;
-
-},{"../messaging.js":3}],6:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
 exports.setErrorMap = exports.overrideErrorMap = exports.defaultErrorMap = exports.ZodError = exports.quotelessJson = exports.ZodIssueCode = void 0;
 
 const parseUtil_1 = require("./helpers/parseUtil");
@@ -1005,7 +296,7 @@ const setErrorMap = map => {
 
 exports.setErrorMap = setErrorMap;
 
-},{"./helpers/parseUtil":9,"./helpers/util":11}],7:[function(require,module,exports){
+},{"./helpers/parseUtil":5,"./helpers/util":7}],3:[function(require,module,exports){
 "use strict";
 
 var __createBinding = void 0 && (void 0).__createBinding || (Object.create ? function (o, m, k, k2) {
@@ -1043,7 +334,7 @@ __exportStar(require("./types"), exports);
 
 __exportStar(require("./ZodError"), exports);
 
-},{"./ZodError":6,"./helpers/parseUtil":9,"./helpers/typeAliases":10,"./types":13}],8:[function(require,module,exports){
+},{"./ZodError":2,"./helpers/parseUtil":5,"./helpers/typeAliases":6,"./types":9}],4:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1060,7 +351,7 @@ var errorUtil;
   errorUtil.toString = message => typeof message === "string" ? message : message === null || message === void 0 ? void 0 : message.message;
 })(errorUtil = exports.errorUtil || (exports.errorUtil = {}));
 
-},{}],9:[function(require,module,exports){
+},{}],5:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1275,14 +566,14 @@ const isAsync = x => typeof Promise !== undefined && x instanceof Promise;
 
 exports.isAsync = isAsync;
 
-},{"../ZodError":6,"./util":11}],10:[function(require,module,exports){
+},{"../ZodError":2,"./util":7}],6:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-},{}],11:[function(require,module,exports){
+},{}],7:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1358,7 +649,7 @@ var util;
   util.joinValues = joinValues;
 })(util = exports.util || (exports.util = {}));
 
-},{}],12:[function(require,module,exports){
+},{}],8:[function(require,module,exports){
 "use strict";
 
 var __createBinding = void 0 && (void 0).__createBinding || (Object.create ? function (o, m, k, k2) {
@@ -1416,7 +707,7 @@ __exportStar(require("./external"), exports);
 
 exports.default = mod;
 
-},{"./external":7}],13:[function(require,module,exports){
+},{"./external":3}],9:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4437,7 +3728,7 @@ const oboolean = () => booleanType().optional();
 
 exports.oboolean = oboolean;
 
-},{"./ZodError":6,"./helpers/errorUtil":8,"./helpers/parseUtil":9,"./helpers/util":11}],14:[function(require,module,exports){
+},{"./ZodError":2,"./helpers/errorUtil":4,"./helpers/parseUtil":5,"./helpers/util":7}],10:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4484,7 +3775,7 @@ var _deviceApiCall = require("./lib/device-api-call.js");
 
 var _deviceApi = require("./lib/device-api.js");
 
-},{"./lib/device-api-call.js":15,"./lib/device-api.js":16}],15:[function(require,module,exports){
+},{"./lib/device-api-call.js":11,"./lib/device-api.js":12}],11:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4810,7 +4101,7 @@ function validate(data) {
   return data;
 }
 
-},{}],16:[function(require,module,exports){
+},{}],12:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4886,7 +4177,615 @@ class DeviceApi {
 
 exports.DeviceApi = DeviceApi;
 
-},{}],17:[function(require,module,exports){
+},{}],13:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.MissingHandler = exports.MessagingTransport = exports.Messaging = void 0;
+Object.defineProperty(exports, "WebkitMessagingConfig", {
+  enumerable: true,
+  get: function () {
+    return _webkit.WebkitMessagingConfig;
+  }
+});
+
+var _webkit = require("./webkit.js");
+
+/**
+ * @module Messaging
+ *
+ * @description
+ *
+ * An abstraction for communications between JavaScript and host platforms.
+ *
+ * 1) First you construct your platform-specific configuration (eg: {@link WebkitMessagingConfig})
+ * 2) Then use that to get an instance of the Messaging utility which allows
+ * you to send and receive data in a unified way
+ * 3) Each platform implements {@link MessagingTransport} along with its own Configuration
+ *     - For example, to learn what configuration is required for Webkit, see: {@link "Webkit Messaging".WebkitMessagingConfig}
+ *     - Or, to learn about how messages are sent and received in Webkit, see {@link "Webkit Messaging".WebkitMessagingTransport}
+ *
+ * @example Webkit Messaging
+ *
+ * ```js
+ * import { Messaging, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * // This config would be injected into the UserScript
+ * const injectedConfig = {
+ *   hasModernWebkitAPI: true,
+ *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
+ *   secret: "dax",
+ * };
+ *
+ * // Then use that config to construct platform-specific configuration
+ * const config = new WebkitMessagingConfig(injectedConfig);
+ *
+ * // finally, get an instance of Messaging and start sending messages in a unified way 🚀
+ * const messaging = new Messaging(config);
+ * messaging.notify("hello world!", {foo: "bar"})
+ *
+ * ```
+ *
+ * @example Windows Messaging
+ *
+ * ```js
+ * import { Messaging, WindowsMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * // Messaging on Windows is namespaced, so you can create multiple messaging instances
+ * const autofillConfig  = new WindowsMessagingConfig({ featureName: "Autofill" });
+ * const debugConfig     = new WindowsMessagingConfig({ featureName: "Debugging" });
+ *
+ * const autofillMessaging = new Messaging(autofillConfig);
+ * const debugMessaging    = new Messaging(debugConfig);
+ *
+ * // Now send messages to both features as needed 🚀
+ * autofillMessaging.notify("storeFormData", { "username": "dax" })
+ * debugMessaging.notify("pageLoad", { time: window.performance.now() })
+ * ```
+ */
+
+/**
+ * @implements {MessagingTransport}
+ */
+class Messaging {
+  /**
+   * @param {WebkitMessagingConfig} config
+   */
+  constructor(config) {
+    this.transport = getTransport(config);
+  }
+  /**
+   * Send a 'fire-and-forget' message.
+   * @throws {Error}
+   * {@link MissingHandler}
+   *
+   * @example
+   *
+   * ```
+   * const messaging = new Messaging(config)
+   * messaging.notify("foo", {bar: "baz"})
+   * ```
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+
+
+  notify(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    this.transport.notify(name, data);
+  }
+  /**
+   * Send a request, and wait for a response
+   * @throws {Error}
+   * {@link MissingHandler}
+   *
+   * @example
+   * ```
+   * const messaging = new Messaging(config)
+   * const response = await messaging.request("foo", {bar: "baz"})
+   * ```
+   *
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @return {Promise<any>}
+   */
+
+
+  request(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    return this.transport.request(name, data);
+  }
+
+}
+/**
+ * @interface
+ */
+
+
+exports.Messaging = Messaging;
+
+class MessagingTransport {
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @returns {void}
+   */
+  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  notify(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    throw new Error("must implement 'notify'");
+  }
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @return {Promise<any>}
+   */
+  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+
+  request(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    throw new Error('must implement');
+  }
+
+}
+/**
+ * @param {WebkitMessagingConfig} config
+ * @returns {MessagingTransport}
+ */
+
+
+exports.MessagingTransport = MessagingTransport;
+
+function getTransport(config) {
+  if (config instanceof _webkit.WebkitMessagingConfig) {
+    return new _webkit.WebkitMessagingTransport(config);
+  }
+
+  throw new Error('unreachable');
+}
+/**
+ * Thrown when a handler cannot be found
+ */
+
+
+class MissingHandler extends Error {
+  /**
+   * @param {string} message
+   * @param {string} handlerName
+   */
+  constructor(message, handlerName) {
+    super(message);
+    this.handlerName = handlerName;
+  }
+
+}
+/**
+ * Some re-exports for convenience
+ */
+
+
+exports.MissingHandler = MissingHandler;
+
+},{"./webkit.js":14}],14:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.WebkitMessagingTransport = exports.WebkitMessagingConfig = exports.SecureMessagingParams = void 0;
+
+var _messaging = require("./messaging.js");
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/**
+ * @example
+ * On macOS 11+, this will just call through to `window.webkit.messageHandlers.x.postMessage`
+ *
+ * Eg: for a `foo` message defined in Swift that accepted the payload `{"bar": "baz"}`, the following
+ * would occur:
+ *
+ * ```js
+ * const json = await window.webkit.messageHandlers.foo.postMessage({ bar: "baz" });
+ * const response = JSON.parse(json)
+ * ```
+ *
+ * @example
+ * On macOS 10 however, the process is a little more involved. A method will be appended to `window`
+ * that allows the response to be delivered there instead. It's not exactly this, but you can visualize the flow
+ * as being something along the lines of:
+ *
+ * ```js
+ * // add the window method
+ * window["_0123456"] = (response) => {
+ *    // decrypt `response` and deliver the result to the caller here
+ *    // then remove the temporary method
+ *    delete window["_0123456"]
+ * };
+ *
+ * // send the data + `messageHanding` values
+ * window.webkit.messageHandlers.foo.postMessage({
+ *   bar: "baz",
+ *   messagingHandling: {
+ *     methodName: "_0123456",
+ *     secret: "super-secret",
+ *     key: [1, 2, 45, 2],
+ *     iv: [34, 4, 43],
+ *   }
+ * });
+ *
+ * // later in swift, the following JavaScript snippet will be executed
+ * (() => {
+ *   window["_0123456"]({
+ *     ciphertext: [12, 13, 4],
+ *     tag: [3, 5, 67, 56]
+ *   })
+ * })()
+ * ```
+ * @implements {MessagingTransport}
+ */
+class WebkitMessagingTransport {
+  /** @type {WebkitMessagingConfig} */
+
+  /**
+   * @param {WebkitMessagingConfig} config
+   */
+  constructor(config) {
+    _defineProperty(this, "config", void 0);
+
+    _defineProperty(this, "globals", void 0);
+
+    _defineProperty(this, "algoObj", {
+      name: 'AES-GCM',
+      length: 256
+    });
+
+    this.config = config;
+    this.globals = captureGlobals();
+
+    if (!this.config.hasModernWebkitAPI) {
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
+    }
+  }
+  /**
+   * Sends message to the webkit layer (fire and forget)
+   * @param {String} handler
+   * @param {*} data
+   * @internal
+   */
+
+
+  wkSend(handler) {
+    var _this$globals$window$, _this$globals$window$2;
+
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    if (!(handler in this.globals.window.webkit.messageHandlers)) {
+      throw new _messaging.MissingHandler("Missing webkit handler: '".concat(handler, "'"), handler);
+    }
+
+    const outgoing = { ...data,
+      messageHandling: { ...data.messageHandling,
+        secret: this.config.secret
+      }
+    };
+
+    if (!this.config.hasModernWebkitAPI) {
+      if (!(handler in this.globals.capturedWebkitHandlers)) {
+        throw new _messaging.MissingHandler("cannot continue, method ".concat(handler, " not captured on macos < 11"), handler);
+      } else {
+        return this.globals.capturedWebkitHandlers[handler](outgoing);
+      }
+    }
+
+    return (_this$globals$window$ = (_this$globals$window$2 = this.globals.window.webkit.messageHandlers[handler]).postMessage) === null || _this$globals$window$ === void 0 ? void 0 : _this$globals$window$.call(_this$globals$window$2, outgoing);
+  }
+  /**
+   * Sends message to the webkit layer and waits for the specified response
+   * @param {String} handler
+   * @param {*} data
+   * @returns {Promise<*>}
+   * @internal
+   */
+
+
+  async wkSendAndWait(handler) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    if (this.config.hasModernWebkitAPI) {
+      const response = await this.wkSend(handler, data);
+      return this.globals.JSONparse(response || '{}');
+    }
+
+    try {
+      const randMethodName = this.createRandMethodName();
+      const key = await this.createRandKey();
+      const iv = this.createRandIv();
+      const {
+        ciphertext,
+        tag
+      } = await new this.globals.Promise((
+      /** @type {any} */
+      resolve) => {
+        this.generateRandomMethod(randMethodName, resolve);
+        data.messageHandling = new SecureMessagingParams({
+          methodName: randMethodName,
+          secret: this.config.secret,
+          key: this.globals.Arrayfrom(key),
+          iv: this.globals.Arrayfrom(iv)
+        });
+        this.wkSend(handler, data);
+      });
+      const cipher = new this.globals.Uint8Array([...ciphertext, ...tag]);
+      const decrypted = await this.decrypt(cipher, key, iv);
+      return this.globals.JSONparse(decrypted || '{}');
+    } catch (e) {
+      // re-throw when the error is just a 'MissingHandler'
+      if (e instanceof _messaging.MissingHandler) {
+        throw e;
+      } else {
+        console.error('decryption failed', e);
+        console.error(e);
+        return {
+          error: e
+        };
+      }
+    }
+  }
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+
+
+  notify(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    this.wkSend(name, data);
+  }
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+
+  request(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    return this.wkSendAndWait(name, data);
+  }
+  /**
+   * Generate a random method name and adds it to the global scope
+   * The native layer will use this method to send the response
+   * @param {string | number} randomMethodName
+   * @param {Function} callback
+   */
+
+
+  generateRandomMethod(randomMethodName, callback) {
+    var _this = this;
+
+    this.globals.ObjectDefineProperty(this.globals.window, randomMethodName, {
+      enumerable: false,
+      // configurable, To allow for deletion later
+      configurable: true,
+      writable: false,
+
+      /**
+       * @param {any[]} args
+       */
+      value: function () {
+        callback(...arguments); // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
+
+        delete _this.globals.window[randomMethodName];
+      }
+    });
+  }
+
+  randomString() {
+    return '' + this.globals.getRandomValues(new this.globals.Uint32Array(1))[0];
+  }
+
+  createRandMethodName() {
+    return '_' + this.randomString();
+  }
+  /**
+   * @type {{name: string, length: number}}
+   */
+
+
+  /**
+   * @returns {Promise<Uint8Array>}
+   */
+  async createRandKey() {
+    const key = await this.globals.generateKey(this.algoObj, true, ['encrypt', 'decrypt']);
+    const exportedKey = await this.globals.exportKey('raw', key);
+    return new this.globals.Uint8Array(exportedKey);
+  }
+  /**
+   * @returns {Uint8Array}
+   */
+
+
+  createRandIv() {
+    return this.globals.getRandomValues(new this.globals.Uint8Array(12));
+  }
+  /**
+   * @param {BufferSource} ciphertext
+   * @param {BufferSource} key
+   * @param {Uint8Array} iv
+   * @returns {Promise<string>}
+   */
+
+
+  async decrypt(ciphertext, key, iv) {
+    const cryptoKey = await this.globals.importKey('raw', key, 'AES-GCM', false, ['decrypt']);
+    const algo = {
+      name: 'AES-GCM',
+      iv
+    };
+    let decrypted = await this.globals.decrypt(algo, cryptoKey, ciphertext);
+    let dec = new this.globals.TextDecoder();
+    return dec.decode(decrypted);
+  }
+  /**
+   * When required (such as on macos 10.x), capture the `postMessage` method on
+   * each webkit messageHandler
+   *
+   * @param {string[]} handlerNames
+   */
+
+
+  captureWebkitHandlers(handlerNames) {
+    const handlers = window.webkit.messageHandlers;
+    if (!handlers) throw new _messaging.MissingHandler('window.webkit.messageHandlers was absent', 'all');
+
+    for (let webkitMessageHandlerName of handlerNames) {
+      var _handlers$webkitMessa;
+
+      if (typeof ((_handlers$webkitMessa = handlers[webkitMessageHandlerName]) === null || _handlers$webkitMessa === void 0 ? void 0 : _handlers$webkitMessa.postMessage) === 'function') {
+        var _handlers$webkitMessa2;
+
+        /**
+         * `bind` is used here to ensure future calls to the captured
+         * `postMessage` have the correct `this` context
+         */
+        const original = handlers[webkitMessageHandlerName];
+        const bound = (_handlers$webkitMessa2 = handlers[webkitMessageHandlerName].postMessage) === null || _handlers$webkitMessa2 === void 0 ? void 0 : _handlers$webkitMessa2.bind(original);
+        this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
+        delete handlers[webkitMessageHandlerName].postMessage;
+      }
+    }
+  }
+
+}
+/**
+ * Use this configuration to create an instance of {@link Messaging} for WebKit
+ *
+ * ```js
+ * import { fromConfig, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * const config = new WebkitMessagingConfig({
+ *   hasModernWebkitAPI: true,
+ *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
+ *   secret: "dax",
+ * });
+ *
+ * const messaging = new Messaging(config)
+ * const resp = await messaging.request("debugConfig")
+ * ```
+ */
+
+
+exports.WebkitMessagingTransport = WebkitMessagingTransport;
+
+class WebkitMessagingConfig {
+  /**
+   * @param {object} params
+   * @param {boolean} params.hasModernWebkitAPI
+   * @param {string[]} params.webkitMessageHandlerNames
+   * @param {string} params.secret
+   */
+  constructor(params) {
+    /**
+     * Whether or not the current WebKit Platform supports secure messaging
+     * by default (eg: macOS 11+)
+     */
+    this.hasModernWebkitAPI = params.hasModernWebkitAPI;
+    /**
+     * A list of WebKit message handler names that a user script can send
+     */
+
+    this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
+    /**
+     * A string provided by native platforms to be sent with future outgoing
+     * messages
+     */
+
+    this.secret = params.secret;
+  }
+
+}
+/**
+ * This is the additional payload that gets appended to outgoing messages.
+ * It's used in the Swift side to encrypt the response that comes back
+ */
+
+
+exports.WebkitMessagingConfig = WebkitMessagingConfig;
+
+class SecureMessagingParams {
+  /**
+   * @param {object} params
+   * @param {string} params.methodName
+   * @param {string} params.secret
+   * @param {number[]} params.key
+   * @param {number[]} params.iv
+   */
+  constructor(params) {
+    /**
+     * The method that's been appended to `window` to be called later
+     */
+    this.methodName = params.methodName;
+    /**
+     * The secret used to ensure message sender validity
+     */
+
+    this.secret = params.secret;
+    /**
+     * The CipherKey as number[]
+     */
+
+    this.key = params.key;
+    /**
+     * The Initial Vector as number[]
+     */
+
+    this.iv = params.iv;
+  }
+
+}
+/**
+ * Capture some globals used for messaging handling to prevent page
+ * scripts from tampering with this
+ */
+
+
+exports.SecureMessagingParams = SecureMessagingParams;
+
+function captureGlobals() {
+  // Creat base with null prototype
+  return {
+    window,
+    // Methods must be bound to their interface, otherwise they throw Illegal invocation
+    encrypt: window.crypto.subtle.encrypt.bind(window.crypto.subtle),
+    decrypt: window.crypto.subtle.decrypt.bind(window.crypto.subtle),
+    generateKey: window.crypto.subtle.generateKey.bind(window.crypto.subtle),
+    exportKey: window.crypto.subtle.exportKey.bind(window.crypto.subtle),
+    importKey: window.crypto.subtle.importKey.bind(window.crypto.subtle),
+    getRandomValues: window.crypto.getRandomValues.bind(window.crypto),
+    TextEncoder,
+    TextDecoder,
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    JSONstringify: window.JSON.stringify,
+    JSONparse: window.JSON.parse,
+    Arrayfrom: window.Array.from,
+    Promise: window.Promise,
+    ObjectDefineProperty: window.Object.defineProperty,
+    addEventListener: window.addEventListener.bind(window),
+
+    /** @type {Record<string, any>} */
+    capturedWebkitHandlers: {}
+  };
+}
+
+},{"./messaging.js":13}],15:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -5035,7 +4934,7 @@ function _safeHostname(inputHostname) {
   }
 }
 
-},{"./lib/apple.password.js":18,"./lib/constants.js":19,"./lib/rules-parser.js":20}],18:[function(require,module,exports){
+},{"./lib/apple.password.js":16,"./lib/constants.js":17,"./lib/rules-parser.js":18}],16:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -5659,7 +5558,7 @@ exports.Password = Password;
 
 _defineProperty(Password, "defaults", defaults);
 
-},{"./constants.js":19,"./rules-parser.js":20}],19:[function(require,module,exports){
+},{"./constants.js":17,"./rules-parser.js":18}],17:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -5680,7 +5579,7 @@ const constants = {
 };
 exports.constants = constants;
 
-},{}],20:[function(require,module,exports){
+},{}],18:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -6413,7 +6312,7 @@ function parsePasswordRules(input, formatRulesForMinifiedVersion) {
   return newPasswordRules;
 }
 
-},{}],21:[function(require,module,exports){
+},{}],19:[function(require,module,exports){
 module.exports={
   "163.com": {
     "password-rules": "minlength: 6; maxlength: 16;"
@@ -7244,7 +7143,7 @@ module.exports={
     "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
   }
 }
-},{}],22:[function(require,module,exports){
+},{}],20:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7317,7 +7216,7 @@ function createDevice() {
   return new _ExtensionInterface.ExtensionInterface(globalConfig, deviceApi, settings);
 }
 
-},{"../packages/device-api/index.js":14,"./DeviceInterface/AndroidInterface.js":23,"./DeviceInterface/AppleDeviceInterface.js":24,"./DeviceInterface/AppleOverlayDeviceInterface.js":25,"./DeviceInterface/ExtensionInterface.js":26,"./DeviceInterface/WindowsInterface.js":28,"./DeviceInterface/WindowsOverlayDeviceInterface.js":29,"./Settings.js":50,"./config.js":63,"./deviceApiCalls/transports/transports.js":71}],23:[function(require,module,exports){
+},{"../packages/device-api/index.js":10,"./DeviceInterface/AndroidInterface.js":21,"./DeviceInterface/AppleDeviceInterface.js":22,"./DeviceInterface/AppleOverlayDeviceInterface.js":23,"./DeviceInterface/ExtensionInterface.js":24,"./DeviceInterface/WindowsInterface.js":26,"./DeviceInterface/WindowsOverlayDeviceInterface.js":27,"./Settings.js":48,"./config.js":61,"./deviceApiCalls/transports/transports.js":69}],21:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7467,7 +7366,7 @@ class AndroidInterface extends _InterfacePrototype.default {
 
 exports.AndroidInterface = AndroidInterface;
 
-},{"../UI/controllers/NativeUIController.js":56,"../autofill-utils.js":61,"./InterfacePrototype.js":27,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],24:[function(require,module,exports){
+},{"../UI/controllers/NativeUIController.js":54,"../autofill-utils.js":59,"./InterfacePrototype.js":25,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],22:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7919,7 +7818,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
 
 exports.AppleDeviceInterface = AppleDeviceInterface;
 
-},{"../../packages/device-api/index.js":14,"../Form/matching.js":43,"../InContextSignup.js":44,"../UI/HTMLTooltip.js":54,"../UI/controllers/HTMLTooltipUIController.js":55,"../UI/controllers/NativeUIController.js":56,"../UI/controllers/OverlayUIController.js":57,"../autofill-utils.js":61,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"../deviceApiCalls/additionalDeviceApiCalls.js":67,"./InterfacePrototype.js":27,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],25:[function(require,module,exports){
+},{"../../packages/device-api/index.js":10,"../Form/matching.js":41,"../InContextSignup.js":42,"../UI/HTMLTooltip.js":52,"../UI/controllers/HTMLTooltipUIController.js":53,"../UI/controllers/NativeUIController.js":54,"../UI/controllers/OverlayUIController.js":55,"../autofill-utils.js":59,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"../deviceApiCalls/additionalDeviceApiCalls.js":65,"./InterfacePrototype.js":25,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],23:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -8074,7 +7973,7 @@ class AppleOverlayDeviceInterface extends _AppleDeviceInterface.AppleDeviceInter
 
 exports.AppleOverlayDeviceInterface = AppleOverlayDeviceInterface;
 
-},{"../../packages/device-api/index.js":14,"../UI/controllers/HTMLTooltipUIController.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"../deviceApiCalls/__generated__/validators.zod.js":66,"./AppleDeviceInterface.js":24,"./overlayApi.js":31}],26:[function(require,module,exports){
+},{"../../packages/device-api/index.js":10,"../UI/controllers/HTMLTooltipUIController.js":53,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"../deviceApiCalls/__generated__/validators.zod.js":64,"./AppleDeviceInterface.js":22,"./overlayApi.js":29}],24:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -8352,7 +8251,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
 exports.ExtensionInterface = ExtensionInterface;
 
-},{"../Form/matching.js":43,"../InContextSignup.js":44,"../UI/HTMLTooltip.js":54,"../UI/controllers/HTMLTooltipUIController.js":55,"../autofill-utils.js":61,"./InterfacePrototype.js":27}],27:[function(require,module,exports){
+},{"../Form/matching.js":41,"../InContextSignup.js":42,"../UI/HTMLTooltip.js":52,"../UI/controllers/HTMLTooltipUIController.js":53,"../autofill-utils.js":59,"./InterfacePrototype.js":25}],25:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9421,7 +9320,7 @@ class InterfacePrototype {
 var _default = InterfacePrototype;
 exports.default = _default;
 
-},{"../../packages/device-api/index.js":14,"../EmailProtection.js":32,"../Form/formatters.js":36,"../Form/matching.js":43,"../InputTypes/Credentials.js":45,"../PasswordGenerator.js":48,"../Scanner.js":49,"../Settings.js":50,"../UI/controllers/NativeUIController.js":56,"../autofill-utils.js":61,"../config.js":63,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"../deviceApiCalls/__generated__/validators.zod.js":66,"../deviceApiCalls/transports/transports.js":71,"./initFormSubmissionsApi.js":30}],28:[function(require,module,exports){
+},{"../../packages/device-api/index.js":10,"../EmailProtection.js":30,"../Form/formatters.js":34,"../Form/matching.js":41,"../InputTypes/Credentials.js":43,"../PasswordGenerator.js":46,"../Scanner.js":47,"../Settings.js":48,"../UI/controllers/NativeUIController.js":54,"../autofill-utils.js":59,"../config.js":61,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"../deviceApiCalls/__generated__/validators.zod.js":64,"../deviceApiCalls/transports/transports.js":69,"./initFormSubmissionsApi.js":28}],26:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9637,7 +9536,7 @@ class WindowsInterface extends _InterfacePrototype.default {
 
 exports.WindowsInterface = WindowsInterface;
 
-},{"../UI/controllers/OverlayUIController.js":57,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"./InterfacePrototype.js":27}],29:[function(require,module,exports){
+},{"../UI/controllers/OverlayUIController.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"./InterfacePrototype.js":25}],27:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9846,7 +9745,7 @@ class WindowsOverlayDeviceInterface extends _InterfacePrototype.default {
 
 exports.WindowsOverlayDeviceInterface = WindowsOverlayDeviceInterface;
 
-},{"../UI/controllers/HTMLTooltipUIController.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"./InterfacePrototype.js":27,"./overlayApi.js":31}],30:[function(require,module,exports){
+},{"../UI/controllers/HTMLTooltipUIController.js":53,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"./InterfacePrototype.js":25,"./overlayApi.js":29}],28:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9952,7 +9851,7 @@ function initFormSubmissionsApi(forms, matching) {
   });
 }
 
-},{"../Form/label-util.js":39,"../autofill-utils.js":61}],31:[function(require,module,exports){
+},{"../Form/label-util.js":37,"../autofill-utils.js":59}],29:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -10019,7 +9918,7 @@ function overlayApi(device) {
   };
 }
 
-},{"../deviceApiCalls/__generated__/deviceApiCalls.js":65}],32:[function(require,module,exports){
+},{"../deviceApiCalls/__generated__/deviceApiCalls.js":63}],30:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -10080,7 +9979,7 @@ class EmailProtection {
 
 exports.EmailProtection = EmailProtection;
 
-},{}],33:[function(require,module,exports){
+},{}],31:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11000,7 +10899,7 @@ class Form {
 
 exports.Form = Form;
 
-},{"../autofill-utils.js":61,"../constants.js":64,"./FormAnalyzer.js":34,"./formatters.js":36,"./inputStyles.js":37,"./inputTypeConfig.js":38,"./matching.js":43}],34:[function(require,module,exports){
+},{"../autofill-utils.js":59,"../constants.js":62,"./FormAnalyzer.js":32,"./formatters.js":34,"./inputStyles.js":35,"./inputTypeConfig.js":36,"./matching.js":41}],32:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11394,7 +11293,7 @@ class FormAnalyzer {
 var _default = FormAnalyzer;
 exports.default = _default;
 
-},{"../autofill-utils.js":61,"../constants.js":64,"./matching-config/__generated__/compiled-matching-config.js":41,"./matching.js":43}],35:[function(require,module,exports){
+},{"../autofill-utils.js":59,"../constants.js":62,"./matching-config/__generated__/compiled-matching-config.js":39,"./matching.js":41}],33:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11962,7 +11861,7 @@ const COUNTRY_NAMES_TO_CODES = {
 };
 exports.COUNTRY_NAMES_TO_CODES = COUNTRY_NAMES_TO_CODES;
 
-},{}],36:[function(require,module,exports){
+},{}],34:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12319,7 +12218,7 @@ const prepareFormValuesForStorage = formValues => {
 
 exports.prepareFormValuesForStorage = prepareFormValuesForStorage;
 
-},{"./countryNames.js":35,"./matching.js":43}],37:[function(require,module,exports){
+},{"./countryNames.js":33,"./matching.js":41}],35:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12421,7 +12320,7 @@ const getIconStylesAutofilled = (input, form) => {
 
 exports.getIconStylesAutofilled = getIconStylesAutofilled;
 
-},{"./inputTypeConfig.js":38}],38:[function(require,module,exports){
+},{"./inputTypeConfig.js":36}],36:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12701,7 +12600,7 @@ const isFieldDecorated = input => {
 
 exports.isFieldDecorated = isFieldDecorated;
 
-},{"../InputTypes/Credentials.js":45,"../InputTypes/CreditCard.js":46,"../InputTypes/Identity.js":47,"../UI/img/ddgPasswordIcon.js":59,"../constants.js":64,"./logo-svg.js":40,"./matching.js":43}],39:[function(require,module,exports){
+},{"../InputTypes/Credentials.js":43,"../InputTypes/CreditCard.js":44,"../InputTypes/Identity.js":45,"../UI/img/ddgPasswordIcon.js":57,"../constants.js":62,"./logo-svg.js":38,"./matching.js":41}],37:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12762,7 +12661,7 @@ const extractElementStrings = element => {
 
 exports.extractElementStrings = extractElementStrings;
 
-},{"./matching.js":43}],40:[function(require,module,exports){
+},{"./matching.js":41}],38:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12776,7 +12675,7 @@ const daxGrayscaleSvg = "\n<svg width=\"128\" height=\"128\" viewBox=\"0 0 128 1
 const daxGrayscaleBase64 = "data:image/svg+xml;base64,".concat(window.btoa(daxGrayscaleSvg));
 exports.daxGrayscaleBase64 = daxGrayscaleBase64;
 
-},{}],41:[function(require,module,exports){
+},{}],39:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -13224,7 +13123,7 @@ const matchingConfiguration = {
 };
 exports.matchingConfiguration = matchingConfiguration;
 
-},{}],42:[function(require,module,exports){
+},{}],40:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -13307,7 +13206,7 @@ function logUnmatched(el, allStrings) {
   console.groupEnd();
 }
 
-},{"../autofill-utils.js":61,"./matching.js":43}],43:[function(require,module,exports){
+},{"../autofill-utils.js":59,"./matching.js":41}],41:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14394,7 +14293,7 @@ function createMatching() {
   return new Matching(_compiledMatchingConfig.matchingConfiguration);
 }
 
-},{"../autofill-utils.js":61,"../constants.js":64,"./label-util.js":39,"./matching-config/__generated__/compiled-matching-config.js":41,"./matching-utils.js":42}],44:[function(require,module,exports){
+},{"../autofill-utils.js":59,"../constants.js":62,"./label-util.js":37,"./matching-config/__generated__/compiled-matching-config.js":39,"./matching-utils.js":40}],42:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14547,7 +14446,7 @@ class InContextSignup {
 
 exports.InContextSignup = InContextSignup;
 
-},{"./autofill-utils.js":61,"./deviceApiCalls/__generated__/deviceApiCalls.js":65}],45:[function(require,module,exports){
+},{"./autofill-utils.js":59,"./deviceApiCalls/__generated__/deviceApiCalls.js":63}],43:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14763,7 +14662,7 @@ function createCredentialsTooltipItem(data) {
   return new CredentialsTooltipItem(data);
 }
 
-},{"../autofill-utils.js":61}],46:[function(require,module,exports){
+},{"../autofill-utils.js":59}],44:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14815,7 +14714,7 @@ class CreditCardTooltipItem {
 
 exports.CreditCardTooltipItem = CreditCardTooltipItem;
 
-},{}],47:[function(require,module,exports){
+},{}],45:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14889,7 +14788,7 @@ class IdentityTooltipItem {
 
 exports.IdentityTooltipItem = IdentityTooltipItem;
 
-},{"../Form/formatters.js":36}],48:[function(require,module,exports){
+},{"../Form/formatters.js":34}],46:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14961,7 +14860,7 @@ class PasswordGenerator {
 
 exports.PasswordGenerator = PasswordGenerator;
 
-},{"../packages/password/index.js":17,"../packages/password/rules.json":21}],49:[function(require,module,exports){
+},{"../packages/password/index.js":15,"../packages/password/rules.json":19}],47:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15397,7 +15296,7 @@ function createScanner(device, scannerOptions) {
   });
 }
 
-},{"./Form/Form.js":33,"./Form/matching.js":43,"./autofill-utils.js":61,"./constants.js":64,"./deviceApiCalls/__generated__/deviceApiCalls.js":65}],50:[function(require,module,exports){
+},{"./Form/Form.js":31,"./Form/matching.js":41,"./autofill-utils.js":59,"./constants.js":62,"./deviceApiCalls/__generated__/deviceApiCalls.js":63}],48:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15802,7 +15701,7 @@ _defineProperty(Settings, "defaults", {
   enabled: null
 });
 
-},{"../packages/device-api/index.js":14,"./autofill-utils.js":61,"./deviceApiCalls/__generated__/deviceApiCalls.js":65,"./deviceApiCalls/__generated__/validators.zod.js":66,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],51:[function(require,module,exports){
+},{"../packages/device-api/index.js":10,"./autofill-utils.js":59,"./deviceApiCalls/__generated__/deviceApiCalls.js":63,"./deviceApiCalls/__generated__/validators.zod.js":64,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],49:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15911,7 +15810,7 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
 var _default = DataHTMLTooltip;
 exports.default = _default;
 
-},{"../InputTypes/Credentials.js":45,"../autofill-utils.js":61,"./HTMLTooltip.js":54}],52:[function(require,module,exports){
+},{"../InputTypes/Credentials.js":43,"../autofill-utils.js":59,"./HTMLTooltip.js":52}],50:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15985,7 +15884,7 @@ class EmailHTMLTooltip extends _HTMLTooltip.default {
 var _default = EmailHTMLTooltip;
 exports.default = _default;
 
-},{"../autofill-utils.js":61,"./HTMLTooltip.js":54}],53:[function(require,module,exports){
+},{"../autofill-utils.js":59,"./HTMLTooltip.js":52}],51:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -16032,7 +15931,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
 var _default = EmailSignupHTMLTooltip;
 exports.default = _default;
 
-},{"./HTMLTooltip.js":54}],54:[function(require,module,exports){
+},{"./HTMLTooltip.js":52}],52:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -16474,7 +16373,7 @@ exports.HTMLTooltip = HTMLTooltip;
 var _default = HTMLTooltip;
 exports.default = _default;
 
-},{"../Form/matching.js":43,"../autofill-utils.js":61,"./styles/styles.js":60}],55:[function(require,module,exports){
+},{"../Form/matching.js":41,"../autofill-utils.js":59,"./styles/styles.js":58}],53:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -16888,7 +16787,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
 exports.HTMLTooltipUIController = HTMLTooltipUIController;
 
-},{"../../Form/inputTypeConfig.js":38,"../../Form/matching.js":43,"../../autofill-utils.js":61,"../DataHTMLTooltip.js":51,"../EmailHTMLTooltip.js":52,"../EmailSignupHTMLTooltip.js":53,"../HTMLTooltip.js":54,"./UIController.js":58}],56:[function(require,module,exports){
+},{"../../Form/inputTypeConfig.js":36,"../../Form/matching.js":41,"../../autofill-utils.js":59,"../DataHTMLTooltip.js":49,"../EmailHTMLTooltip.js":50,"../EmailSignupHTMLTooltip.js":51,"../HTMLTooltip.js":52,"./UIController.js":56}],54:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17091,7 +16990,7 @@ class NativeUIController extends _UIController.UIController {
 
 exports.NativeUIController = NativeUIController;
 
-},{"../../Form/matching.js":43,"../../InputTypes/Credentials.js":45,"../../deviceApiCalls/__generated__/deviceApiCalls.js":65,"./UIController.js":58}],57:[function(require,module,exports){
+},{"../../Form/matching.js":41,"../../InputTypes/Credentials.js":43,"../../deviceApiCalls/__generated__/deviceApiCalls.js":63,"./UIController.js":56}],55:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17392,7 +17291,7 @@ class OverlayUIController extends _UIController.UIController {
 
 exports.OverlayUIController = OverlayUIController;
 
-},{"../../Form/matching.js":43,"./UIController.js":58}],58:[function(require,module,exports){
+},{"../../Form/matching.js":41,"./UIController.js":56}],56:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17488,7 +17387,7 @@ class UIController {
 
 exports.UIController = UIController;
 
-},{}],59:[function(require,module,exports){
+},{}],57:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17510,7 +17409,7 @@ exports.ddgCcIconFilled = ddgCcIconFilled;
 const ddgIdentityIconBase = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4KPHBhdGggeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiBmaWxsPSJub25lIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMiAyMWMyLjE0MyAwIDQuMTExLS43NSA1LjY1Ny0yLS42MjYtLjUwNi0xLjMxOC0uOTI3LTIuMDYtMS4yNS0xLjEtLjQ4LTIuMjg1LS43MzUtMy40ODYtLjc1LTEuMi0uMDE0LTIuMzkyLjIxMS0zLjUwNC42NjQtLjgxNy4zMzMtMS41OC43ODMtMi4yNjQgMS4zMzYgMS41NDYgMS4yNSAzLjUxNCAyIDUuNjU3IDJ6bTQuMzk3LTUuMDgzYy45NjcuNDIyIDEuODY2Ljk4IDIuNjcyIDEuNjU1QzIwLjI3OSAxNi4wMzkgMjEgMTQuMTA0IDIxIDEyYzAtNC45Ny00LjAzLTktOS05cy05IDQuMDMtOSA5YzAgMi4xMDQuNzIyIDQuMDQgMS45MzIgNS41NzIuODc0LS43MzQgMS44Ni0xLjMyOCAyLjkyMS0xLjc2IDEuMzYtLjU1NCAyLjgxNi0uODMgNC4yODMtLjgxMSAxLjQ2Ny4wMTggMi45MTYuMzMgNC4yNi45MTZ6TTEyIDIzYzYuMDc1IDAgMTEtNC45MjUgMTEtMTFTMTguMDc1IDEgMTIgMSAxIDUuOTI1IDEgMTJzNC45MjUgMTEgMTEgMTF6bTMtMTNjMCAxLjY1Ny0xLjM0MyAzLTMgM3MtMy0xLjM0My0zLTMgMS4zNDMtMyAzLTMgMyAxLjM0MyAzIDN6bTIgMGMwIDIuNzYxLTIuMjM5IDUtNSA1cy01LTIuMjM5LTUtNSAyLjIzOS01IDUtNSA1IDIuMjM5IDUgNXoiIGZpbGw9IiMwMDAiLz4KPC9zdmc+Cg==";
 exports.ddgIdentityIconBase = ddgIdentityIconBase;
 
-},{}],60:[function(require,module,exports){
+},{}],58:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17520,7 +17419,7 @@ exports.CSS_STYLES = void 0;
 const CSS_STYLES = ":root {\n    color-scheme: light dark;\n}\n\n.wrapper *, .wrapper *::before, .wrapper *::after {\n    box-sizing: border-box;\n}\n.wrapper {\n    position: fixed;\n    top: 0;\n    left: 0;\n    padding: 0;\n    font-family: 'DDG_ProximaNova', 'Proxima Nova', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n    -webkit-font-smoothing: antialiased;\n    z-index: 2147483647;\n}\n.wrapper--data {\n    font-family: 'SF Pro Text', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n}\n:not(.top-autofill) .tooltip {\n    position: absolute;\n    width: 300px;\n    max-width: calc(100vw - 25px);\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--data, #topAutofill {\n    background-color: rgba(242, 240, 240, 1);\n    -webkit-backdrop-filter: blur(40px);\n    backdrop-filter: blur(40px);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data, #topAutofill {\n        background: rgb(100, 98, 102, .9);\n    }\n}\n.tooltip--data {\n    padding: 6px;\n    font-size: 13px;\n    line-height: 14px;\n    width: 315px;\n    max-height: 290px;\n    overflow-y: auto;\n}\n.top-autofill .tooltip--data {\n    min-height: 100vh;\n}\n.tooltip--data.tooltip--incontext-signup {\n    width: 360px;\n}\n:not(.top-autofill) .tooltip--data {\n    top: 100%;\n    left: 100%;\n    border: 0.5px solid rgba(255, 255, 255, 0.2);\n    border-radius: 6px;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.32);\n}\n@media (prefers-color-scheme: dark) {\n    :not(.top-autofill) .tooltip--data {\n        border: 1px solid rgba(255, 255, 255, 0.2);\n    }\n}\n:not(.top-autofill) .tooltip--email {\n    top: calc(100% + 6px);\n    right: calc(100% - 48px);\n    padding: 8px;\n    border: 1px solid #D0D0D0;\n    border-radius: 10px;\n    background-color: #FFFFFF;\n    font-size: 14px;\n    line-height: 1.3;\n    color: #333333;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);\n}\n.tooltip--email__caret {\n    position: absolute;\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--email__caret::before,\n.tooltip--email__caret::after {\n    content: \"\";\n    width: 0;\n    height: 0;\n    border-left: 10px solid transparent;\n    border-right: 10px solid transparent;\n    display: block;\n    border-bottom: 8px solid #D0D0D0;\n    position: absolute;\n    right: -28px;\n}\n.tooltip--email__caret::before {\n    border-bottom-color: #D0D0D0;\n    top: -1px;\n}\n.tooltip--email__caret::after {\n    border-bottom-color: #FFFFFF;\n    top: 0px;\n}\n\n/* Buttons */\n.tooltip__button {\n    display: flex;\n    width: 100%;\n    padding: 8px 8px 8px 0px;\n    font-family: inherit;\n    color: inherit;\n    background: transparent;\n    border: none;\n    border-radius: 6px;\n}\n.tooltip__button.currentFocus,\n.wrapper:not(.top-autofill) .tooltip__button:hover {\n    background-color: #3969EF;\n    color: #FFFFFF;\n}\n\n/* Data autofill tooltip specific */\n.tooltip__button--data {\n    position: relative;\n    min-height: 48px;\n    flex-direction: row;\n    justify-content: flex-start;\n    font-size: inherit;\n    font-weight: 500;\n    line-height: 16px;\n    text-align: left;\n    border-radius: 3px;\n}\n.tooltip--data__item-container {\n    max-height: 220px;\n    overflow: auto;\n}\n.tooltip__button--data:first-child {\n    margin-top: 0;\n}\n.tooltip__button--data:last-child {\n    margin-bottom: 0;\n}\n.tooltip__button--data::before {\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 20px 20px;\n    background-repeat: no-repeat;\n    background-position: center 6px;\n}\n#provider_locked::after {\n    position: absolute;\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 11px 13px;\n    background-repeat: no-repeat;\n    background-position: right bottom;\n}\n.tooltip__button--data.currentFocus:not(.tooltip__button--data--bitwarden)::before,\n.wrapper:not(.top-autofill) .tooltip__button--data:not(.tooltip__button--data--bitwarden):hover::before {\n    filter: invert(100%);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before,\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before {\n        filter: invert(100%);\n        opacity: .9;\n    }\n}\n.tooltip__button__text-container {\n    margin: auto 0;\n}\n.label {\n    display: block;\n    font-weight: 400;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.8);\n    font-size: 13px;\n    line-height: 1;\n}\n.label + .label {\n    margin-top: 2px;\n}\n.label.label--medium {\n    font-weight: 500;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.9);\n}\n.label.label--small {\n    font-size: 11px;\n    font-weight: 400;\n    letter-spacing: 0.06px;\n    color: rgba(0,0,0,0.6);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data .label {\n        color: #ffffff;\n    }\n    .tooltip--data .label--medium {\n        color: #ffffff;\n    }\n    .tooltip--data .label--small {\n        color: #cdcdcd;\n    }\n}\n.tooltip__button.currentFocus .label,\n.wrapper:not(.top-autofill) .tooltip__button:hover .label {\n    color: #FFFFFF;\n}\n\n.tooltip__button--manage {\n    font-size: 13px;\n    padding: 5px 9px;\n    border-radius: 3px;\n    margin: 0;\n}\n\n/* Icons */\n.tooltip__button--data--credentials::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik05LjYzNiA4LjY4MkM5LjYzNiA1LjU0NCAxMi4xOCAzIDE1LjMxOCAzIDE4LjQ1NiAzIDIxIDUuNTQ0IDIxIDguNjgyYzAgMy4xMzgtMi41NDQgNS42ODItNS42ODIgNS42ODItLjY5MiAwLTEuMzUzLS4xMjQtMS45NjQtLjM0OS0uMzcyLS4xMzctLjc5LS4wNDEtMS4wNjYuMjQ1bC0uNzEzLjc0SDEwYy0uNTUyIDAtMSAuNDQ4LTEgMXYySDdjLS41NTIgMC0xIC40NDgtMSAxdjJIM3YtMi44ODFsNi42NjgtNi42NjhjLjI2NS0uMjY2LjM2LS42NTguMjQ0LTEuMDE1LS4xNzktLjU1MS0uMjc2LTEuMTQtLjI3Ni0xLjc1NHpNMTUuMzE4IDFjLTQuMjQyIDAtNy42ODIgMy40NC03LjY4MiA3LjY4MiAwIC42MDcuMDcxIDEuMi4yMDUgMS43NjdsLTYuNTQ4IDYuNTQ4Yy0uMTg4LjE4OC0uMjkzLjQ0Mi0uMjkzLjcwOFYyMmMwIC4yNjUuMTA1LjUyLjI5My43MDcuMTg3LjE4OC40NDIuMjkzLjcwNy4yOTNoNGMxLjEwNSAwIDItLjg5NSAyLTJ2LTFoMWMxLjEwNSAwIDItLjg5NSAyLTJ2LTFoMWMuMjcyIDAgLjUzMi0uMTEuNzItLjMwNmwuNTc3LS42Yy42NDUuMTc2IDEuMzIzLjI3IDIuMDIxLjI3IDQuMjQzIDAgNy42ODItMy40NCA3LjY4Mi03LjY4MkMyMyA0LjQzOSAxOS41NiAxIDE1LjMxOCAxek0xNSA4YzAtLjU1Mi40NDgtMSAxLTFzMSAuNDQ4IDEgMS0uNDQ4IDEtMSAxLTEtLjQ0OC0xLTF6bTEtM2MtMS42NTcgMC0zIDEuMzQzLTMgM3MxLjM0MyAzIDMgMyAzLTEuMzQzIDMtMy0xLjM0My0zLTMtM3oiIGZpbGw9IiMwMDAiIGZpbGwtb3BhY2l0eT0iLjkiLz4KPC9zdmc+');\n}\n.tooltip__button--data--creditCards::before {\n    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBkPSJNNSA5Yy0uNTUyIDAtMSAuNDQ4LTEgMXYyYzAgLjU1Mi40NDggMSAxIDFoM2MuNTUyIDAgMS0uNDQ4IDEtMXYtMmMwLS41NTItLjQ0OC0xLTEtMUg1eiIgZmlsbD0iIzAwMCIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xIDZjMC0yLjIxIDEuNzktNCA0LTRoMTRjMi4yMSAwIDQgMS43OSA0IDR2MTJjMCAyLjIxLTEuNzkgNC00IDRINWMtMi4yMSAwLTQtMS43OS00LTRWNnptNC0yYy0xLjEwNSAwLTIgLjg5NS0yIDJ2OWgxOFY2YzAtMS4xMDUtLjg5NS0yLTItMkg1em0wIDE2Yy0xLjEwNSAwLTItLjg5NS0yLTJoMThjMCAxLjEwNS0uODk1IDItMiAySDV6IiBmaWxsPSIjMDAwIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--identities::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4=');\n}\n.tooltip__button--data--credentials.tooltip__button--data--bitwarden::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iOCIgZmlsbD0iIzE3NUREQyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE4LjU2OTYgNS40MzM1NUMxOC41MDg0IDUuMzc0NDIgMTguNDM0NyA1LjMyNzYzIDE4LjM1MzEgNS4yOTYxMUMxOC4yNzE1IDUuMjY0NiAxOC4xODM3IDUuMjQ5MDQgMTguMDk1MyA1LjI1MDQxSDUuOTIxOTFDNS44MzMyNiA1LjI0NzI5IDUuNzQ0OTMgNS4yNjIwNSA1LjY2MzA0IDUuMjkzNjdDNS41ODExNSA1LjMyNTI5IDUuNTA3NjUgNS4zNzMwMiA1LjQ0NzYyIDUuNDMzNTVDNS4zMjE3IDUuNTUwMTMgNS4yNTA2NSA1LjcwODE1IDUuMjUgNS44NzMxVjEzLjM4MjFDNS4yNTMzNiAxMy45NTM1IDUuMzc0MDggMTQuNTE5MSA1LjYwNTcyIDE1LjA0ODdDNS44MTkzMSAxNS41NzI4IDYuMTEyMDcgMTYuMDY2MSA2LjQ3NTI0IDE2LjUxMzlDNi44NDIgMTYuOTY4MyA3LjI1OTI5IDE3LjM4NTcgNy43MjAyNSAxNy43NTkzQzguMTQwNTMgMTguMTI1NiA4LjU4OTcxIDE4LjQ2MjMgOS4wNjQwNyAxOC43NjY2QzkuNDU5MzEgMTkuMDIzIDkuOTEzODMgMTkuMjc5NCAxMC4zNDg2IDE5LjUxNzVDMTAuNzgzNCAxOS43NTU2IDExLjA5OTYgMTkuOTIwNCAxMS4yNzc0IDE5Ljk5MzdDMTEuNDU1MyAyMC4wNjY5IDExLjYxMzQgMjAuMTQwMiAxMS43MTIyIDIwLjE5NTFDMTEuNzk5MiAyMC4yMzEzIDExLjg5MzUgMjAuMjUgMTEuOTg4OCAyMC4yNUMxMi4wODQyIDIwLjI1IDEyLjE3ODUgMjAuMjMxMyAxMi4yNjU1IDIwLjE5NTFDMTIuNDIxMiAyMC4xMzYzIDEyLjU3MjkgMjAuMDY5IDEyLjcyIDE5Ljk5MzdDMTIuNzcxMSAxOS45Njc0IDEyLjgzMzUgMTkuOTM2NiAxMi45MDY5IDE5LjkwMDRDMTMuMDg5MSAxOS44MTA1IDEzLjMzODggMTkuNjg3MiAxMy42NDg5IDE5LjUxNzVDMTQuMDgzNiAxOS4yNzk0IDE0LjUxODQgMTkuMDIzIDE0LjkzMzQgMTguNzY2NkMxNS40MDQgMTguNDU3NyAxNS44NTI4IDE4LjEyMTIgMTYuMjc3MiAxNy43NTkzQzE2LjczMzEgMTcuMzgwOSAxNy4xNDk5IDE2Ljk2NCAxNy41MjIyIDE2LjUxMzlDMTcuODc4IDE2LjA2MTcgMTguMTcwMiAxNS41NjkzIDE4LjM5MTcgMTUuMDQ4N0MxOC42MjM0IDE0LjUxOTEgMTguNzQ0MSAxMy45NTM1IDE4Ljc0NzQgMTMuMzgyMVY1Ljg3MzFDMTguNzU1NyA1Ljc5MjE0IDE4Ljc0MzkgNS43MTA1IDE4LjcxMzEgNS42MzQzNUMxOC42ODIzIDUuNTU4MiAxOC42MzMyIDUuNDg5NTQgMTguNTY5NiA1LjQzMzU1Wk0xNy4wMDg0IDEzLjQ1NTNDMTcuMDA4NCAxNi4xODQyIDEyLjAwODYgMTguNTI4NSAxMi4wMDg2IDE4LjUyODVWNi44NjIwOUgxNy4wMDg0VjEzLjQ1NTNaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K');\n}\n#provider_locked:after {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMSAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEgNy42MDA1N1Y3LjYwMjVWOS41MjI1QzEgMTAuMDgwMSAxLjIyMTUxIDEwLjYxNDkgMS42MTU4MSAxMS4wMDkyQzIuMDEwMSAxMS40MDM1IDIuNTQ0ODggMTEuNjI1IDMuMTAyNSAxMS42MjVINy4yNzI1QzcuNTQ4NjEgMTEuNjI1IDcuODIyMDEgMTEuNTcwNiA4LjA3NzA5IDExLjQ2NUM4LjMzMjE4IDExLjM1OTMgOC41NjM5NiAxMS4yMDQ0IDguNzU5MTkgMTEuMDA5MkM4Ljk1NDQzIDEwLjgxNCA5LjEwOTMgMTAuNTgyMiA5LjIxNDk2IDEwLjMyNzFDOS4zMjA2MiAxMC4wNzIgOS4zNzUgOS43OTg2MSA5LjM3NSA5LjUyMjVMOS4zNzUgNy42MDI1TDkuMzc1IDcuNjAwNTdDOS4zNzQxNSA3LjE2MTMxIDkuMjM1NzQgNi43MzMzNSA4Ljk3OTIyIDYuMzc2NzhDOC44NzY4MyA2LjIzNDQ2IDguNzU3NjggNi4xMDYzNyA4LjYyNSA1Ljk5NDg5VjUuMTg3NUM4LjYyNSA0LjI3NTgyIDguMjYyODQgMy40MDE0OCA3LjYxODE4IDIuNzU2ODJDNi45NzM1MiAyLjExMjE2IDYuMDk5MTggMS43NSA1LjE4NzUgMS43NUM0LjI3NTgyIDEuNzUgMy40MDE0OCAyLjExMjE2IDIuNzU2ODIgMi43NTY4MkMyLjExMjE2IDMuNDAxNDggMS43NSA0LjI3NTgyIDEuNzUgNS4xODc1VjUuOTk0ODlDMS42MTczMiA2LjEwNjM3IDEuNDk4MTcgNi4yMzQ0NiAxLjM5NTc4IDYuMzc2NzhDMS4xMzkyNiA2LjczMzM1IDEuMDAwODUgNy4xNjEzMSAxIDcuNjAwNTdaTTQuOTY4NyA0Ljk2ODdDNS4wMjY5NCA0LjkxMDQ3IDUuMTA1MzIgNC44NzY5OSA1LjE4NzUgNC44NzUwN0M1LjI2OTY4IDQuODc2OTkgNS4zNDgwNiA0LjkxMDQ3IDUuNDA2MyA0Ljk2ODdDNS40NjU0MiA1LjAyNzgzIDUuNDk5MDQgNS4xMDc3NCA1LjUgNS4xOTEzVjUuNUg0Ljg3NVY1LjE5MTNDNC44NzU5NiA1LjEwNzc0IDQuOTA5NTggNS4wMjc4MyA0Ljk2ODcgNC45Njg3WiIgZmlsbD0iIzIyMjIyMiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIi8+Cjwvc3ZnPgo=');\n}\n\nhr {\n    display: block;\n    margin: 5px 9px;\n    border: none; /* reset the border */\n    border-top: 1px solid rgba(0,0,0,.1);\n}\n\nhr:first-child {\n    display: none;\n}\n\n@media (prefers-color-scheme: dark) {\n    hr {\n        border-top: 1px solid rgba(255,255,255,.2);\n    }\n}\n\n#privateAddress {\n    align-items: flex-start;\n}\n#personalAddress::before,\n#privateAddress::before,\n#incontextSignup::before,\n#personalAddress.currentFocus::before,\n#personalAddress:hover::before,\n#privateAddress.currentFocus::before,\n#privateAddress:hover::before {\n    filter: none;\n    /* This is the same icon as `daxBase64` in `src/Form/logo-svg.js` */\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMTI4IDEyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0ibTY0IDEyOGMzNS4zNDYgMCA2NC0yOC42NTQgNjQtNjRzLTI4LjY1NC02NC02NC02NC02NCAyOC42NTQtNjQgNjQgMjguNjU0IDY0IDY0IDY0eiIgZmlsbD0iI2RlNTgzMyIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im03MyAxMTEuNzVjMC0uNS4xMjMtLjYxNC0xLjQ2Ni0zLjc4Mi00LjIyNC04LjQ1OS04LjQ3LTIwLjM4NC02LjU0LTI4LjA3NS4zNTMtMS4zOTctMy45NzgtNTEuNzQ0LTcuMDQtNTMuMzY1LTMuNDAyLTEuODEzLTcuNTg4LTQuNjktMTEuNDE4LTUuMzMtMS45NDMtLjMxLTQuNDktLjE2NC02LjQ4Mi4xMDUtLjM1My4wNDctLjM2OC42ODMtLjAzLjc5OCAxLjMwOC40NDMgMi44OTUgMS4yMTIgMy44MyAyLjM3NS4xNzguMjItLjA2LjU2Ni0uMzQyLjU3Ny0uODgyLjAzMi0yLjQ4Mi40MDItNC41OTMgMi4xOTUtLjI0NC4yMDctLjA0MS41OTIuMjczLjUzIDQuNTM2LS44OTcgOS4xNy0uNDU1IDExLjkgMi4wMjcuMTc3LjE2LjA4NC40NS0uMTQ3LjUxMi0yMy42OTQgNi40NC0xOS4wMDMgMjcuMDUtMTIuNjk2IDUyLjM0NCA1LjYxOSAyMi41MyA3LjczMyAyOS43OTIgOC40IDMyLjAwNGEuNzE4LjcxOCAwIDAgMCAuNDIzLjQ2N2M4LjE1NiAzLjI0OCAyNS45MjggMy4zOTIgMjUuOTI4LTIuMTMyeiIgZmlsbD0iI2RkZCIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBkPSJtNzYuMjUgMTE2LjVjLTIuODc1IDEuMTI1LTguNSAxLjYyNS0xMS43NSAxLjYyNS00Ljc2NCAwLTExLjYyNS0uNzUtMTQuMTI1LTEuODc1LTEuNTQ0LTQuNzUxLTYuMTY0LTE5LjQ4LTEwLjcyNy0zOC4xODVsLS40NDctMS44MjctLjAwNC0uMDE1Yy01LjQyNC0yMi4xNTctOS44NTUtNDAuMjUzIDE0LjQyNy00NS45MzguMjIyLS4wNTIuMzMtLjMxNy4xODQtLjQ5Mi0yLjc4Ni0zLjMwNS04LjAwNS00LjM4OC0xNC42MDUtMi4xMTEtLjI3LjA5My0uNTA2LS4xOC0uMzM3LS40MTIgMS4yOTQtMS43ODMgMy44MjMtMy4xNTUgNS4wNzEtMy43NTYuMjU4LS4xMjQuMjQyLS41MDItLjAzLS41ODhhMjcuODc3IDI3Ljg3NyAwIDAgMCAtMy43NzItLjljLS4zNy0uMDU5LS40MDMtLjY5My0uMDMyLS43NDMgOS4zNTYtMS4yNTkgMTkuMTI1IDEuNTUgMjQuMDI4IDcuNzI2YS4zMjYuMzI2IDAgMCAwIC4xODYuMTE0YzE3Ljk1MiAzLjg1NiAxOS4yMzggMzIuMjM1IDE3LjE3IDMzLjUyOC0uNDA4LjI1NS0xLjcxNS4xMDgtMy40MzgtLjA4NS02Ljk4Ni0uNzgxLTIwLjgxOC0yLjMyOS05LjQwMiAxOC45NDguMTEzLjIxLS4wMzYuNDg4LS4yNzIuNTI1LTYuNDM4IDEgMS44MTIgMjEuMTczIDcuODc1IDM0LjQ2MXoiIGZpbGw9IiNmZmYiLz4KICAgIDxwYXRoIGQ9Im04NC4yOCA5MC42OThjLTEuMzY3LS42MzMtNi42MjEgMy4xMzUtMTAuMTEgNi4wMjgtLjcyOC0xLjAzMS0yLjEwMy0xLjc4LTUuMjAzLTEuMjQyLTIuNzEzLjQ3Mi00LjIxMSAxLjEyNi00Ljg4IDIuMjU0LTQuMjgzLTEuNjIzLTExLjQ4OC00LjEzLTEzLjIyOS0xLjcxLTEuOTAyIDIuNjQ2LjQ3NiAxNS4xNjEgMy4wMDMgMTYuNzg2IDEuMzIuODQ5IDcuNjMtMy4yMDggMTAuOTI2LTYuMDA1LjUzMi43NDkgMS4zODggMS4xNzggMy4xNDggMS4xMzcgMi42NjItLjA2MiA2Ljk3OS0uNjgxIDcuNjQ5LTEuOTIxLjA0LS4wNzUuMDc1LS4xNjQuMTA1LS4yNjYgMy4zODggMS4yNjYgOS4zNSAyLjYwNiAxMC42ODIgMi40MDYgMy40Ny0uNTIxLS40ODQtMTYuNzIzLTIuMDktMTcuNDY3eiIgZmlsbD0iIzNjYTgyYiIvPgogICAgPHBhdGggZD0ibTc0LjQ5IDk3LjA5N2MuMTQ0LjI1Ni4yNi41MjYuMzU4LjguNDgzIDEuMzUyIDEuMjcgNS42NDguNjc0IDYuNzA5LS41OTUgMS4wNjItNC40NTkgMS41NzQtNi44NDMgMS42MTVzLTIuOTItLjgzMS0zLjQwMy0yLjE4MWMtLjM4Ny0xLjA4MS0uNTc3LTMuNjIxLS41NzItNS4wNzUtLjA5OC0yLjE1OC42OS0yLjkxNiA0LjMzNC0zLjUwNiAyLjY5Ni0uNDM2IDQuMTIxLjA3MSA0Ljk0NC45NCAzLjgyOC0yLjg1NyAxMC4yMTUtNi44ODkgMTAuODM4LTYuMTUyIDMuMTA2IDMuNjc0IDMuNDk5IDEyLjQyIDIuODI2IDE1LjkzOS0uMjIgMS4xNTEtMTAuNTA1LTEuMTM5LTEwLjUwNS0yLjM4IDAtNS4xNTItMS4zMzctNi41NjUtMi42NS02Ljcxem0tMjIuNTMtMS42MDljLjg0My0xLjMzMyA3LjY3NC4zMjUgMTEuNDI0IDEuOTkzIDAgMC0uNzcgMy40OTEuNDU2IDcuNjA0LjM1OSAxLjIwMy04LjYyNyA2LjU1OC05LjggNS42MzctMS4zNTUtMS4wNjUtMy44NS0xMi40MzItMi4wOC0xNS4yMzR6IiBmaWxsPSIjNGNiYTNjIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im01NS4yNjkgNjguNDA2Yy41NTMtMi40MDMgMy4xMjctNi45MzIgMTIuMzIxLTYuODIyIDQuNjQ4LS4wMTkgMTAuNDIyLS4wMDIgMTQuMjUtLjQzNmE1MS4zMTIgNTEuMzEyIDAgMCAwIDEyLjcyNi0zLjA5NWMzLjk4LTEuNTE5IDUuMzkyLTEuMTggNS44ODctLjI3Mi41NDQuOTk5LS4wOTcgMi43MjItMS40ODggNC4zMDktMi42NTYgMy4wMy03LjQzMSA1LjM4LTE1Ljg2NSA2LjA3Ni04LjQzMy42OTgtMTQuMDItMS41NjUtMTYuNDI1IDIuMTE4LTEuMDM4IDEuNTg5LS4yMzYgNS4zMzMgNy45MiA2LjUxMiAxMS4wMiAxLjU5IDIwLjA3Mi0xLjkxNyAyMS4xOS4yMDEgMS4xMTkgMi4xMTgtNS4zMjMgNi40MjgtMTYuMzYyIDYuNTE4cy0xNy45MzQtMy44NjUtMjAuMzc5LTUuODNjLTMuMTAyLTIuNDk1LTQuNDktNi4xMzMtMy43NzUtOS4yNzl6IiBmaWxsPSIjZmMzIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KICAgIDxnIGZpbGw9IiMxNDMwN2UiIG9wYWNpdHk9Ii44Ij4KICAgICAgPHBhdGggZD0ibTY5LjMyNyA0Mi4xMjdjLjYxNi0xLjAwOCAxLjk4MS0xLjc4NiA0LjIxNi0xLjc4NiAyLjIzNCAwIDMuMjg1Ljg4OSA0LjAxMyAxLjg4LjE0OC4yMDItLjA3Ni40NC0uMzA2LjM0YTU5Ljg2OSA1OS44NjkgMCAwIDEgLS4xNjgtLjA3M2MtLjgxNy0uMzU3LTEuODItLjc5NS0zLjU0LS44Mi0xLjgzOC0uMDI2LTIuOTk3LjQzNS0zLjcyNy44MzEtLjI0Ni4xMzQtLjYzNC0uMTMzLS40ODgtLjM3MnptLTI1LjE1NyAxLjI5YzIuMTctLjkwNyAzLjg3Ni0uNzkgNS4wODEtLjUwNC4yNTQuMDYuNDMtLjIxMy4yMjctLjM3Ny0uOTM1LS43NTUtMy4wMy0xLjY5Mi01Ljc2LS42NzQtMi40MzcuOTA5LTMuNTg1IDIuNzk2LTMuNTkyIDQuMDM4LS4wMDIuMjkyLjYuMzE3Ljc1Ni4wNy40Mi0uNjcgMS4xMi0xLjY0NiAzLjI4OS0yLjU1M3oiLz4KICAgICAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtNzUuNDQgNTUuOTJhMy40NyAzLjQ3IDAgMCAxIC0zLjQ3NC0zLjQ2MiAzLjQ3IDMuNDcgMCAwIDEgMy40NzUtMy40NiAzLjQ3IDMuNDcgMCAwIDEgMy40NzQgMy40NiAzLjQ3IDMuNDcgMCAwIDEgLTMuNDc1IDMuNDYyem0yLjQ0Ny00LjYwOGEuODk5Ljg5OSAwIDAgMCAtMS43OTkgMGMwIC40OTQuNDA1Ljg5NS45Ljg5NS40OTkgMCAuOS0uNC45LS44OTV6bS0yNS40NjQgMy41NDJhNC4wNDIgNC4wNDIgMCAwIDEgLTQuMDQ5IDQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIC00LjA1LTQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIDQuMDUtNC4wMzcgNC4wNDUgNC4wNDUgMCAwIDEgNC4wNSA0LjAzN3ptLTEuMTkzLTEuMzM4YTEuMDUgMS4wNSAwIDAgMCAtMi4wOTcgMCAxLjA0OCAxLjA0OCAwIDAgMCAyLjA5NyAweiIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8L2c+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im02NCAxMTcuNzVjMjkuNjg1IDAgNTMuNzUtMjQuMDY1IDUzLjc1LTUzLjc1cy0yNC4wNjUtNTMuNzUtNTMuNzUtNTMuNzUtNTMuNzUgMjQuMDY1LTUzLjc1IDUzLjc1IDI0LjA2NSA1My43NSA1My43NSA1My43NXptMCA1YzMyLjQ0NyAwIDU4Ljc1LTI2LjMwMyA1OC43NS01OC43NXMtMjYuMzAzLTU4Ljc1LTU4Ljc1LTU4Ljc1LTU4Ljc1IDI2LjMwMy01OC43NSA1OC43NSAyNi4zMDMgNTguNzUgNTguNzUgNTguNzV6IiBmaWxsPSIjZmZmIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+');\n}\n\n/* Email tooltip specific */\n.tooltip__button--email {\n    flex-direction: column;\n    justify-content: center;\n    align-items: flex-start;\n    font-size: 14px;\n    padding: 4px 8px;\n}\n.tooltip__button--email__primary-text {\n    font-weight: bold;\n}\n.tooltip__button--email__secondary-text {\n    font-size: 12px;\n}\n\n/* Email Protection signup notice */\n:not(.top-autofill) .tooltip--email-signup {\n    text-align: left;\n    color: #222222;\n    padding: 16px 20px;\n    width: 380px;\n}\n\n.tooltip--email-signup h1 {\n    font-weight: 700;\n    font-size: 16px;\n    line-height: 1.5;\n    margin: 0;\n}\n\n.tooltip--email-signup p {\n    font-weight: 400;\n    font-size: 14px;\n    line-height: 1.4;\n}\n\n.notice-controls {\n    display: flex;\n}\n\n.tooltip--email-signup .notice-controls > * {\n    border-radius: 8px;\n    border: 0;\n    cursor: pointer;\n    display: inline-block;\n    font-family: inherit;\n    font-style: normal;\n    font-weight: bold;\n    padding: 8px 12px;\n    text-decoration: none;\n}\n\n.notice-controls .ghost {\n    margin-left: 1rem;\n}\n\n.tooltip--email-signup a.primary {\n    background: #3969EF;\n    color: #fff;\n}\n\n.tooltip--email-signup a.primary:hover,\n.tooltip--email-signup a.primary:focus {\n    background: #2b55ca;\n}\n\n.tooltip--email-signup a.primary:active {\n    background: #1e42a4;\n}\n\n.tooltip--email-signup button.ghost {\n    background: transparent;\n    color: #3969EF;\n}\n\n.tooltip--email-signup button.ghost:hover,\n.tooltip--email-signup button.ghost:focus {\n    background-color: rgba(0, 0, 0, 0.06);\n    color: #2b55ca;\n}\n\n.tooltip--email-signup button.ghost:active {\n    background-color: rgba(0, 0, 0, 0.12);\n    color: #1e42a4;\n}\n\n.tooltip--email-signup button.close-tooltip {\n    background-color: transparent;\n    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjI5Mjg5NCAwLjY1NjkwN0MwLjY4MzQxOCAwLjI2NjM4MyAxLjMxNjU4IDAuMjY2MzgzIDEuNzA3MTEgMC42NTY5MDdMNiA0Ljk0OThMMTAuMjkyOSAwLjY1NjkwN0MxMC42ODM0IDAuMjY2MzgzIDExLjMxNjYgMC4yNjYzODMgMTEuNzA3MSAwLjY1NjkwN0MxMi4wOTc2IDEuMDQ3NDMgMTIuMDk3NiAxLjY4MDYgMTEuNzA3MSAyLjA3MTEyTDcuNDE0MjEgNi4zNjQwMUwxMS43MDcxIDEwLjY1NjlDMTIuMDk3NiAxMS4wNDc0IDEyLjA5NzYgMTEuNjgwNiAxMS43MDcxIDEyLjA3MTFDMTEuMzE2NiAxMi40NjE2IDEwLjY4MzQgMTIuNDYxNiAxMC4yOTI5IDEyLjA3MTFMNiA3Ljc3ODIzTDEuNzA3MTEgMTIuMDcxMUMxLjMxNjU4IDEyLjQ2MTYgMC42ODM0MTcgMTIuNDYxNiAwLjI5Mjg5MyAxMi4wNzExQy0wLjA5NzYzMTEgMTEuNjgwNiAtMC4wOTc2MzExIDExLjA0NzQgMC4yOTI4OTMgMTAuNjU2OUw0LjU4NTc5IDYuMzY0MDFMMC4yOTI4OTQgMi4wNzExMkMtMC4wOTc2MzA2IDEuNjgwNiAtMC4wOTc2MzA2IDEuMDQ3NDMgMC4yOTI4OTQgMC42NTY5MDdaIiBmaWxsPSJibGFjayIgZmlsbC1vcGFjaXR5PSIwLjg0Ii8+Cjwvc3ZnPgo=);\n    background-position: center center;\n    background-repeat: no-repeat;\n    border: 0;\n    cursor: pointer;\n    padding: 16px;\n    position: absolute;\n    right: 12px;\n    top: 12px;\n}\n";
 exports.CSS_STYLES = CSS_STYLES;
 
-},{}],61:[function(require,module,exports){
+},{}],59:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18148,7 +18047,7 @@ function isFormLikelyToBeUsedAsPageWrapper(form) {
   return formChildrenPercentage > 50;
 }
 
-},{"./Form/matching.js":43}],62:[function(require,module,exports){
+},{"./Form/matching.js":41}],60:[function(require,module,exports){
 "use strict";
 
 require("./requestIdleCallback.js");
@@ -18183,7 +18082,7 @@ var _autofillUtils = require("./autofill-utils.js");
   }
 })();
 
-},{"./DeviceInterface.js":22,"./autofill-utils.js":61,"./requestIdleCallback.js":73}],63:[function(require,module,exports){
+},{"./DeviceInterface.js":20,"./autofill-utils.js":59,"./requestIdleCallback.js":71}],61:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18271,7 +18170,7 @@ function createGlobalConfig(overrides) {
   return config;
 }
 
-},{}],64:[function(require,module,exports){
+},{}],62:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18289,7 +18188,7 @@ const constants = {
 };
 exports.constants = constants;
 
-},{}],65:[function(require,module,exports){
+},{}],63:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18779,7 +18678,7 @@ class CloseEmailProtectionTabCall extends _deviceApi.DeviceApiCall {
 
 exports.CloseEmailProtectionTabCall = CloseEmailProtectionTabCall;
 
-},{"../../../packages/device-api":14,"./validators.zod.js":66}],66:[function(require,module,exports){
+},{"../../../packages/device-api":10,"./validators.zod.js":64}],64:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19285,7 +19184,7 @@ const apiSchema = _zod.z.object({
 
 exports.apiSchema = apiSchema;
 
-},{"zod":12}],67:[function(require,module,exports){
+},{"zod":8}],65:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19326,7 +19225,7 @@ class GetAlias extends _index.DeviceApiCall {
 
 exports.GetAlias = GetAlias;
 
-},{"../../packages/device-api/index.js":14,"./__generated__/validators.zod.js":66}],68:[function(require,module,exports){
+},{"../../packages/device-api/index.js":10,"./__generated__/validators.zod.js":64}],66:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19484,7 +19383,7 @@ function androidSpecificAvailableInputTypes(globalConfig) {
   };
 }
 
-},{"../../../packages/device-api/index.js":14,"../__generated__/deviceApiCalls.js":65}],69:[function(require,module,exports){
+},{"../../../packages/device-api/index.js":10,"../__generated__/deviceApiCalls.js":63}],67:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19492,7 +19391,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.AppleTransport = void 0;
 
-var _contentScopeUtils = require("@duckduckgo/content-scope-utils");
+var _messaging = require("../../../packages/messaging/messaging.js");
 
 var _index = require("../../../packages/device-api/index.js");
 
@@ -19503,12 +19402,12 @@ class AppleTransport extends _index.DeviceApiTransport {
   constructor(globalConfig) {
     super();
     this.config = globalConfig;
-    const webkitConfig = new _contentScopeUtils.WebkitMessagingConfig({
+    const webkitConfig = new _messaging.WebkitMessagingConfig({
       hasModernWebkitAPI: this.config.hasModernWebkitAPI,
       webkitMessageHandlerNames: this.config.webkitMessageHandlerNames,
       secret: this.config.secret
     });
-    this.messaging = new _contentScopeUtils.Messaging(webkitConfig);
+    this.messaging = new _messaging.Messaging(webkitConfig);
   }
 
   async send(deviceApiCall) {
@@ -19520,7 +19419,7 @@ class AppleTransport extends _index.DeviceApiTransport {
         return this.messaging.notify(deviceApiCall.method, deviceApiCall.params || undefined);
       }
     } catch (e) {
-      if (e instanceof _contentScopeUtils.MissingHandler) {
+      if (e instanceof _messaging.MissingHandler) {
         if (this.config.isDDGTestMode) {
           console.log('MissingWebkitHandler error for:', deviceApiCall.method);
         }
@@ -19560,7 +19459,7 @@ function appleSpecificRuntimeConfiguration(globalConfig) {
   };
 }
 
-},{"../../../packages/device-api/index.js":14,"../__generated__/deviceApiCalls.js":65,"@duckduckgo/content-scope-utils":2}],70:[function(require,module,exports){
+},{"../../../packages/device-api/index.js":10,"../../../packages/messaging/messaging.js":13,"../__generated__/deviceApiCalls.js":63}],68:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19732,7 +19631,7 @@ async function extensionSpecificSetIncontextSignupPermanentlyDismissedAtCall(par
   });
 }
 
-},{"../../../packages/device-api/index.js":14,"../../Settings.js":50,"../../autofill-utils.js":61,"../__generated__/deviceApiCalls.js":65}],71:[function(require,module,exports){
+},{"../../../packages/device-api/index.js":10,"../../Settings.js":48,"../../autofill-utils.js":59,"../__generated__/deviceApiCalls.js":63}],69:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19786,7 +19685,7 @@ function createTransport(globalConfig) {
   return new _extensionTransport.ExtensionTransport(globalConfig);
 }
 
-},{"./android.transport.js":68,"./apple.transport.js":69,"./extension.transport.js":70,"./windows.transport.js":72}],72:[function(require,module,exports){
+},{"./android.transport.js":66,"./apple.transport.js":67,"./extension.transport.js":68,"./windows.transport.js":70}],70:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19886,7 +19785,7 @@ function waitForWindowsResponse(responseId, options) {
   });
 }
 
-},{"../../../packages/device-api/index.js":14}],73:[function(require,module,exports){
+},{"../../../packages/device-api/index.js":10}],71:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19934,4 +19833,4 @@ window.cancelIdleCallback = window.cancelIdleCallback || function (id) {
 var _default = {};
 exports.default = _default;
 
-},{}]},{},[62]);
+},{}]},{},[60]);

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -4251,25 +4251,25 @@ var _webkit = require("./webkit.js");
  */
 class Messaging {
   /**
-   * @param {WebkitMessagingConfig} config
-   */
+  * @param {WebkitMessagingConfig} config
+  */
   constructor(config) {
     this.transport = getTransport(config);
   }
   /**
-   * Send a 'fire-and-forget' message.
-   * @throws {Error}
-   * {@link MissingHandler}
-   *
-   * @example
-   *
-   * ```
-   * const messaging = new Messaging(config)
-   * messaging.notify("foo", {bar: "baz"})
-   * ```
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
+  * Send a 'fire-and-forget' message.
+  * @throws {Error}
+  * {@link MissingHandler}
+  *
+  * @example
+  *
+  * ```
+  * const messaging = new Messaging(config)
+  * messaging.notify("foo", {bar: "baz"})
+  * ```
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  */
 
 
   notify(name) {
@@ -4277,20 +4277,20 @@ class Messaging {
     this.transport.notify(name, data);
   }
   /**
-   * Send a request, and wait for a response
-   * @throws {Error}
-   * {@link MissingHandler}
-   *
-   * @example
-   * ```
-   * const messaging = new Messaging(config)
-   * const response = await messaging.request("foo", {bar: "baz"})
-   * ```
-   *
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
+  * Send a request, and wait for a response
+  * @throws {Error}
+  * {@link MissingHandler}
+  *
+  * @example
+  * ```
+  * const messaging = new Messaging(config)
+  * const response = await messaging.request("foo", {bar: "baz"})
+  * ```
+  *
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @return {Promise<any>}
+  */
 
 
   request(name) {
@@ -4308,23 +4308,21 @@ exports.Messaging = Messaging;
 
 class MessagingTransport {
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @returns {void}
-   */
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @returns {void}
+  */
   // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   notify(name) {
     let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     throw new Error("must implement 'notify'");
   }
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @return {Promise<any>}
+  */
   // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 
   request(name) {
@@ -4355,9 +4353,9 @@ function getTransport(config) {
 
 class MissingHandler extends Error {
   /**
-   * @param {string} message
-   * @param {string} handlerName
-   */
+  * @param {string} message
+  * @param {string} handlerName
+  */
   constructor(message, handlerName) {
     super(message);
     this.handlerName = handlerName;
@@ -4382,6 +4380,10 @@ exports.WebkitMessagingTransport = exports.WebkitMessagingConfig = exports.Secur
 var _messaging = require("./messaging.js");
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/**
+ * @typedef {import("./messaging").MessagingTransport} MessagingTransport
+ */
 
 /**
  * @example
@@ -4551,7 +4553,6 @@ class WebkitMessagingTransport {
    * @param {string} name
    * @param {Record<string, any>} [data]
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 
   request(name) {
@@ -4576,8 +4577,8 @@ class WebkitMessagingTransport {
       writable: false,
 
       /**
-       * @param {any[]} args
-       */
+      * @param {any[]} args
+      */
       value: function () {
         callback(...arguments); // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
 
@@ -4651,9 +4652,9 @@ class WebkitMessagingTransport {
         var _handlers$webkitMessa2;
 
         /**
-         * `bind` is used here to ensure future calls to the captured
-         * `postMessage` have the correct `this` context
-         */
+        * `bind` is used here to ensure future calls to the captured
+        * `postMessage` have the correct `this` context
+        */
         const original = handlers[webkitMessageHandlerName];
         const bound = (_handlers$webkitMessa2 = handlers[webkitMessageHandlerName].postMessage) === null || _handlers$webkitMessa2 === void 0 ? void 0 : _handlers$webkitMessa2.bind(original);
         this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
@@ -4685,11 +4686,11 @@ exports.WebkitMessagingTransport = WebkitMessagingTransport;
 
 class WebkitMessagingConfig {
   /**
-   * @param {object} params
-   * @param {boolean} params.hasModernWebkitAPI
-   * @param {string[]} params.webkitMessageHandlerNames
-   * @param {string} params.secret
-   */
+  * @param {object} params
+  * @param {boolean} params.hasModernWebkitAPI
+  * @param {string[]} params.webkitMessageHandlerNames
+  * @param {string} params.secret
+  */
   constructor(params) {
     /**
      * Whether or not the current WebKit Platform supports secure messaging
@@ -4697,14 +4698,14 @@ class WebkitMessagingConfig {
      */
     this.hasModernWebkitAPI = params.hasModernWebkitAPI;
     /**
-     * A list of WebKit message handler names that a user script can send
-     */
+    * A list of WebKit message handler names that a user script can send
+    */
 
     this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
     /**
-     * A string provided by native platforms to be sent with future outgoing
-     * messages
-     */
+    * A string provided by native platforms to be sent with future outgoing
+    * messages
+    */
 
     this.secret = params.secret;
   }
@@ -4720,30 +4721,30 @@ exports.WebkitMessagingConfig = WebkitMessagingConfig;
 
 class SecureMessagingParams {
   /**
-   * @param {object} params
-   * @param {string} params.methodName
-   * @param {string} params.secret
-   * @param {number[]} params.key
-   * @param {number[]} params.iv
-   */
+  * @param {object} params
+  * @param {string} params.methodName
+  * @param {string} params.secret
+  * @param {number[]} params.key
+  * @param {number[]} params.iv
+  */
   constructor(params) {
     /**
      * The method that's been appended to `window` to be called later
      */
     this.methodName = params.methodName;
     /**
-     * The secret used to ensure message sender validity
-     */
+    * The secret used to ensure message sender validity
+    */
 
     this.secret = params.secret;
     /**
-     * The CipherKey as number[]
-     */
+    * The CipherKey as number[]
+    */
 
     this.key = params.key;
     /**
-     * The Initial Vector as number[]
-     */
+    * The Initial Vector as number[]
+    */
 
     this.iv = params.iv;
   }

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -575,25 +575,25 @@ var _webkit = require("./webkit.js");
  */
 class Messaging {
   /**
-   * @param {WebkitMessagingConfig} config
-   */
+  * @param {WebkitMessagingConfig} config
+  */
   constructor(config) {
     this.transport = getTransport(config);
   }
   /**
-   * Send a 'fire-and-forget' message.
-   * @throws {Error}
-   * {@link MissingHandler}
-   *
-   * @example
-   *
-   * ```
-   * const messaging = new Messaging(config)
-   * messaging.notify("foo", {bar: "baz"})
-   * ```
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
+  * Send a 'fire-and-forget' message.
+  * @throws {Error}
+  * {@link MissingHandler}
+  *
+  * @example
+  *
+  * ```
+  * const messaging = new Messaging(config)
+  * messaging.notify("foo", {bar: "baz"})
+  * ```
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  */
 
 
   notify(name) {
@@ -601,20 +601,20 @@ class Messaging {
     this.transport.notify(name, data);
   }
   /**
-   * Send a request, and wait for a response
-   * @throws {Error}
-   * {@link MissingHandler}
-   *
-   * @example
-   * ```
-   * const messaging = new Messaging(config)
-   * const response = await messaging.request("foo", {bar: "baz"})
-   * ```
-   *
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
+  * Send a request, and wait for a response
+  * @throws {Error}
+  * {@link MissingHandler}
+  *
+  * @example
+  * ```
+  * const messaging = new Messaging(config)
+  * const response = await messaging.request("foo", {bar: "baz"})
+  * ```
+  *
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @return {Promise<any>}
+  */
 
 
   request(name) {
@@ -632,23 +632,21 @@ exports.Messaging = Messaging;
 
 class MessagingTransport {
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @returns {void}
-   */
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @returns {void}
+  */
   // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   notify(name) {
     let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     throw new Error("must implement 'notify'");
   }
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @return {Promise<any>}
+  */
   // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 
   request(name) {
@@ -679,9 +677,9 @@ function getTransport(config) {
 
 class MissingHandler extends Error {
   /**
-   * @param {string} message
-   * @param {string} handlerName
-   */
+  * @param {string} message
+  * @param {string} handlerName
+  */
   constructor(message, handlerName) {
     super(message);
     this.handlerName = handlerName;
@@ -706,6 +704,10 @@ exports.WebkitMessagingTransport = exports.WebkitMessagingConfig = exports.Secur
 var _messaging = require("./messaging.js");
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/**
+ * @typedef {import("./messaging").MessagingTransport} MessagingTransport
+ */
 
 /**
  * @example
@@ -875,7 +877,6 @@ class WebkitMessagingTransport {
    * @param {string} name
    * @param {Record<string, any>} [data]
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 
   request(name) {
@@ -900,8 +901,8 @@ class WebkitMessagingTransport {
       writable: false,
 
       /**
-       * @param {any[]} args
-       */
+      * @param {any[]} args
+      */
       value: function () {
         callback(...arguments); // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
 
@@ -975,9 +976,9 @@ class WebkitMessagingTransport {
         var _handlers$webkitMessa2;
 
         /**
-         * `bind` is used here to ensure future calls to the captured
-         * `postMessage` have the correct `this` context
-         */
+        * `bind` is used here to ensure future calls to the captured
+        * `postMessage` have the correct `this` context
+        */
         const original = handlers[webkitMessageHandlerName];
         const bound = (_handlers$webkitMessa2 = handlers[webkitMessageHandlerName].postMessage) === null || _handlers$webkitMessa2 === void 0 ? void 0 : _handlers$webkitMessa2.bind(original);
         this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
@@ -1009,11 +1010,11 @@ exports.WebkitMessagingTransport = WebkitMessagingTransport;
 
 class WebkitMessagingConfig {
   /**
-   * @param {object} params
-   * @param {boolean} params.hasModernWebkitAPI
-   * @param {string[]} params.webkitMessageHandlerNames
-   * @param {string} params.secret
-   */
+  * @param {object} params
+  * @param {boolean} params.hasModernWebkitAPI
+  * @param {string[]} params.webkitMessageHandlerNames
+  * @param {string} params.secret
+  */
   constructor(params) {
     /**
      * Whether or not the current WebKit Platform supports secure messaging
@@ -1021,14 +1022,14 @@ class WebkitMessagingConfig {
      */
     this.hasModernWebkitAPI = params.hasModernWebkitAPI;
     /**
-     * A list of WebKit message handler names that a user script can send
-     */
+    * A list of WebKit message handler names that a user script can send
+    */
 
     this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
     /**
-     * A string provided by native platforms to be sent with future outgoing
-     * messages
-     */
+    * A string provided by native platforms to be sent with future outgoing
+    * messages
+    */
 
     this.secret = params.secret;
   }
@@ -1044,30 +1045,30 @@ exports.WebkitMessagingConfig = WebkitMessagingConfig;
 
 class SecureMessagingParams {
   /**
-   * @param {object} params
-   * @param {string} params.methodName
-   * @param {string} params.secret
-   * @param {number[]} params.key
-   * @param {number[]} params.iv
-   */
+  * @param {object} params
+  * @param {string} params.methodName
+  * @param {string} params.secret
+  * @param {number[]} params.key
+  * @param {number[]} params.iv
+  */
   constructor(params) {
     /**
      * The method that's been appended to `window` to be called later
      */
     this.methodName = params.methodName;
     /**
-     * The secret used to ensure message sender validity
-     */
+    * The secret used to ensure message sender validity
+    */
 
     this.secret = params.secret;
     /**
-     * The CipherKey as number[]
-     */
+    * The CipherKey as number[]
+    */
 
     this.key = params.key;
     /**
-     * The Initial Vector as number[]
-     */
+    * The Initial Vector as number[]
+    */
 
     this.iv = params.iv;
   }

--- a/integration-test/helpers/mocks.android.js
+++ b/integration-test/helpers/mocks.android.js
@@ -197,7 +197,6 @@ export function createAndroidMocks () {
                     },
                     storeFormData (request) {
                         /** @type {MockCall} */
-                        // @ts-expect-error
                         const call = ['storeFormData', request, mocks.getAutofillData]
                         window.__playwright_autofill.mocks.calls.push(JSON.parse(JSON.stringify(call)))
                     }

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -283,7 +283,6 @@ export function signupPage (page) {
             const calls = await mockedCalls(page, { names: ['storeFormData'] })
             expect(calls.length).toBeGreaterThanOrEqual(1)
             const [, sent] = calls[0]
-            // @ts-expect-error
             expect(sent.Data.credentials).toEqual(credentials)
         }
         /**
@@ -481,7 +480,6 @@ export function loginPage (page, opts = {}) {
          */
         async assertParentOpened () {
             const credsCalls = await mockedCalls(page, { names: ['getSelectedCredentials'] })
-            // @ts-expect-error
             const hasSucceeded = credsCalls.some((call) => call[2]?.some(({type}) => type === 'ok'))
             expect(hasSucceeded).toBe(true)
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@babel/eslint-parser": "^7.18.2",
         "@babel/preset-env": "^7.16.11",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0",
-        "@duckduckgo/content-scope-utils": "github:duckduckgo/content-scope-utils#1.0.1",
         "@playwright/test": "^1.32.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^16.11.36",
@@ -1751,12 +1750,6 @@
         "seedrandom": "^3.0.5",
         "sjcl": "^1.0.8"
       }
-    },
-    "node_modules/@duckduckgo/content-scope-utils": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-utils.git#97b233e9b257c0b11d4aebb74656ed15a63660ae",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -15922,11 +15915,6 @@
         "seedrandom": "^3.0.5",
         "sjcl": "^1.0.8"
       }
-    },
-    "@duckduckgo/content-scope-utils": {
-      "version": "git+ssh://git@github.com/duckduckgo/content-scope-utils.git#97b233e9b257c0b11d4aebb74656ed15a63660ae",
-      "dev": true,
-      "from": "@duckduckgo/content-scope-utils@github:duckduckgo/content-scope-utils#1.0.1"
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@babel/eslint-parser": "^7.18.2",
     "@babel/preset-env": "^7.16.11",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0",
-    "@duckduckgo/content-scope-utils": "github:duckduckgo/content-scope-utils#1.0.1",
     "@playwright/test": "^1.32.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.11.36",

--- a/packages/messaging/messaging.js
+++ b/packages/messaging/messaging.js
@@ -1,0 +1,154 @@
+/**
+ * @module Messaging
+ *
+ * @description
+ *
+ * An abstraction for communications between JavaScript and host platforms.
+ *
+ * 1) First you construct your platform-specific configuration (eg: {@link WebkitMessagingConfig})
+ * 2) Then use that to get an instance of the Messaging utility which allows
+ * you to send and receive data in a unified way
+ * 3) Each platform implements {@link MessagingTransport} along with its own Configuration
+ *     - For example, to learn what configuration is required for Webkit, see: {@link "Webkit Messaging".WebkitMessagingConfig}
+ *     - Or, to learn about how messages are sent and received in Webkit, see {@link "Webkit Messaging".WebkitMessagingTransport}
+ *
+ * @example Webkit Messaging
+ *
+ * ```js
+ * import { Messaging, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * // This config would be injected into the UserScript
+ * const injectedConfig = {
+ *   hasModernWebkitAPI: true,
+ *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
+ *   secret: "dax",
+ * };
+ *
+ * // Then use that config to construct platform-specific configuration
+ * const config = new WebkitMessagingConfig(injectedConfig);
+ *
+ * // finally, get an instance of Messaging and start sending messages in a unified way 🚀
+ * const messaging = new Messaging(config);
+ * messaging.notify("hello world!", {foo: "bar"})
+ *
+ * ```
+ *
+ * @example Windows Messaging
+ *
+ * ```js
+ * import { Messaging, WindowsMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * // Messaging on Windows is namespaced, so you can create multiple messaging instances
+ * const autofillConfig  = new WindowsMessagingConfig({ featureName: "Autofill" });
+ * const debugConfig     = new WindowsMessagingConfig({ featureName: "Debugging" });
+ *
+ * const autofillMessaging = new Messaging(autofillConfig);
+ * const debugMessaging    = new Messaging(debugConfig);
+ *
+ * // Now send messages to both features as needed 🚀
+ * autofillMessaging.notify("storeFormData", { "username": "dax" })
+ * debugMessaging.notify("pageLoad", { time: window.performance.now() })
+ * ```
+ */
+import { WebkitMessagingConfig, WebkitMessagingTransport } from './webkit.js'
+
+/**
+ * @implements {MessagingTransport}
+ */
+export class Messaging {
+    /**
+   * @param {WebkitMessagingConfig} config
+   */
+    constructor (config) {
+        this.transport = getTransport(config)
+    }
+    /**
+   * Send a 'fire-and-forget' message.
+   * @throws {Error}
+   * {@link MissingHandler}
+   *
+   * @example
+   *
+   * ```
+   * const messaging = new Messaging(config)
+   * messaging.notify("foo", {bar: "baz"})
+   * ```
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+    notify (name, data = {}) {
+        this.transport.notify(name, data)
+    }
+    /**
+   * Send a request, and wait for a response
+   * @throws {Error}
+   * {@link MissingHandler}
+   *
+   * @example
+   * ```
+   * const messaging = new Messaging(config)
+   * const response = await messaging.request("foo", {bar: "baz"})
+   * ```
+   *
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @return {Promise<any>}
+   */
+    request (name, data = {}) {
+        return this.transport.request(name, data)
+    }
+}
+
+/**
+ * @interface
+ */
+export class MessagingTransport {
+    /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @returns {void}
+   */
+    // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
+    notify (name, data = {}) {
+        throw new Error("must implement 'notify'")
+    }
+    /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @return {Promise<any>}
+   */
+    // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
+    request (name, data = {}) {
+        throw new Error('must implement')
+    }
+}
+
+/**
+ * @param {WebkitMessagingConfig} config
+ * @returns {MessagingTransport}
+ */
+function getTransport (config) {
+    if (config instanceof WebkitMessagingConfig) {
+        return new WebkitMessagingTransport(config)
+    }
+    throw new Error('unreachable')
+}
+
+/**
+ * Thrown when a handler cannot be found
+ */
+export class MissingHandler extends Error {
+    /**
+   * @param {string} message
+   * @param {string} handlerName
+   */
+    constructor (message, handlerName) {
+        super(message)
+        this.handlerName = handlerName
+    }
+}
+
+/**
+ * Some re-exports for convenience
+ */
+export { WebkitMessagingConfig }

--- a/packages/messaging/webkit.js
+++ b/packages/messaging/webkit.js
@@ -1,0 +1,372 @@
+/**
+ * @module Webkit Messaging
+ *
+ * @description
+ *
+ * A wrapper for messaging on WebKit platforms. It supports modern WebKit messageHandlers
+ * along with encryption for older versions (like macOS Catalina)
+ *
+ * Note: If you wish to support Catalina then you'll need to implement the native
+ * part of the message handling, see {@link WebkitMessagingTransport} for details.
+ *
+ * ```js
+ * import { Messaging, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * // This config would be injected into the UserScript
+ * const injectedConfig = {
+ *   hasModernWebkitAPI: true,
+ *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
+ *   secret: "dax",
+ * };
+ *
+ * // Then use that config to construct platform-specific configuration
+ * const config = new WebkitMessagingConfig(injectedConfig);
+ *
+ * // finally, get an instance of Messaging and start sending messages in a unified way 🚀
+ * const messaging = new Messaging(config);
+ * messaging.notify("hello world!", {foo: "bar"})
+ *
+ * ```
+ */
+import { MissingHandler } from './messaging.js'
+
+/**
+ * @typedef {import("./messaging").MessagingTransport} MessagingTransport
+ */
+
+/**
+ * @example
+ * On macOS 11+, this will just call through to `window.webkit.messageHandlers.x.postMessage`
+ *
+ * Eg: for a `foo` message defined in Swift that accepted the payload `{"bar": "baz"}`, the following
+ * would occur:
+ *
+ * ```js
+ * const json = await window.webkit.messageHandlers.foo.postMessage({ bar: "baz" });
+ * const response = JSON.parse(json)
+ * ```
+ *
+ * @example
+ * On macOS 10 however, the process is a little more involved. A method will be appended to `window`
+ * that allows the response to be delivered there instead. It's not exactly this, but you can visualize the flow
+ * as being something along the lines of:
+ *
+ * ```js
+ * // add the window method
+ * window["_0123456"] = (response) => {
+ *    // decrypt `response` and deliver the result to the caller here
+ *    // then remove the temporary method
+ *    delete window["_0123456"]
+ * };
+ *
+ * // send the data + `messageHanding` values
+ * window.webkit.messageHandlers.foo.postMessage({
+ *   bar: "baz",
+ *   messagingHandling: {
+ *     methodName: "_0123456",
+ *     secret: "super-secret",
+ *     key: [1, 2, 45, 2],
+ *     iv: [34, 4, 43],
+ *   }
+ * });
+ *
+ * // later in swift, the following JavaScript snippet will be executed
+ * (() => {
+ *   window["_0123456"]({
+ *     ciphertext: [12, 13, 4],
+ *     tag: [3, 5, 67, 56]
+ *   })
+ * })()
+ * ```
+ * @implements {MessagingTransport}
+ */
+export class WebkitMessagingTransport {
+  /** @type {WebkitMessagingConfig} */
+  config
+  globals
+  /**
+   * @param {WebkitMessagingConfig} config
+   */
+  constructor (config) {
+      this.config = config
+      this.globals = captureGlobals()
+      if (!this.config.hasModernWebkitAPI) {
+          this.captureWebkitHandlers(this.config.webkitMessageHandlerNames)
+      }
+  }
+  /**
+   * Sends message to the webkit layer (fire and forget)
+   * @param {String} handler
+   * @param {*} data
+   * @internal
+   */
+  wkSend (handler, data = {}) {
+      if (!(handler in this.globals.window.webkit.messageHandlers)) {
+          throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler)
+      }
+      const outgoing = {
+          ...data,
+          messageHandling: { ...data.messageHandling, secret: this.config.secret }
+      }
+      if (!this.config.hasModernWebkitAPI) {
+          if (!(handler in this.globals.capturedWebkitHandlers)) {
+              throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler)
+          } else {
+              return this.globals.capturedWebkitHandlers[handler](outgoing)
+          }
+      }
+      return this.globals.window.webkit.messageHandlers[handler].postMessage?.(outgoing)
+  }
+
+  /**
+   * Sends message to the webkit layer and waits for the specified response
+   * @param {String} handler
+   * @param {*} data
+   * @returns {Promise<*>}
+   * @internal
+   */
+  async wkSendAndWait (handler, data = {}) {
+      if (this.config.hasModernWebkitAPI) {
+          const response = await this.wkSend(handler, data)
+          return this.globals.JSONparse(response || '{}')
+      }
+
+      try {
+          const randMethodName = this.createRandMethodName()
+          const key = await this.createRandKey()
+          const iv = this.createRandIv()
+
+          const { ciphertext, tag } = await new this.globals.Promise((/** @type {any} */ resolve) => {
+              this.generateRandomMethod(randMethodName, resolve)
+              data.messageHandling = new SecureMessagingParams({
+                  methodName: randMethodName,
+                  secret: this.config.secret,
+                  key: this.globals.Arrayfrom(key),
+                  iv: this.globals.Arrayfrom(iv)
+              })
+              this.wkSend(handler, data)
+          })
+
+          const cipher = new this.globals.Uint8Array([...ciphertext, ...tag])
+          const decrypted = await this.decrypt(cipher, key, iv)
+          return this.globals.JSONparse(decrypted || '{}')
+      } catch (e) {
+      // re-throw when the error is just a 'MissingHandler'
+          if (e instanceof MissingHandler) {
+              throw e
+          } else {
+              console.error('decryption failed', e)
+              console.error(e)
+              return { error: e }
+          }
+      }
+  }
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+  notify (name, data = {}) {
+      this.wkSend(name, data)
+  }
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+  request (name, data = {}) {
+      return this.wkSendAndWait(name, data)
+  }
+  /**
+   * Generate a random method name and adds it to the global scope
+   * The native layer will use this method to send the response
+   * @param {string | number} randomMethodName
+   * @param {Function} callback
+   */
+  generateRandomMethod (randomMethodName, callback) {
+      this.globals.ObjectDefineProperty(this.globals.window, randomMethodName, {
+          enumerable: false,
+          // configurable, To allow for deletion later
+          configurable: true,
+          writable: false,
+          /**
+       * @param {any[]} args
+       */
+          value: (...args) => {
+              callback(...args)
+              // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
+              delete this.globals.window[randomMethodName]
+          }
+      })
+  }
+
+  randomString () {
+      return '' + this.globals.getRandomValues(new this.globals.Uint32Array(1))[0]
+  }
+
+  createRandMethodName () {
+      return '_' + this.randomString()
+  }
+
+  /**
+   * @type {{name: string, length: number}}
+   */
+  algoObj = { name: 'AES-GCM', length: 256 }
+
+  /**
+   * @returns {Promise<Uint8Array>}
+   */
+  async createRandKey () {
+      const key = await this.globals.generateKey(this.algoObj, true, ['encrypt', 'decrypt'])
+      const exportedKey = await this.globals.exportKey('raw', key)
+      return new this.globals.Uint8Array(exportedKey)
+  }
+
+  /**
+   * @returns {Uint8Array}
+   */
+  createRandIv () {
+      return this.globals.getRandomValues(new this.globals.Uint8Array(12))
+  }
+
+  /**
+   * @param {BufferSource} ciphertext
+   * @param {BufferSource} key
+   * @param {Uint8Array} iv
+   * @returns {Promise<string>}
+   */
+  async decrypt (ciphertext, key, iv) {
+      const cryptoKey = await this.globals.importKey('raw', key, 'AES-GCM', false, ['decrypt'])
+      const algo = { name: 'AES-GCM', iv }
+
+      let decrypted = await this.globals.decrypt(algo, cryptoKey, ciphertext)
+
+      let dec = new this.globals.TextDecoder()
+      return dec.decode(decrypted)
+  }
+
+  /**
+   * When required (such as on macos 10.x), capture the `postMessage` method on
+   * each webkit messageHandler
+   *
+   * @param {string[]} handlerNames
+   */
+  captureWebkitHandlers (handlerNames) {
+      const handlers = window.webkit.messageHandlers
+      if (!handlers) throw new MissingHandler('window.webkit.messageHandlers was absent', 'all')
+      for (let webkitMessageHandlerName of handlerNames) {
+          if (typeof handlers[webkitMessageHandlerName]?.postMessage === 'function') {
+              /**
+         * `bind` is used here to ensure future calls to the captured
+         * `postMessage` have the correct `this` context
+         */
+              const original = handlers[webkitMessageHandlerName]
+              const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original)
+              this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound
+              delete handlers[webkitMessageHandlerName].postMessage
+          }
+      }
+  }
+}
+
+/**
+ * Use this configuration to create an instance of {@link Messaging} for WebKit
+ *
+ * ```js
+ * import { fromConfig, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * const config = new WebkitMessagingConfig({
+ *   hasModernWebkitAPI: true,
+ *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
+ *   secret: "dax",
+ * });
+ *
+ * const messaging = new Messaging(config)
+ * const resp = await messaging.request("debugConfig")
+ * ```
+ */
+export class WebkitMessagingConfig {
+    /**
+   * @param {object} params
+   * @param {boolean} params.hasModernWebkitAPI
+   * @param {string[]} params.webkitMessageHandlerNames
+   * @param {string} params.secret
+   */
+    constructor (params) {
+    /**
+     * Whether or not the current WebKit Platform supports secure messaging
+     * by default (eg: macOS 11+)
+     */
+        this.hasModernWebkitAPI = params.hasModernWebkitAPI
+        /**
+     * A list of WebKit message handler names that a user script can send
+     */
+        this.webkitMessageHandlerNames = params.webkitMessageHandlerNames
+        /**
+     * A string provided by native platforms to be sent with future outgoing
+     * messages
+     */
+        this.secret = params.secret
+    }
+}
+
+/**
+ * This is the additional payload that gets appended to outgoing messages.
+ * It's used in the Swift side to encrypt the response that comes back
+ */
+export class SecureMessagingParams {
+    /**
+   * @param {object} params
+   * @param {string} params.methodName
+   * @param {string} params.secret
+   * @param {number[]} params.key
+   * @param {number[]} params.iv
+   */
+    constructor (params) {
+    /**
+     * The method that's been appended to `window` to be called later
+     */
+        this.methodName = params.methodName
+        /**
+     * The secret used to ensure message sender validity
+     */
+        this.secret = params.secret
+        /**
+     * The CipherKey as number[]
+     */
+        this.key = params.key
+        /**
+     * The Initial Vector as number[]
+     */
+        this.iv = params.iv
+    }
+}
+
+/**
+ * Capture some globals used for messaging handling to prevent page
+ * scripts from tampering with this
+ */
+function captureGlobals () {
+    // Creat base with null prototype
+    return {
+        window,
+        // Methods must be bound to their interface, otherwise they throw Illegal invocation
+        encrypt: window.crypto.subtle.encrypt.bind(window.crypto.subtle),
+        decrypt: window.crypto.subtle.decrypt.bind(window.crypto.subtle),
+        generateKey: window.crypto.subtle.generateKey.bind(window.crypto.subtle),
+        exportKey: window.crypto.subtle.exportKey.bind(window.crypto.subtle),
+        importKey: window.crypto.subtle.importKey.bind(window.crypto.subtle),
+        getRandomValues: window.crypto.getRandomValues.bind(window.crypto),
+        TextEncoder,
+        TextDecoder,
+        Uint8Array,
+        Uint16Array,
+        Uint32Array,
+        JSONstringify: window.JSON.stringify,
+        JSONparse: window.JSON.parse,
+        Arrayfrom: window.Array.from,
+        Promise: window.Promise,
+        ObjectDefineProperty: window.Object.defineProperty,
+        addEventListener: window.addEventListener.bind(window),
+        /** @type {Record<string, any>} */
+        capturedWebkitHandlers: {}
+    }
+}

--- a/src/deviceApiCalls/transports/apple.transport.js
+++ b/src/deviceApiCalls/transports/apple.transport.js
@@ -1,4 +1,4 @@
-import { Messaging, MissingHandler, WebkitMessagingConfig } from '@duckduckgo/content-scope-utils'
+import { Messaging, MissingHandler, WebkitMessagingConfig } from '../../../packages/messaging/messaging.js'
 import { DeviceApiTransport } from '../../../packages/device-api/index.js'
 import { GetRuntimeConfigurationCall } from '../__generated__/deviceApiCalls.js'
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -58,715 +58,6 @@ function processConfig(data, userList, preferences) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-var _messaging = require("./messaging.js");
-
-Object.keys(_messaging).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _messaging[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _messaging[key];
-    }
-  });
-});
-
-},{"./messaging.js":3}],3:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.MissingHandler = exports.MessagingTransport = exports.Messaging = void 0;
-Object.defineProperty(exports, "WebkitMessagingConfig", {
-  enumerable: true,
-  get: function () {
-    return _webkit.WebkitMessagingConfig;
-  }
-});
-Object.defineProperty(exports, "WindowsMessagingConfig", {
-  enumerable: true,
-  get: function () {
-    return _windows.WindowsMessagingConfig;
-  }
-});
-
-var _windows = require("./messaging/windows.js");
-
-var _webkit = require("./messaging/webkit.js");
-
-/**
- * @module Messaging
- *
- * @description
- *
- * An abstraction for communications between JavaScript and host platforms.
- *
- * 1) First you construct your platform-specific configuration (eg: {@link WebkitMessagingConfig})
- * 2) Then use that to get an instance of the Messaging utility which allows
- * you to send and receive data in a unified way
- * 3) Each platform implements {@link MessagingTransport} along with its own Configuration
- *     - For example, to learn what configuration is required for Webkit, see: {@link "Webkit Messaging".WebkitMessagingConfig}
- *     - Or, to learn about how messages are sent and received in Webkit, see {@link "Webkit Messaging".WebkitMessagingTransport}
- *
- * @example Webkit Messaging
- *
- * ```js
- * import { Messaging, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
- *
- * // This config would be injected into the UserScript
- * const injectedConfig = {
- *   hasModernWebkitAPI: true,
- *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
- *   secret: "dax",
- * };
- *
- * // Then use that config to construct platform-specific configuration
- * const config = new WebkitMessagingConfig(injectedConfig);
- *
- * // finally, get an instance of Messaging and start sending messages in a unified way 🚀
- * const messaging = new Messaging(config);
- * messaging.notify("hello world!", {foo: "bar"})
- *
- * ```
- *
- * @example Windows Messaging
- *
- * ```js
- * import { Messaging, WindowsMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
- *
- * // Messaging on Windows is namespaced, so you can create multiple messaging instances
- * const autofillConfig  = new WindowsMessagingConfig({ featureName: "Autofill" });
- * const debugConfig     = new WindowsMessagingConfig({ featureName: "Debugging" });
- *
- * const autofillMessaging = new Messaging(autofillConfig);
- * const debugMessaging    = new Messaging(debugConfig);
- *
- * // Now send messages to both features as needed 🚀
- * autofillMessaging.notify("storeFormData", { "username": "dax" })
- * debugMessaging.notify("pageLoad", { time: window.performance.now() })
- * ```
- */
-
-/**
- * @implements {MessagingTransport}
- */
-class Messaging {
-  /**
-   * @param {WebkitMessagingConfig | WindowsMessagingConfig} config
-   */
-  constructor(config) {
-    this.transport = getTransport(config);
-  }
-  /**
-   * Send a 'fire-and-forget' message.
-   * @throws
-   * {@link MissingHandler}
-   *
-   * @example
-   *
-   * ```
-   * const messaging = new Messaging(config)
-   * messaging.notify("foo", {bar: "baz"})
-   * ```
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
-
-
-  notify(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    this.transport.notify(name, data);
-  }
-  /**
-   * Send a request, and wait for a response
-   * @throws
-   * {@link MissingHandler}
-   *
-   * @example
-   * ```
-   * const messaging = new Messaging(config)
-   * const response = await messaging.request("foo", {bar: "baz"})
-   * ```
-   *
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
-
-
-  request(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    return this.transport.request(name, data);
-  }
-
-}
-/**
- * @interface
- */
-
-
-exports.Messaging = Messaging;
-
-class MessagingTransport {
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @returns {void}
-   */
-  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  notify(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    throw new Error("must implement 'notify'");
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
-  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-  request(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    throw new Error('must implement');
-  }
-
-}
-/**
- * @param {WebkitMessagingConfig | WindowsMessagingConfig} config
- * @returns {MessagingTransport}
- */
-
-
-exports.MessagingTransport = MessagingTransport;
-
-function getTransport(config) {
-  if (config instanceof _webkit.WebkitMessagingConfig) {
-    return new _webkit.WebkitMessagingTransport(config);
-  }
-
-  if (config instanceof _windows.WindowsMessagingConfig) {
-    return new _windows.WindowsMessagingTransport(config);
-  }
-
-  throw new Error('unreachable');
-}
-/**
- * Thrown when a handler cannot be found
- */
-
-
-class MissingHandler extends Error {
-  /**
-   * @param {string} message
-   * @param {string} handlerName
-   */
-  constructor(message, handlerName) {
-    super(message);
-    this.handlerName = handlerName;
-  }
-
-}
-/**
- * Some re-exports for convenience
- */
-
-
-exports.MissingHandler = MissingHandler;
-
-},{"./messaging/webkit.js":4,"./messaging/windows.js":5}],4:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.WebkitMessagingTransport = exports.WebkitMessagingConfig = exports.SecureMessagingParams = void 0;
-
-var _messaging = require("../messaging.js");
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-/**
- * @example
- * On macOS 11+, this will just call through to `window.webkit.messageHandlers.x.postMessage`
- *
- * Eg: for a `foo` message defined in Swift that accepted the payload `{"bar": "baz"}`, the following
- * would occur:
- *
- * ```js
- * const json = await window.webkit.messageHandlers.foo.postMessage({ bar: "baz" });
- * const response = JSON.parse(json)
- * ```
- *
- * @example
- * On macOS 10 however, the process is a little more involved. A method will be appended to `window`
- * that allows the response to be delivered there instead. It's not exactly this, but you can visualize the flow
- * as being something along the lines of:
- *
- * ```js
- * // add the window method
- * window["_0123456"] = (response) => {
- *    // decrypt `response` and deliver the result to the caller here
- *    // then remove the temporary method
- *    delete window["_0123456"]
- * };
- *
- * // send the data + `messageHanding` values
- * window.webkit.messageHandlers.foo.postMessage({
- *   bar: "baz",
- *   messagingHandling: {
- *     methodName: "_0123456",
- *     secret: "super-secret",
- *     key: [1, 2, 45, 2],
- *     iv: [34, 4, 43],
- *   }
- * });
- *
- * // later in swift, the following JavaScript snippet will be executed
- * (() => {
- *   window["_0123456"]({
- *     ciphertext: [12, 13, 4],
- *     tag: [3, 5, 67, 56]
- *   })
- * })()
- * ```
- * @implements {MessagingTransport}
- */
-class WebkitMessagingTransport {
-  /** @type {WebkitMessagingConfig} */
-
-  /**
-   * @param {WebkitMessagingConfig} config
-   */
-  constructor(config) {
-    _defineProperty(this, "config", void 0);
-
-    _defineProperty(this, "globals", void 0);
-
-    _defineProperty(this, "algoObj", {
-      name: 'AES-GCM',
-      length: 256
-    });
-
-    this.config = config;
-    this.globals = captureGlobals();
-
-    if (!this.config.hasModernWebkitAPI) {
-      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-    }
-  }
-  /**
-   * Sends message to the webkit layer (fire and forget)
-   * @param {String} handler
-   * @param {*} data
-   * @internal
-   */
-
-
-  wkSend(handler) {
-    var _this$globals$window$, _this$globals$window$2;
-
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    if (!(handler in this.globals.window.webkit.messageHandlers)) {
-      throw new _messaging.MissingHandler("Missing webkit handler: '".concat(handler, "'"), handler);
-    }
-
-    const outgoing = { ...data,
-      messageHandling: { ...data.messageHandling,
-        secret: this.config.secret
-      }
-    };
-
-    if (!this.config.hasModernWebkitAPI) {
-      if (!(handler in this.globals.capturedWebkitHandlers)) {
-        throw new _messaging.MissingHandler("cannot continue, method ".concat(handler, " not captured on macos < 11"), handler);
-      } else {
-        return this.globals.capturedWebkitHandlers[handler](outgoing);
-      }
-    }
-
-    return (_this$globals$window$ = (_this$globals$window$2 = this.globals.window.webkit.messageHandlers[handler]).postMessage) === null || _this$globals$window$ === void 0 ? void 0 : _this$globals$window$.call(_this$globals$window$2, outgoing);
-  }
-  /**
-   * Sends message to the webkit layer and waits for the specified response
-   * @param {String} handler
-   * @param {*} data
-   * @returns {Promise<*>}
-   * @internal
-   */
-
-
-  async wkSendAndWait(handler) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    if (this.config.hasModernWebkitAPI) {
-      const response = await this.wkSend(handler, data);
-      return this.globals.JSONparse(response || '{}');
-    }
-
-    try {
-      const randMethodName = this.createRandMethodName();
-      const key = await this.createRandKey();
-      const iv = this.createRandIv();
-      const {
-        ciphertext,
-        tag
-      } = await new this.globals.Promise((
-      /** @type {any} */
-      resolve) => {
-        this.generateRandomMethod(randMethodName, resolve);
-        data.messageHandling = new SecureMessagingParams({
-          methodName: randMethodName,
-          secret: this.config.secret,
-          key: this.globals.Arrayfrom(key),
-          iv: this.globals.Arrayfrom(iv)
-        });
-        this.wkSend(handler, data);
-      });
-      const cipher = new this.globals.Uint8Array([...ciphertext, ...tag]);
-      const decrypted = await this.decrypt(cipher, key, iv);
-      return this.globals.JSONparse(decrypted || '{}');
-    } catch (e) {
-      // re-throw when the error is just a 'MissingHandler'
-      if (e instanceof _messaging.MissingHandler) {
-        throw e;
-      } else {
-        console.error('decryption failed', e);
-        console.error(e);
-        return {
-          error: e
-        };
-      }
-    }
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
-
-
-  notify(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    this.wkSend(name, data);
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-  request(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    return this.wkSendAndWait(name, data);
-  }
-  /**
-   * Generate a random method name and adds it to the global scope
-   * The native layer will use this method to send the response
-   * @param {string | number} randomMethodName
-   * @param {Function} callback
-   */
-
-
-  generateRandomMethod(randomMethodName, callback) {
-    var _this = this;
-
-    this.globals.ObjectDefineProperty(this.globals.window, randomMethodName, {
-      enumerable: false,
-      // configurable, To allow for deletion later
-      configurable: true,
-      writable: false,
-
-      /**
-       * @param {any[]} args
-       */
-      value: function () {
-        callback(...arguments); // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
-
-        delete _this.globals.window[randomMethodName];
-      }
-    });
-  }
-
-  randomString() {
-    return '' + this.globals.getRandomValues(new this.globals.Uint32Array(1))[0];
-  }
-
-  createRandMethodName() {
-    return '_' + this.randomString();
-  }
-  /**
-   * @type {{name: string, length: number}}
-   */
-
-
-  /**
-   * @returns {Promise<Uint8Array>}
-   */
-  async createRandKey() {
-    const key = await this.globals.generateKey(this.algoObj, true, ['encrypt', 'decrypt']);
-    const exportedKey = await this.globals.exportKey('raw', key);
-    return new this.globals.Uint8Array(exportedKey);
-  }
-  /**
-   * @returns {Uint8Array}
-   */
-
-
-  createRandIv() {
-    return this.globals.getRandomValues(new this.globals.Uint8Array(12));
-  }
-  /**
-   * @param {BufferSource} ciphertext
-   * @param {BufferSource} key
-   * @param {Uint8Array} iv
-   * @returns {Promise<string>}
-   */
-
-
-  async decrypt(ciphertext, key, iv) {
-    const cryptoKey = await this.globals.importKey('raw', key, 'AES-GCM', false, ['decrypt']);
-    const algo = {
-      name: 'AES-GCM',
-      iv
-    };
-    let decrypted = await this.globals.decrypt(algo, cryptoKey, ciphertext);
-    let dec = new this.globals.TextDecoder();
-    return dec.decode(decrypted);
-  }
-  /**
-   * When required (such as on macos 10.x), capture the `postMessage` method on
-   * each webkit messageHandler
-   *
-   * @param {string[]} handlerNames
-   */
-
-
-  captureWebkitHandlers(handlerNames) {
-    const handlers = window.webkit.messageHandlers;
-    if (!handlers) throw new _messaging.MissingHandler('window.webkit.messageHandlers was absent', 'all');
-
-    for (let webkitMessageHandlerName of handlerNames) {
-      var _handlers$webkitMessa;
-
-      if (typeof ((_handlers$webkitMessa = handlers[webkitMessageHandlerName]) === null || _handlers$webkitMessa === void 0 ? void 0 : _handlers$webkitMessa.postMessage) === 'function') {
-        var _handlers$webkitMessa2;
-
-        /**
-         * `bind` is used here to ensure future calls to the captured
-         * `postMessage` have the correct `this` context
-         */
-        const original = handlers[webkitMessageHandlerName];
-        const bound = (_handlers$webkitMessa2 = handlers[webkitMessageHandlerName].postMessage) === null || _handlers$webkitMessa2 === void 0 ? void 0 : _handlers$webkitMessa2.bind(original);
-        this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-        delete handlers[webkitMessageHandlerName].postMessage;
-      }
-    }
-  }
-
-}
-/**
- * Use this configuration to create an instance of {@link Messaging} for WebKit
- *
- * ```js
- * import { fromConfig, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
- *
- * const config = new WebkitMessagingConfig({
- *   hasModernWebkitAPI: true,
- *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
- *   secret: "dax",
- * });
- *
- * const messaging = new Messaging(config)
- * const resp = await messaging.request("debugConfig")
- * ```
- */
-
-
-exports.WebkitMessagingTransport = WebkitMessagingTransport;
-
-class WebkitMessagingConfig {
-  /**
-   * @param {object} params
-   * @param {boolean} params.hasModernWebkitAPI
-   * @param {string[]} params.webkitMessageHandlerNames
-   * @param {string} params.secret
-   */
-  constructor(params) {
-    /**
-     * Whether or not the current WebKit Platform supports secure messaging
-     * by default (eg: macOS 11+)
-     */
-    this.hasModernWebkitAPI = params.hasModernWebkitAPI;
-    /**
-     * A list of WebKit message handler names that a user script can send
-     */
-
-    this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-    /**
-     * A string provided by native platforms to be sent with future outgoing
-     * messages
-     */
-
-    this.secret = params.secret;
-  }
-
-}
-/**
- * This is the additional payload that gets appended to outgoing messages.
- * It's used in the Swift side to encrypt the response that comes back
- */
-
-
-exports.WebkitMessagingConfig = WebkitMessagingConfig;
-
-class SecureMessagingParams {
-  /**
-   * @param {object} params
-   * @param {string} params.methodName
-   * @param {string} params.secret
-   * @param {number[]} params.key
-   * @param {number[]} params.iv
-   */
-  constructor(params) {
-    /**
-     * The method that's been appended to `window` to be called later
-     */
-    this.methodName = params.methodName;
-    /**
-     * The secret used to ensure message sender validity
-     */
-
-    this.secret = params.secret;
-    /**
-     * The CipherKey as number[]
-     */
-
-    this.key = params.key;
-    /**
-     * The Initial Vector as number[]
-     */
-
-    this.iv = params.iv;
-  }
-
-}
-/**
- * Capture some globals used for messaging handling to prevent page
- * scripts from tampering with this
- */
-
-
-exports.SecureMessagingParams = SecureMessagingParams;
-
-function captureGlobals() {
-  // Creat base with null prototype
-  return {
-    window,
-    // Methods must be bound to their interface, otherwise they throw Illegal invocation
-    encrypt: window.crypto.subtle.encrypt.bind(window.crypto.subtle),
-    decrypt: window.crypto.subtle.decrypt.bind(window.crypto.subtle),
-    generateKey: window.crypto.subtle.generateKey.bind(window.crypto.subtle),
-    exportKey: window.crypto.subtle.exportKey.bind(window.crypto.subtle),
-    importKey: window.crypto.subtle.importKey.bind(window.crypto.subtle),
-    getRandomValues: window.crypto.getRandomValues.bind(window.crypto),
-    TextEncoder,
-    TextDecoder,
-    Uint8Array,
-    Uint16Array,
-    Uint32Array,
-    JSONstringify: window.JSON.stringify,
-    JSONparse: window.JSON.parse,
-    Arrayfrom: window.Array.from,
-    Promise: window.Promise,
-    ObjectDefineProperty: window.Object.defineProperty,
-    addEventListener: window.addEventListener.bind(window),
-
-    /** @type {Record<string, any>} */
-    capturedWebkitHandlers: {}
-  };
-}
-
-},{"../messaging.js":3}],5:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.WindowsMessagingTransport = exports.WindowsMessagingConfig = void 0;
-
-var _messaging = require("../messaging.js");
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-/**
- * @implements {MessagingTransport}
- */
-class WindowsMessagingTransport {
-  /**
-   * @param {WindowsMessagingConfig} config
-   */
-  constructor(config) {
-    _defineProperty(this, "config", void 0);
-
-    this.config = config;
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-  notify(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    throw new Error('todo: implement notify for windows');
-  }
-  /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @param {{signal?: AbortSignal}} opts
-   * @return {Promise<any>}
-   */
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-  request(name) {
-    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    let opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-    throw new Error('todo: implement request for windows');
-  }
-
-}
-
-exports.WindowsMessagingTransport = WindowsMessagingTransport;
-
-class WindowsMessagingConfig {
-  /**
-   * @param {object} params
-   * @param {string} params.featureName
-   */
-  constructor(params) {
-    this.featureName = params.featureName;
-  }
-
-}
-
-exports.WindowsMessagingConfig = WindowsMessagingConfig;
-
-},{"../messaging.js":3}],6:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
 exports.setErrorMap = exports.overrideErrorMap = exports.defaultErrorMap = exports.ZodError = exports.quotelessJson = exports.ZodIssueCode = void 0;
 
 const parseUtil_1 = require("./helpers/parseUtil");
@@ -1005,7 +296,7 @@ const setErrorMap = map => {
 
 exports.setErrorMap = setErrorMap;
 
-},{"./helpers/parseUtil":9,"./helpers/util":11}],7:[function(require,module,exports){
+},{"./helpers/parseUtil":5,"./helpers/util":7}],3:[function(require,module,exports){
 "use strict";
 
 var __createBinding = void 0 && (void 0).__createBinding || (Object.create ? function (o, m, k, k2) {
@@ -1043,7 +334,7 @@ __exportStar(require("./types"), exports);
 
 __exportStar(require("./ZodError"), exports);
 
-},{"./ZodError":6,"./helpers/parseUtil":9,"./helpers/typeAliases":10,"./types":13}],8:[function(require,module,exports){
+},{"./ZodError":2,"./helpers/parseUtil":5,"./helpers/typeAliases":6,"./types":9}],4:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1060,7 +351,7 @@ var errorUtil;
   errorUtil.toString = message => typeof message === "string" ? message : message === null || message === void 0 ? void 0 : message.message;
 })(errorUtil = exports.errorUtil || (exports.errorUtil = {}));
 
-},{}],9:[function(require,module,exports){
+},{}],5:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1275,14 +566,14 @@ const isAsync = x => typeof Promise !== undefined && x instanceof Promise;
 
 exports.isAsync = isAsync;
 
-},{"../ZodError":6,"./util":11}],10:[function(require,module,exports){
+},{"../ZodError":2,"./util":7}],6:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-},{}],11:[function(require,module,exports){
+},{}],7:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1358,7 +649,7 @@ var util;
   util.joinValues = joinValues;
 })(util = exports.util || (exports.util = {}));
 
-},{}],12:[function(require,module,exports){
+},{}],8:[function(require,module,exports){
 "use strict";
 
 var __createBinding = void 0 && (void 0).__createBinding || (Object.create ? function (o, m, k, k2) {
@@ -1416,7 +707,7 @@ __exportStar(require("./external"), exports);
 
 exports.default = mod;
 
-},{"./external":7}],13:[function(require,module,exports){
+},{"./external":3}],9:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4437,7 +3728,7 @@ const oboolean = () => booleanType().optional();
 
 exports.oboolean = oboolean;
 
-},{"./ZodError":6,"./helpers/errorUtil":8,"./helpers/parseUtil":9,"./helpers/util":11}],14:[function(require,module,exports){
+},{"./ZodError":2,"./helpers/errorUtil":4,"./helpers/parseUtil":5,"./helpers/util":7}],10:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4484,7 +3775,7 @@ var _deviceApiCall = require("./lib/device-api-call.js");
 
 var _deviceApi = require("./lib/device-api.js");
 
-},{"./lib/device-api-call.js":15,"./lib/device-api.js":16}],15:[function(require,module,exports){
+},{"./lib/device-api-call.js":11,"./lib/device-api.js":12}],11:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4810,7 +4101,7 @@ function validate(data) {
   return data;
 }
 
-},{}],16:[function(require,module,exports){
+},{}],12:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4886,7 +4177,615 @@ class DeviceApi {
 
 exports.DeviceApi = DeviceApi;
 
-},{}],17:[function(require,module,exports){
+},{}],13:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.MissingHandler = exports.MessagingTransport = exports.Messaging = void 0;
+Object.defineProperty(exports, "WebkitMessagingConfig", {
+  enumerable: true,
+  get: function () {
+    return _webkit.WebkitMessagingConfig;
+  }
+});
+
+var _webkit = require("./webkit.js");
+
+/**
+ * @module Messaging
+ *
+ * @description
+ *
+ * An abstraction for communications between JavaScript and host platforms.
+ *
+ * 1) First you construct your platform-specific configuration (eg: {@link WebkitMessagingConfig})
+ * 2) Then use that to get an instance of the Messaging utility which allows
+ * you to send and receive data in a unified way
+ * 3) Each platform implements {@link MessagingTransport} along with its own Configuration
+ *     - For example, to learn what configuration is required for Webkit, see: {@link "Webkit Messaging".WebkitMessagingConfig}
+ *     - Or, to learn about how messages are sent and received in Webkit, see {@link "Webkit Messaging".WebkitMessagingTransport}
+ *
+ * @example Webkit Messaging
+ *
+ * ```js
+ * import { Messaging, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * // This config would be injected into the UserScript
+ * const injectedConfig = {
+ *   hasModernWebkitAPI: true,
+ *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
+ *   secret: "dax",
+ * };
+ *
+ * // Then use that config to construct platform-specific configuration
+ * const config = new WebkitMessagingConfig(injectedConfig);
+ *
+ * // finally, get an instance of Messaging and start sending messages in a unified way 🚀
+ * const messaging = new Messaging(config);
+ * messaging.notify("hello world!", {foo: "bar"})
+ *
+ * ```
+ *
+ * @example Windows Messaging
+ *
+ * ```js
+ * import { Messaging, WindowsMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * // Messaging on Windows is namespaced, so you can create multiple messaging instances
+ * const autofillConfig  = new WindowsMessagingConfig({ featureName: "Autofill" });
+ * const debugConfig     = new WindowsMessagingConfig({ featureName: "Debugging" });
+ *
+ * const autofillMessaging = new Messaging(autofillConfig);
+ * const debugMessaging    = new Messaging(debugConfig);
+ *
+ * // Now send messages to both features as needed 🚀
+ * autofillMessaging.notify("storeFormData", { "username": "dax" })
+ * debugMessaging.notify("pageLoad", { time: window.performance.now() })
+ * ```
+ */
+
+/**
+ * @implements {MessagingTransport}
+ */
+class Messaging {
+  /**
+   * @param {WebkitMessagingConfig} config
+   */
+  constructor(config) {
+    this.transport = getTransport(config);
+  }
+  /**
+   * Send a 'fire-and-forget' message.
+   * @throws {Error}
+   * {@link MissingHandler}
+   *
+   * @example
+   *
+   * ```
+   * const messaging = new Messaging(config)
+   * messaging.notify("foo", {bar: "baz"})
+   * ```
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+
+
+  notify(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    this.transport.notify(name, data);
+  }
+  /**
+   * Send a request, and wait for a response
+   * @throws {Error}
+   * {@link MissingHandler}
+   *
+   * @example
+   * ```
+   * const messaging = new Messaging(config)
+   * const response = await messaging.request("foo", {bar: "baz"})
+   * ```
+   *
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @return {Promise<any>}
+   */
+
+
+  request(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    return this.transport.request(name, data);
+  }
+
+}
+/**
+ * @interface
+ */
+
+
+exports.Messaging = Messaging;
+
+class MessagingTransport {
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @returns {void}
+   */
+  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  notify(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    throw new Error("must implement 'notify'");
+  }
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   * @return {Promise<any>}
+   */
+  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+
+  request(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    throw new Error('must implement');
+  }
+
+}
+/**
+ * @param {WebkitMessagingConfig} config
+ * @returns {MessagingTransport}
+ */
+
+
+exports.MessagingTransport = MessagingTransport;
+
+function getTransport(config) {
+  if (config instanceof _webkit.WebkitMessagingConfig) {
+    return new _webkit.WebkitMessagingTransport(config);
+  }
+
+  throw new Error('unreachable');
+}
+/**
+ * Thrown when a handler cannot be found
+ */
+
+
+class MissingHandler extends Error {
+  /**
+   * @param {string} message
+   * @param {string} handlerName
+   */
+  constructor(message, handlerName) {
+    super(message);
+    this.handlerName = handlerName;
+  }
+
+}
+/**
+ * Some re-exports for convenience
+ */
+
+
+exports.MissingHandler = MissingHandler;
+
+},{"./webkit.js":14}],14:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.WebkitMessagingTransport = exports.WebkitMessagingConfig = exports.SecureMessagingParams = void 0;
+
+var _messaging = require("./messaging.js");
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/**
+ * @example
+ * On macOS 11+, this will just call through to `window.webkit.messageHandlers.x.postMessage`
+ *
+ * Eg: for a `foo` message defined in Swift that accepted the payload `{"bar": "baz"}`, the following
+ * would occur:
+ *
+ * ```js
+ * const json = await window.webkit.messageHandlers.foo.postMessage({ bar: "baz" });
+ * const response = JSON.parse(json)
+ * ```
+ *
+ * @example
+ * On macOS 10 however, the process is a little more involved. A method will be appended to `window`
+ * that allows the response to be delivered there instead. It's not exactly this, but you can visualize the flow
+ * as being something along the lines of:
+ *
+ * ```js
+ * // add the window method
+ * window["_0123456"] = (response) => {
+ *    // decrypt `response` and deliver the result to the caller here
+ *    // then remove the temporary method
+ *    delete window["_0123456"]
+ * };
+ *
+ * // send the data + `messageHanding` values
+ * window.webkit.messageHandlers.foo.postMessage({
+ *   bar: "baz",
+ *   messagingHandling: {
+ *     methodName: "_0123456",
+ *     secret: "super-secret",
+ *     key: [1, 2, 45, 2],
+ *     iv: [34, 4, 43],
+ *   }
+ * });
+ *
+ * // later in swift, the following JavaScript snippet will be executed
+ * (() => {
+ *   window["_0123456"]({
+ *     ciphertext: [12, 13, 4],
+ *     tag: [3, 5, 67, 56]
+ *   })
+ * })()
+ * ```
+ * @implements {MessagingTransport}
+ */
+class WebkitMessagingTransport {
+  /** @type {WebkitMessagingConfig} */
+
+  /**
+   * @param {WebkitMessagingConfig} config
+   */
+  constructor(config) {
+    _defineProperty(this, "config", void 0);
+
+    _defineProperty(this, "globals", void 0);
+
+    _defineProperty(this, "algoObj", {
+      name: 'AES-GCM',
+      length: 256
+    });
+
+    this.config = config;
+    this.globals = captureGlobals();
+
+    if (!this.config.hasModernWebkitAPI) {
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
+    }
+  }
+  /**
+   * Sends message to the webkit layer (fire and forget)
+   * @param {String} handler
+   * @param {*} data
+   * @internal
+   */
+
+
+  wkSend(handler) {
+    var _this$globals$window$, _this$globals$window$2;
+
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    if (!(handler in this.globals.window.webkit.messageHandlers)) {
+      throw new _messaging.MissingHandler("Missing webkit handler: '".concat(handler, "'"), handler);
+    }
+
+    const outgoing = { ...data,
+      messageHandling: { ...data.messageHandling,
+        secret: this.config.secret
+      }
+    };
+
+    if (!this.config.hasModernWebkitAPI) {
+      if (!(handler in this.globals.capturedWebkitHandlers)) {
+        throw new _messaging.MissingHandler("cannot continue, method ".concat(handler, " not captured on macos < 11"), handler);
+      } else {
+        return this.globals.capturedWebkitHandlers[handler](outgoing);
+      }
+    }
+
+    return (_this$globals$window$ = (_this$globals$window$2 = this.globals.window.webkit.messageHandlers[handler]).postMessage) === null || _this$globals$window$ === void 0 ? void 0 : _this$globals$window$.call(_this$globals$window$2, outgoing);
+  }
+  /**
+   * Sends message to the webkit layer and waits for the specified response
+   * @param {String} handler
+   * @param {*} data
+   * @returns {Promise<*>}
+   * @internal
+   */
+
+
+  async wkSendAndWait(handler) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    if (this.config.hasModernWebkitAPI) {
+      const response = await this.wkSend(handler, data);
+      return this.globals.JSONparse(response || '{}');
+    }
+
+    try {
+      const randMethodName = this.createRandMethodName();
+      const key = await this.createRandKey();
+      const iv = this.createRandIv();
+      const {
+        ciphertext,
+        tag
+      } = await new this.globals.Promise((
+      /** @type {any} */
+      resolve) => {
+        this.generateRandomMethod(randMethodName, resolve);
+        data.messageHandling = new SecureMessagingParams({
+          methodName: randMethodName,
+          secret: this.config.secret,
+          key: this.globals.Arrayfrom(key),
+          iv: this.globals.Arrayfrom(iv)
+        });
+        this.wkSend(handler, data);
+      });
+      const cipher = new this.globals.Uint8Array([...ciphertext, ...tag]);
+      const decrypted = await this.decrypt(cipher, key, iv);
+      return this.globals.JSONparse(decrypted || '{}');
+    } catch (e) {
+      // re-throw when the error is just a 'MissingHandler'
+      if (e instanceof _messaging.MissingHandler) {
+        throw e;
+      } else {
+        console.error('decryption failed', e);
+        console.error(e);
+        return {
+          error: e
+        };
+      }
+    }
+  }
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+
+
+  notify(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    this.wkSend(name, data);
+  }
+  /**
+   * @param {string} name
+   * @param {Record<string, any>} [data]
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+
+  request(name) {
+    let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    return this.wkSendAndWait(name, data);
+  }
+  /**
+   * Generate a random method name and adds it to the global scope
+   * The native layer will use this method to send the response
+   * @param {string | number} randomMethodName
+   * @param {Function} callback
+   */
+
+
+  generateRandomMethod(randomMethodName, callback) {
+    var _this = this;
+
+    this.globals.ObjectDefineProperty(this.globals.window, randomMethodName, {
+      enumerable: false,
+      // configurable, To allow for deletion later
+      configurable: true,
+      writable: false,
+
+      /**
+       * @param {any[]} args
+       */
+      value: function () {
+        callback(...arguments); // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
+
+        delete _this.globals.window[randomMethodName];
+      }
+    });
+  }
+
+  randomString() {
+    return '' + this.globals.getRandomValues(new this.globals.Uint32Array(1))[0];
+  }
+
+  createRandMethodName() {
+    return '_' + this.randomString();
+  }
+  /**
+   * @type {{name: string, length: number}}
+   */
+
+
+  /**
+   * @returns {Promise<Uint8Array>}
+   */
+  async createRandKey() {
+    const key = await this.globals.generateKey(this.algoObj, true, ['encrypt', 'decrypt']);
+    const exportedKey = await this.globals.exportKey('raw', key);
+    return new this.globals.Uint8Array(exportedKey);
+  }
+  /**
+   * @returns {Uint8Array}
+   */
+
+
+  createRandIv() {
+    return this.globals.getRandomValues(new this.globals.Uint8Array(12));
+  }
+  /**
+   * @param {BufferSource} ciphertext
+   * @param {BufferSource} key
+   * @param {Uint8Array} iv
+   * @returns {Promise<string>}
+   */
+
+
+  async decrypt(ciphertext, key, iv) {
+    const cryptoKey = await this.globals.importKey('raw', key, 'AES-GCM', false, ['decrypt']);
+    const algo = {
+      name: 'AES-GCM',
+      iv
+    };
+    let decrypted = await this.globals.decrypt(algo, cryptoKey, ciphertext);
+    let dec = new this.globals.TextDecoder();
+    return dec.decode(decrypted);
+  }
+  /**
+   * When required (such as on macos 10.x), capture the `postMessage` method on
+   * each webkit messageHandler
+   *
+   * @param {string[]} handlerNames
+   */
+
+
+  captureWebkitHandlers(handlerNames) {
+    const handlers = window.webkit.messageHandlers;
+    if (!handlers) throw new _messaging.MissingHandler('window.webkit.messageHandlers was absent', 'all');
+
+    for (let webkitMessageHandlerName of handlerNames) {
+      var _handlers$webkitMessa;
+
+      if (typeof ((_handlers$webkitMessa = handlers[webkitMessageHandlerName]) === null || _handlers$webkitMessa === void 0 ? void 0 : _handlers$webkitMessa.postMessage) === 'function') {
+        var _handlers$webkitMessa2;
+
+        /**
+         * `bind` is used here to ensure future calls to the captured
+         * `postMessage` have the correct `this` context
+         */
+        const original = handlers[webkitMessageHandlerName];
+        const bound = (_handlers$webkitMessa2 = handlers[webkitMessageHandlerName].postMessage) === null || _handlers$webkitMessa2 === void 0 ? void 0 : _handlers$webkitMessa2.bind(original);
+        this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
+        delete handlers[webkitMessageHandlerName].postMessage;
+      }
+    }
+  }
+
+}
+/**
+ * Use this configuration to create an instance of {@link Messaging} for WebKit
+ *
+ * ```js
+ * import { fromConfig, WebkitMessagingConfig } from "@duckduckgo/content-scope-scripts/lib/messaging.js"
+ *
+ * const config = new WebkitMessagingConfig({
+ *   hasModernWebkitAPI: true,
+ *   webkitMessageHandlerNames: ["foo", "bar", "baz"],
+ *   secret: "dax",
+ * });
+ *
+ * const messaging = new Messaging(config)
+ * const resp = await messaging.request("debugConfig")
+ * ```
+ */
+
+
+exports.WebkitMessagingTransport = WebkitMessagingTransport;
+
+class WebkitMessagingConfig {
+  /**
+   * @param {object} params
+   * @param {boolean} params.hasModernWebkitAPI
+   * @param {string[]} params.webkitMessageHandlerNames
+   * @param {string} params.secret
+   */
+  constructor(params) {
+    /**
+     * Whether or not the current WebKit Platform supports secure messaging
+     * by default (eg: macOS 11+)
+     */
+    this.hasModernWebkitAPI = params.hasModernWebkitAPI;
+    /**
+     * A list of WebKit message handler names that a user script can send
+     */
+
+    this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
+    /**
+     * A string provided by native platforms to be sent with future outgoing
+     * messages
+     */
+
+    this.secret = params.secret;
+  }
+
+}
+/**
+ * This is the additional payload that gets appended to outgoing messages.
+ * It's used in the Swift side to encrypt the response that comes back
+ */
+
+
+exports.WebkitMessagingConfig = WebkitMessagingConfig;
+
+class SecureMessagingParams {
+  /**
+   * @param {object} params
+   * @param {string} params.methodName
+   * @param {string} params.secret
+   * @param {number[]} params.key
+   * @param {number[]} params.iv
+   */
+  constructor(params) {
+    /**
+     * The method that's been appended to `window` to be called later
+     */
+    this.methodName = params.methodName;
+    /**
+     * The secret used to ensure message sender validity
+     */
+
+    this.secret = params.secret;
+    /**
+     * The CipherKey as number[]
+     */
+
+    this.key = params.key;
+    /**
+     * The Initial Vector as number[]
+     */
+
+    this.iv = params.iv;
+  }
+
+}
+/**
+ * Capture some globals used for messaging handling to prevent page
+ * scripts from tampering with this
+ */
+
+
+exports.SecureMessagingParams = SecureMessagingParams;
+
+function captureGlobals() {
+  // Creat base with null prototype
+  return {
+    window,
+    // Methods must be bound to their interface, otherwise they throw Illegal invocation
+    encrypt: window.crypto.subtle.encrypt.bind(window.crypto.subtle),
+    decrypt: window.crypto.subtle.decrypt.bind(window.crypto.subtle),
+    generateKey: window.crypto.subtle.generateKey.bind(window.crypto.subtle),
+    exportKey: window.crypto.subtle.exportKey.bind(window.crypto.subtle),
+    importKey: window.crypto.subtle.importKey.bind(window.crypto.subtle),
+    getRandomValues: window.crypto.getRandomValues.bind(window.crypto),
+    TextEncoder,
+    TextDecoder,
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    JSONstringify: window.JSON.stringify,
+    JSONparse: window.JSON.parse,
+    Arrayfrom: window.Array.from,
+    Promise: window.Promise,
+    ObjectDefineProperty: window.Object.defineProperty,
+    addEventListener: window.addEventListener.bind(window),
+
+    /** @type {Record<string, any>} */
+    capturedWebkitHandlers: {}
+  };
+}
+
+},{"./messaging.js":13}],15:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -5035,7 +4934,7 @@ function _safeHostname(inputHostname) {
   }
 }
 
-},{"./lib/apple.password.js":18,"./lib/constants.js":19,"./lib/rules-parser.js":20}],18:[function(require,module,exports){
+},{"./lib/apple.password.js":16,"./lib/constants.js":17,"./lib/rules-parser.js":18}],16:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -5659,7 +5558,7 @@ exports.Password = Password;
 
 _defineProperty(Password, "defaults", defaults);
 
-},{"./constants.js":19,"./rules-parser.js":20}],19:[function(require,module,exports){
+},{"./constants.js":17,"./rules-parser.js":18}],17:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -5680,7 +5579,7 @@ const constants = {
 };
 exports.constants = constants;
 
-},{}],20:[function(require,module,exports){
+},{}],18:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -6413,7 +6312,7 @@ function parsePasswordRules(input, formatRulesForMinifiedVersion) {
   return newPasswordRules;
 }
 
-},{}],21:[function(require,module,exports){
+},{}],19:[function(require,module,exports){
 module.exports={
   "163.com": {
     "password-rules": "minlength: 6; maxlength: 16;"
@@ -7244,7 +7143,7 @@ module.exports={
     "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
   }
 }
-},{}],22:[function(require,module,exports){
+},{}],20:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7317,7 +7216,7 @@ function createDevice() {
   return new _ExtensionInterface.ExtensionInterface(globalConfig, deviceApi, settings);
 }
 
-},{"../packages/device-api/index.js":14,"./DeviceInterface/AndroidInterface.js":23,"./DeviceInterface/AppleDeviceInterface.js":24,"./DeviceInterface/AppleOverlayDeviceInterface.js":25,"./DeviceInterface/ExtensionInterface.js":26,"./DeviceInterface/WindowsInterface.js":28,"./DeviceInterface/WindowsOverlayDeviceInterface.js":29,"./Settings.js":50,"./config.js":63,"./deviceApiCalls/transports/transports.js":71}],23:[function(require,module,exports){
+},{"../packages/device-api/index.js":10,"./DeviceInterface/AndroidInterface.js":21,"./DeviceInterface/AppleDeviceInterface.js":22,"./DeviceInterface/AppleOverlayDeviceInterface.js":23,"./DeviceInterface/ExtensionInterface.js":24,"./DeviceInterface/WindowsInterface.js":26,"./DeviceInterface/WindowsOverlayDeviceInterface.js":27,"./Settings.js":48,"./config.js":61,"./deviceApiCalls/transports/transports.js":69}],21:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7467,7 +7366,7 @@ class AndroidInterface extends _InterfacePrototype.default {
 
 exports.AndroidInterface = AndroidInterface;
 
-},{"../UI/controllers/NativeUIController.js":56,"../autofill-utils.js":61,"./InterfacePrototype.js":27,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],24:[function(require,module,exports){
+},{"../UI/controllers/NativeUIController.js":54,"../autofill-utils.js":59,"./InterfacePrototype.js":25,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],22:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7919,7 +7818,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
 
 exports.AppleDeviceInterface = AppleDeviceInterface;
 
-},{"../../packages/device-api/index.js":14,"../Form/matching.js":43,"../InContextSignup.js":44,"../UI/HTMLTooltip.js":54,"../UI/controllers/HTMLTooltipUIController.js":55,"../UI/controllers/NativeUIController.js":56,"../UI/controllers/OverlayUIController.js":57,"../autofill-utils.js":61,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"../deviceApiCalls/additionalDeviceApiCalls.js":67,"./InterfacePrototype.js":27,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],25:[function(require,module,exports){
+},{"../../packages/device-api/index.js":10,"../Form/matching.js":41,"../InContextSignup.js":42,"../UI/HTMLTooltip.js":52,"../UI/controllers/HTMLTooltipUIController.js":53,"../UI/controllers/NativeUIController.js":54,"../UI/controllers/OverlayUIController.js":55,"../autofill-utils.js":59,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"../deviceApiCalls/additionalDeviceApiCalls.js":65,"./InterfacePrototype.js":25,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],23:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -8074,7 +7973,7 @@ class AppleOverlayDeviceInterface extends _AppleDeviceInterface.AppleDeviceInter
 
 exports.AppleOverlayDeviceInterface = AppleOverlayDeviceInterface;
 
-},{"../../packages/device-api/index.js":14,"../UI/controllers/HTMLTooltipUIController.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"../deviceApiCalls/__generated__/validators.zod.js":66,"./AppleDeviceInterface.js":24,"./overlayApi.js":31}],26:[function(require,module,exports){
+},{"../../packages/device-api/index.js":10,"../UI/controllers/HTMLTooltipUIController.js":53,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"../deviceApiCalls/__generated__/validators.zod.js":64,"./AppleDeviceInterface.js":22,"./overlayApi.js":29}],24:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -8352,7 +8251,7 @@ class ExtensionInterface extends _InterfacePrototype.default {
 
 exports.ExtensionInterface = ExtensionInterface;
 
-},{"../Form/matching.js":43,"../InContextSignup.js":44,"../UI/HTMLTooltip.js":54,"../UI/controllers/HTMLTooltipUIController.js":55,"../autofill-utils.js":61,"./InterfacePrototype.js":27}],27:[function(require,module,exports){
+},{"../Form/matching.js":41,"../InContextSignup.js":42,"../UI/HTMLTooltip.js":52,"../UI/controllers/HTMLTooltipUIController.js":53,"../autofill-utils.js":59,"./InterfacePrototype.js":25}],25:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9421,7 +9320,7 @@ class InterfacePrototype {
 var _default = InterfacePrototype;
 exports.default = _default;
 
-},{"../../packages/device-api/index.js":14,"../EmailProtection.js":32,"../Form/formatters.js":36,"../Form/matching.js":43,"../InputTypes/Credentials.js":45,"../PasswordGenerator.js":48,"../Scanner.js":49,"../Settings.js":50,"../UI/controllers/NativeUIController.js":56,"../autofill-utils.js":61,"../config.js":63,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"../deviceApiCalls/__generated__/validators.zod.js":66,"../deviceApiCalls/transports/transports.js":71,"./initFormSubmissionsApi.js":30}],28:[function(require,module,exports){
+},{"../../packages/device-api/index.js":10,"../EmailProtection.js":30,"../Form/formatters.js":34,"../Form/matching.js":41,"../InputTypes/Credentials.js":43,"../PasswordGenerator.js":46,"../Scanner.js":47,"../Settings.js":48,"../UI/controllers/NativeUIController.js":54,"../autofill-utils.js":59,"../config.js":61,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"../deviceApiCalls/__generated__/validators.zod.js":64,"../deviceApiCalls/transports/transports.js":69,"./initFormSubmissionsApi.js":28}],26:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9637,7 +9536,7 @@ class WindowsInterface extends _InterfacePrototype.default {
 
 exports.WindowsInterface = WindowsInterface;
 
-},{"../UI/controllers/OverlayUIController.js":57,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"./InterfacePrototype.js":27}],29:[function(require,module,exports){
+},{"../UI/controllers/OverlayUIController.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"./InterfacePrototype.js":25}],27:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9846,7 +9745,7 @@ class WindowsOverlayDeviceInterface extends _InterfacePrototype.default {
 
 exports.WindowsOverlayDeviceInterface = WindowsOverlayDeviceInterface;
 
-},{"../UI/controllers/HTMLTooltipUIController.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":65,"./InterfacePrototype.js":27,"./overlayApi.js":31}],30:[function(require,module,exports){
+},{"../UI/controllers/HTMLTooltipUIController.js":53,"../deviceApiCalls/__generated__/deviceApiCalls.js":63,"./InterfacePrototype.js":25,"./overlayApi.js":29}],28:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -9952,7 +9851,7 @@ function initFormSubmissionsApi(forms, matching) {
   });
 }
 
-},{"../Form/label-util.js":39,"../autofill-utils.js":61}],31:[function(require,module,exports){
+},{"../Form/label-util.js":37,"../autofill-utils.js":59}],29:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -10019,7 +9918,7 @@ function overlayApi(device) {
   };
 }
 
-},{"../deviceApiCalls/__generated__/deviceApiCalls.js":65}],32:[function(require,module,exports){
+},{"../deviceApiCalls/__generated__/deviceApiCalls.js":63}],30:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -10080,7 +9979,7 @@ class EmailProtection {
 
 exports.EmailProtection = EmailProtection;
 
-},{}],33:[function(require,module,exports){
+},{}],31:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11000,7 +10899,7 @@ class Form {
 
 exports.Form = Form;
 
-},{"../autofill-utils.js":61,"../constants.js":64,"./FormAnalyzer.js":34,"./formatters.js":36,"./inputStyles.js":37,"./inputTypeConfig.js":38,"./matching.js":43}],34:[function(require,module,exports){
+},{"../autofill-utils.js":59,"../constants.js":62,"./FormAnalyzer.js":32,"./formatters.js":34,"./inputStyles.js":35,"./inputTypeConfig.js":36,"./matching.js":41}],32:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11394,7 +11293,7 @@ class FormAnalyzer {
 var _default = FormAnalyzer;
 exports.default = _default;
 
-},{"../autofill-utils.js":61,"../constants.js":64,"./matching-config/__generated__/compiled-matching-config.js":41,"./matching.js":43}],35:[function(require,module,exports){
+},{"../autofill-utils.js":59,"../constants.js":62,"./matching-config/__generated__/compiled-matching-config.js":39,"./matching.js":41}],33:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11962,7 +11861,7 @@ const COUNTRY_NAMES_TO_CODES = {
 };
 exports.COUNTRY_NAMES_TO_CODES = COUNTRY_NAMES_TO_CODES;
 
-},{}],36:[function(require,module,exports){
+},{}],34:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12319,7 +12218,7 @@ const prepareFormValuesForStorage = formValues => {
 
 exports.prepareFormValuesForStorage = prepareFormValuesForStorage;
 
-},{"./countryNames.js":35,"./matching.js":43}],37:[function(require,module,exports){
+},{"./countryNames.js":33,"./matching.js":41}],35:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12421,7 +12320,7 @@ const getIconStylesAutofilled = (input, form) => {
 
 exports.getIconStylesAutofilled = getIconStylesAutofilled;
 
-},{"./inputTypeConfig.js":38}],38:[function(require,module,exports){
+},{"./inputTypeConfig.js":36}],36:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12701,7 +12600,7 @@ const isFieldDecorated = input => {
 
 exports.isFieldDecorated = isFieldDecorated;
 
-},{"../InputTypes/Credentials.js":45,"../InputTypes/CreditCard.js":46,"../InputTypes/Identity.js":47,"../UI/img/ddgPasswordIcon.js":59,"../constants.js":64,"./logo-svg.js":40,"./matching.js":43}],39:[function(require,module,exports){
+},{"../InputTypes/Credentials.js":43,"../InputTypes/CreditCard.js":44,"../InputTypes/Identity.js":45,"../UI/img/ddgPasswordIcon.js":57,"../constants.js":62,"./logo-svg.js":38,"./matching.js":41}],37:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12762,7 +12661,7 @@ const extractElementStrings = element => {
 
 exports.extractElementStrings = extractElementStrings;
 
-},{"./matching.js":43}],40:[function(require,module,exports){
+},{"./matching.js":41}],38:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12776,7 +12675,7 @@ const daxGrayscaleSvg = "\n<svg width=\"128\" height=\"128\" viewBox=\"0 0 128 1
 const daxGrayscaleBase64 = "data:image/svg+xml;base64,".concat(window.btoa(daxGrayscaleSvg));
 exports.daxGrayscaleBase64 = daxGrayscaleBase64;
 
-},{}],41:[function(require,module,exports){
+},{}],39:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -13224,7 +13123,7 @@ const matchingConfiguration = {
 };
 exports.matchingConfiguration = matchingConfiguration;
 
-},{}],42:[function(require,module,exports){
+},{}],40:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -13307,7 +13206,7 @@ function logUnmatched(el, allStrings) {
   console.groupEnd();
 }
 
-},{"../autofill-utils.js":61,"./matching.js":43}],43:[function(require,module,exports){
+},{"../autofill-utils.js":59,"./matching.js":41}],41:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14394,7 +14293,7 @@ function createMatching() {
   return new Matching(_compiledMatchingConfig.matchingConfiguration);
 }
 
-},{"../autofill-utils.js":61,"../constants.js":64,"./label-util.js":39,"./matching-config/__generated__/compiled-matching-config.js":41,"./matching-utils.js":42}],44:[function(require,module,exports){
+},{"../autofill-utils.js":59,"../constants.js":62,"./label-util.js":37,"./matching-config/__generated__/compiled-matching-config.js":39,"./matching-utils.js":40}],42:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14547,7 +14446,7 @@ class InContextSignup {
 
 exports.InContextSignup = InContextSignup;
 
-},{"./autofill-utils.js":61,"./deviceApiCalls/__generated__/deviceApiCalls.js":65}],45:[function(require,module,exports){
+},{"./autofill-utils.js":59,"./deviceApiCalls/__generated__/deviceApiCalls.js":63}],43:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14763,7 +14662,7 @@ function createCredentialsTooltipItem(data) {
   return new CredentialsTooltipItem(data);
 }
 
-},{"../autofill-utils.js":61}],46:[function(require,module,exports){
+},{"../autofill-utils.js":59}],44:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14815,7 +14714,7 @@ class CreditCardTooltipItem {
 
 exports.CreditCardTooltipItem = CreditCardTooltipItem;
 
-},{}],47:[function(require,module,exports){
+},{}],45:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14889,7 +14788,7 @@ class IdentityTooltipItem {
 
 exports.IdentityTooltipItem = IdentityTooltipItem;
 
-},{"../Form/formatters.js":36}],48:[function(require,module,exports){
+},{"../Form/formatters.js":34}],46:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14961,7 +14860,7 @@ class PasswordGenerator {
 
 exports.PasswordGenerator = PasswordGenerator;
 
-},{"../packages/password/index.js":17,"../packages/password/rules.json":21}],49:[function(require,module,exports){
+},{"../packages/password/index.js":15,"../packages/password/rules.json":19}],47:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15397,7 +15296,7 @@ function createScanner(device, scannerOptions) {
   });
 }
 
-},{"./Form/Form.js":33,"./Form/matching.js":43,"./autofill-utils.js":61,"./constants.js":64,"./deviceApiCalls/__generated__/deviceApiCalls.js":65}],50:[function(require,module,exports){
+},{"./Form/Form.js":31,"./Form/matching.js":41,"./autofill-utils.js":59,"./constants.js":62,"./deviceApiCalls/__generated__/deviceApiCalls.js":63}],48:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15802,7 +15701,7 @@ _defineProperty(Settings, "defaults", {
   enabled: null
 });
 
-},{"../packages/device-api/index.js":14,"./autofill-utils.js":61,"./deviceApiCalls/__generated__/deviceApiCalls.js":65,"./deviceApiCalls/__generated__/validators.zod.js":66,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],51:[function(require,module,exports){
+},{"../packages/device-api/index.js":10,"./autofill-utils.js":59,"./deviceApiCalls/__generated__/deviceApiCalls.js":63,"./deviceApiCalls/__generated__/validators.zod.js":64,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],49:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15911,7 +15810,7 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
 var _default = DataHTMLTooltip;
 exports.default = _default;
 
-},{"../InputTypes/Credentials.js":45,"../autofill-utils.js":61,"./HTMLTooltip.js":54}],52:[function(require,module,exports){
+},{"../InputTypes/Credentials.js":43,"../autofill-utils.js":59,"./HTMLTooltip.js":52}],50:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15985,7 +15884,7 @@ class EmailHTMLTooltip extends _HTMLTooltip.default {
 var _default = EmailHTMLTooltip;
 exports.default = _default;
 
-},{"../autofill-utils.js":61,"./HTMLTooltip.js":54}],53:[function(require,module,exports){
+},{"../autofill-utils.js":59,"./HTMLTooltip.js":52}],51:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -16032,7 +15931,7 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
 var _default = EmailSignupHTMLTooltip;
 exports.default = _default;
 
-},{"./HTMLTooltip.js":54}],54:[function(require,module,exports){
+},{"./HTMLTooltip.js":52}],52:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -16474,7 +16373,7 @@ exports.HTMLTooltip = HTMLTooltip;
 var _default = HTMLTooltip;
 exports.default = _default;
 
-},{"../Form/matching.js":43,"../autofill-utils.js":61,"./styles/styles.js":60}],55:[function(require,module,exports){
+},{"../Form/matching.js":41,"../autofill-utils.js":59,"./styles/styles.js":58}],53:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -16888,7 +16787,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
 exports.HTMLTooltipUIController = HTMLTooltipUIController;
 
-},{"../../Form/inputTypeConfig.js":38,"../../Form/matching.js":43,"../../autofill-utils.js":61,"../DataHTMLTooltip.js":51,"../EmailHTMLTooltip.js":52,"../EmailSignupHTMLTooltip.js":53,"../HTMLTooltip.js":54,"./UIController.js":58}],56:[function(require,module,exports){
+},{"../../Form/inputTypeConfig.js":36,"../../Form/matching.js":41,"../../autofill-utils.js":59,"../DataHTMLTooltip.js":49,"../EmailHTMLTooltip.js":50,"../EmailSignupHTMLTooltip.js":51,"../HTMLTooltip.js":52,"./UIController.js":56}],54:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17091,7 +16990,7 @@ class NativeUIController extends _UIController.UIController {
 
 exports.NativeUIController = NativeUIController;
 
-},{"../../Form/matching.js":43,"../../InputTypes/Credentials.js":45,"../../deviceApiCalls/__generated__/deviceApiCalls.js":65,"./UIController.js":58}],57:[function(require,module,exports){
+},{"../../Form/matching.js":41,"../../InputTypes/Credentials.js":43,"../../deviceApiCalls/__generated__/deviceApiCalls.js":63,"./UIController.js":56}],55:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17392,7 +17291,7 @@ class OverlayUIController extends _UIController.UIController {
 
 exports.OverlayUIController = OverlayUIController;
 
-},{"../../Form/matching.js":43,"./UIController.js":58}],58:[function(require,module,exports){
+},{"../../Form/matching.js":41,"./UIController.js":56}],56:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17488,7 +17387,7 @@ class UIController {
 
 exports.UIController = UIController;
 
-},{}],59:[function(require,module,exports){
+},{}],57:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17510,7 +17409,7 @@ exports.ddgCcIconFilled = ddgCcIconFilled;
 const ddgIdentityIconBase = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4KPHBhdGggeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiBmaWxsPSJub25lIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMiAyMWMyLjE0MyAwIDQuMTExLS43NSA1LjY1Ny0yLS42MjYtLjUwNi0xLjMxOC0uOTI3LTIuMDYtMS4yNS0xLjEtLjQ4LTIuMjg1LS43MzUtMy40ODYtLjc1LTEuMi0uMDE0LTIuMzkyLjIxMS0zLjUwNC42NjQtLjgxNy4zMzMtMS41OC43ODMtMi4yNjQgMS4zMzYgMS41NDYgMS4yNSAzLjUxNCAyIDUuNjU3IDJ6bTQuMzk3LTUuMDgzYy45NjcuNDIyIDEuODY2Ljk4IDIuNjcyIDEuNjU1QzIwLjI3OSAxNi4wMzkgMjEgMTQuMTA0IDIxIDEyYzAtNC45Ny00LjAzLTktOS05cy05IDQuMDMtOSA5YzAgMi4xMDQuNzIyIDQuMDQgMS45MzIgNS41NzIuODc0LS43MzQgMS44Ni0xLjMyOCAyLjkyMS0xLjc2IDEuMzYtLjU1NCAyLjgxNi0uODMgNC4yODMtLjgxMSAxLjQ2Ny4wMTggMi45MTYuMzMgNC4yNi45MTZ6TTEyIDIzYzYuMDc1IDAgMTEtNC45MjUgMTEtMTFTMTguMDc1IDEgMTIgMSAxIDUuOTI1IDEgMTJzNC45MjUgMTEgMTEgMTF6bTMtMTNjMCAxLjY1Ny0xLjM0MyAzLTMgM3MtMy0xLjM0My0zLTMgMS4zNDMtMyAzLTMgMyAxLjM0MyAzIDN6bTIgMGMwIDIuNzYxLTIuMjM5IDUtNSA1cy01LTIuMjM5LTUtNSAyLjIzOS01IDUtNSA1IDIuMjM5IDUgNXoiIGZpbGw9IiMwMDAiLz4KPC9zdmc+Cg==";
 exports.ddgIdentityIconBase = ddgIdentityIconBase;
 
-},{}],60:[function(require,module,exports){
+},{}],58:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17520,7 +17419,7 @@ exports.CSS_STYLES = void 0;
 const CSS_STYLES = ":root {\n    color-scheme: light dark;\n}\n\n.wrapper *, .wrapper *::before, .wrapper *::after {\n    box-sizing: border-box;\n}\n.wrapper {\n    position: fixed;\n    top: 0;\n    left: 0;\n    padding: 0;\n    font-family: 'DDG_ProximaNova', 'Proxima Nova', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n    -webkit-font-smoothing: antialiased;\n    z-index: 2147483647;\n}\n.wrapper--data {\n    font-family: 'SF Pro Text', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n}\n:not(.top-autofill) .tooltip {\n    position: absolute;\n    width: 300px;\n    max-width: calc(100vw - 25px);\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--data, #topAutofill {\n    background-color: rgba(242, 240, 240, 1);\n    -webkit-backdrop-filter: blur(40px);\n    backdrop-filter: blur(40px);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data, #topAutofill {\n        background: rgb(100, 98, 102, .9);\n    }\n}\n.tooltip--data {\n    padding: 6px;\n    font-size: 13px;\n    line-height: 14px;\n    width: 315px;\n    max-height: 290px;\n    overflow-y: auto;\n}\n.top-autofill .tooltip--data {\n    min-height: 100vh;\n}\n.tooltip--data.tooltip--incontext-signup {\n    width: 360px;\n}\n:not(.top-autofill) .tooltip--data {\n    top: 100%;\n    left: 100%;\n    border: 0.5px solid rgba(255, 255, 255, 0.2);\n    border-radius: 6px;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.32);\n}\n@media (prefers-color-scheme: dark) {\n    :not(.top-autofill) .tooltip--data {\n        border: 1px solid rgba(255, 255, 255, 0.2);\n    }\n}\n:not(.top-autofill) .tooltip--email {\n    top: calc(100% + 6px);\n    right: calc(100% - 48px);\n    padding: 8px;\n    border: 1px solid #D0D0D0;\n    border-radius: 10px;\n    background-color: #FFFFFF;\n    font-size: 14px;\n    line-height: 1.3;\n    color: #333333;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);\n}\n.tooltip--email__caret {\n    position: absolute;\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--email__caret::before,\n.tooltip--email__caret::after {\n    content: \"\";\n    width: 0;\n    height: 0;\n    border-left: 10px solid transparent;\n    border-right: 10px solid transparent;\n    display: block;\n    border-bottom: 8px solid #D0D0D0;\n    position: absolute;\n    right: -28px;\n}\n.tooltip--email__caret::before {\n    border-bottom-color: #D0D0D0;\n    top: -1px;\n}\n.tooltip--email__caret::after {\n    border-bottom-color: #FFFFFF;\n    top: 0px;\n}\n\n/* Buttons */\n.tooltip__button {\n    display: flex;\n    width: 100%;\n    padding: 8px 8px 8px 0px;\n    font-family: inherit;\n    color: inherit;\n    background: transparent;\n    border: none;\n    border-radius: 6px;\n}\n.tooltip__button.currentFocus,\n.wrapper:not(.top-autofill) .tooltip__button:hover {\n    background-color: #3969EF;\n    color: #FFFFFF;\n}\n\n/* Data autofill tooltip specific */\n.tooltip__button--data {\n    position: relative;\n    min-height: 48px;\n    flex-direction: row;\n    justify-content: flex-start;\n    font-size: inherit;\n    font-weight: 500;\n    line-height: 16px;\n    text-align: left;\n    border-radius: 3px;\n}\n.tooltip--data__item-container {\n    max-height: 220px;\n    overflow: auto;\n}\n.tooltip__button--data:first-child {\n    margin-top: 0;\n}\n.tooltip__button--data:last-child {\n    margin-bottom: 0;\n}\n.tooltip__button--data::before {\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 20px 20px;\n    background-repeat: no-repeat;\n    background-position: center 6px;\n}\n#provider_locked::after {\n    position: absolute;\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 11px 13px;\n    background-repeat: no-repeat;\n    background-position: right bottom;\n}\n.tooltip__button--data.currentFocus:not(.tooltip__button--data--bitwarden)::before,\n.wrapper:not(.top-autofill) .tooltip__button--data:not(.tooltip__button--data--bitwarden):hover::before {\n    filter: invert(100%);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before,\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before {\n        filter: invert(100%);\n        opacity: .9;\n    }\n}\n.tooltip__button__text-container {\n    margin: auto 0;\n}\n.label {\n    display: block;\n    font-weight: 400;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.8);\n    font-size: 13px;\n    line-height: 1;\n}\n.label + .label {\n    margin-top: 2px;\n}\n.label.label--medium {\n    font-weight: 500;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.9);\n}\n.label.label--small {\n    font-size: 11px;\n    font-weight: 400;\n    letter-spacing: 0.06px;\n    color: rgba(0,0,0,0.6);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data .label {\n        color: #ffffff;\n    }\n    .tooltip--data .label--medium {\n        color: #ffffff;\n    }\n    .tooltip--data .label--small {\n        color: #cdcdcd;\n    }\n}\n.tooltip__button.currentFocus .label,\n.wrapper:not(.top-autofill) .tooltip__button:hover .label {\n    color: #FFFFFF;\n}\n\n.tooltip__button--manage {\n    font-size: 13px;\n    padding: 5px 9px;\n    border-radius: 3px;\n    margin: 0;\n}\n\n/* Icons */\n.tooltip__button--data--credentials::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik05LjYzNiA4LjY4MkM5LjYzNiA1LjU0NCAxMi4xOCAzIDE1LjMxOCAzIDE4LjQ1NiAzIDIxIDUuNTQ0IDIxIDguNjgyYzAgMy4xMzgtMi41NDQgNS42ODItNS42ODIgNS42ODItLjY5MiAwLTEuMzUzLS4xMjQtMS45NjQtLjM0OS0uMzcyLS4xMzctLjc5LS4wNDEtMS4wNjYuMjQ1bC0uNzEzLjc0SDEwYy0uNTUyIDAtMSAuNDQ4LTEgMXYySDdjLS41NTIgMC0xIC40NDgtMSAxdjJIM3YtMi44ODFsNi42NjgtNi42NjhjLjI2NS0uMjY2LjM2LS42NTguMjQ0LTEuMDE1LS4xNzktLjU1MS0uMjc2LTEuMTQtLjI3Ni0xLjc1NHpNMTUuMzE4IDFjLTQuMjQyIDAtNy42ODIgMy40NC03LjY4MiA3LjY4MiAwIC42MDcuMDcxIDEuMi4yMDUgMS43NjdsLTYuNTQ4IDYuNTQ4Yy0uMTg4LjE4OC0uMjkzLjQ0Mi0uMjkzLjcwOFYyMmMwIC4yNjUuMTA1LjUyLjI5My43MDcuMTg3LjE4OC40NDIuMjkzLjcwNy4yOTNoNGMxLjEwNSAwIDItLjg5NSAyLTJ2LTFoMWMxLjEwNSAwIDItLjg5NSAyLTJ2LTFoMWMuMjcyIDAgLjUzMi0uMTEuNzItLjMwNmwuNTc3LS42Yy42NDUuMTc2IDEuMzIzLjI3IDIuMDIxLjI3IDQuMjQzIDAgNy42ODItMy40NCA3LjY4Mi03LjY4MkMyMyA0LjQzOSAxOS41NiAxIDE1LjMxOCAxek0xNSA4YzAtLjU1Mi40NDgtMSAxLTFzMSAuNDQ4IDEgMS0uNDQ4IDEtMSAxLTEtLjQ0OC0xLTF6bTEtM2MtMS42NTcgMC0zIDEuMzQzLTMgM3MxLjM0MyAzIDMgMyAzLTEuMzQzIDMtMy0xLjM0My0zLTMtM3oiIGZpbGw9IiMwMDAiIGZpbGwtb3BhY2l0eT0iLjkiLz4KPC9zdmc+');\n}\n.tooltip__button--data--creditCards::before {\n    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBkPSJNNSA5Yy0uNTUyIDAtMSAuNDQ4LTEgMXYyYzAgLjU1Mi40NDggMSAxIDFoM2MuNTUyIDAgMS0uNDQ4IDEtMXYtMmMwLS41NTItLjQ0OC0xLTEtMUg1eiIgZmlsbD0iIzAwMCIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xIDZjMC0yLjIxIDEuNzktNCA0LTRoMTRjMi4yMSAwIDQgMS43OSA0IDR2MTJjMCAyLjIxLTEuNzkgNC00IDRINWMtMi4yMSAwLTQtMS43OS00LTRWNnptNC0yYy0xLjEwNSAwLTIgLjg5NS0yIDJ2OWgxOFY2YzAtMS4xMDUtLjg5NS0yLTItMkg1em0wIDE2Yy0xLjEwNSAwLTItLjg5NS0yLTJoMThjMCAxLjEwNS0uODk1IDItMiAySDV6IiBmaWxsPSIjMDAwIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--identities::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4=');\n}\n.tooltip__button--data--credentials.tooltip__button--data--bitwarden::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iOCIgZmlsbD0iIzE3NUREQyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE4LjU2OTYgNS40MzM1NUMxOC41MDg0IDUuMzc0NDIgMTguNDM0NyA1LjMyNzYzIDE4LjM1MzEgNS4yOTYxMUMxOC4yNzE1IDUuMjY0NiAxOC4xODM3IDUuMjQ5MDQgMTguMDk1MyA1LjI1MDQxSDUuOTIxOTFDNS44MzMyNiA1LjI0NzI5IDUuNzQ0OTMgNS4yNjIwNSA1LjY2MzA0IDUuMjkzNjdDNS41ODExNSA1LjMyNTI5IDUuNTA3NjUgNS4zNzMwMiA1LjQ0NzYyIDUuNDMzNTVDNS4zMjE3IDUuNTUwMTMgNS4yNTA2NSA1LjcwODE1IDUuMjUgNS44NzMxVjEzLjM4MjFDNS4yNTMzNiAxMy45NTM1IDUuMzc0MDggMTQuNTE5MSA1LjYwNTcyIDE1LjA0ODdDNS44MTkzMSAxNS41NzI4IDYuMTEyMDcgMTYuMDY2MSA2LjQ3NTI0IDE2LjUxMzlDNi44NDIgMTYuOTY4MyA3LjI1OTI5IDE3LjM4NTcgNy43MjAyNSAxNy43NTkzQzguMTQwNTMgMTguMTI1NiA4LjU4OTcxIDE4LjQ2MjMgOS4wNjQwNyAxOC43NjY2QzkuNDU5MzEgMTkuMDIzIDkuOTEzODMgMTkuMjc5NCAxMC4zNDg2IDE5LjUxNzVDMTAuNzgzNCAxOS43NTU2IDExLjA5OTYgMTkuOTIwNCAxMS4yNzc0IDE5Ljk5MzdDMTEuNDU1MyAyMC4wNjY5IDExLjYxMzQgMjAuMTQwMiAxMS43MTIyIDIwLjE5NTFDMTEuNzk5MiAyMC4yMzEzIDExLjg5MzUgMjAuMjUgMTEuOTg4OCAyMC4yNUMxMi4wODQyIDIwLjI1IDEyLjE3ODUgMjAuMjMxMyAxMi4yNjU1IDIwLjE5NTFDMTIuNDIxMiAyMC4xMzYzIDEyLjU3MjkgMjAuMDY5IDEyLjcyIDE5Ljk5MzdDMTIuNzcxMSAxOS45Njc0IDEyLjgzMzUgMTkuOTM2NiAxMi45MDY5IDE5LjkwMDRDMTMuMDg5MSAxOS44MTA1IDEzLjMzODggMTkuNjg3MiAxMy42NDg5IDE5LjUxNzVDMTQuMDgzNiAxOS4yNzk0IDE0LjUxODQgMTkuMDIzIDE0LjkzMzQgMTguNzY2NkMxNS40MDQgMTguNDU3NyAxNS44NTI4IDE4LjEyMTIgMTYuMjc3MiAxNy43NTkzQzE2LjczMzEgMTcuMzgwOSAxNy4xNDk5IDE2Ljk2NCAxNy41MjIyIDE2LjUxMzlDMTcuODc4IDE2LjA2MTcgMTguMTcwMiAxNS41NjkzIDE4LjM5MTcgMTUuMDQ4N0MxOC42MjM0IDE0LjUxOTEgMTguNzQ0MSAxMy45NTM1IDE4Ljc0NzQgMTMuMzgyMVY1Ljg3MzFDMTguNzU1NyA1Ljc5MjE0IDE4Ljc0MzkgNS43MTA1IDE4LjcxMzEgNS42MzQzNUMxOC42ODIzIDUuNTU4MiAxOC42MzMyIDUuNDg5NTQgMTguNTY5NiA1LjQzMzU1Wk0xNy4wMDg0IDEzLjQ1NTNDMTcuMDA4NCAxNi4xODQyIDEyLjAwODYgMTguNTI4NSAxMi4wMDg2IDE4LjUyODVWNi44NjIwOUgxNy4wMDg0VjEzLjQ1NTNaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K');\n}\n#provider_locked:after {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMSAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEgNy42MDA1N1Y3LjYwMjVWOS41MjI1QzEgMTAuMDgwMSAxLjIyMTUxIDEwLjYxNDkgMS42MTU4MSAxMS4wMDkyQzIuMDEwMSAxMS40MDM1IDIuNTQ0ODggMTEuNjI1IDMuMTAyNSAxMS42MjVINy4yNzI1QzcuNTQ4NjEgMTEuNjI1IDcuODIyMDEgMTEuNTcwNiA4LjA3NzA5IDExLjQ2NUM4LjMzMjE4IDExLjM1OTMgOC41NjM5NiAxMS4yMDQ0IDguNzU5MTkgMTEuMDA5MkM4Ljk1NDQzIDEwLjgxNCA5LjEwOTMgMTAuNTgyMiA5LjIxNDk2IDEwLjMyNzFDOS4zMjA2MiAxMC4wNzIgOS4zNzUgOS43OTg2MSA5LjM3NSA5LjUyMjVMOS4zNzUgNy42MDI1TDkuMzc1IDcuNjAwNTdDOS4zNzQxNSA3LjE2MTMxIDkuMjM1NzQgNi43MzMzNSA4Ljk3OTIyIDYuMzc2NzhDOC44NzY4MyA2LjIzNDQ2IDguNzU3NjggNi4xMDYzNyA4LjYyNSA1Ljk5NDg5VjUuMTg3NUM4LjYyNSA0LjI3NTgyIDguMjYyODQgMy40MDE0OCA3LjYxODE4IDIuNzU2ODJDNi45NzM1MiAyLjExMjE2IDYuMDk5MTggMS43NSA1LjE4NzUgMS43NUM0LjI3NTgyIDEuNzUgMy40MDE0OCAyLjExMjE2IDIuNzU2ODIgMi43NTY4MkMyLjExMjE2IDMuNDAxNDggMS43NSA0LjI3NTgyIDEuNzUgNS4xODc1VjUuOTk0ODlDMS42MTczMiA2LjEwNjM3IDEuNDk4MTcgNi4yMzQ0NiAxLjM5NTc4IDYuMzc2NzhDMS4xMzkyNiA2LjczMzM1IDEuMDAwODUgNy4xNjEzMSAxIDcuNjAwNTdaTTQuOTY4NyA0Ljk2ODdDNS4wMjY5NCA0LjkxMDQ3IDUuMTA1MzIgNC44NzY5OSA1LjE4NzUgNC44NzUwN0M1LjI2OTY4IDQuODc2OTkgNS4zNDgwNiA0LjkxMDQ3IDUuNDA2MyA0Ljk2ODdDNS40NjU0MiA1LjAyNzgzIDUuNDk5MDQgNS4xMDc3NCA1LjUgNS4xOTEzVjUuNUg0Ljg3NVY1LjE5MTNDNC44NzU5NiA1LjEwNzc0IDQuOTA5NTggNS4wMjc4MyA0Ljk2ODcgNC45Njg3WiIgZmlsbD0iIzIyMjIyMiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIi8+Cjwvc3ZnPgo=');\n}\n\nhr {\n    display: block;\n    margin: 5px 9px;\n    border: none; /* reset the border */\n    border-top: 1px solid rgba(0,0,0,.1);\n}\n\nhr:first-child {\n    display: none;\n}\n\n@media (prefers-color-scheme: dark) {\n    hr {\n        border-top: 1px solid rgba(255,255,255,.2);\n    }\n}\n\n#privateAddress {\n    align-items: flex-start;\n}\n#personalAddress::before,\n#privateAddress::before,\n#incontextSignup::before,\n#personalAddress.currentFocus::before,\n#personalAddress:hover::before,\n#privateAddress.currentFocus::before,\n#privateAddress:hover::before {\n    filter: none;\n    /* This is the same icon as `daxBase64` in `src/Form/logo-svg.js` */\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMTI4IDEyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0ibTY0IDEyOGMzNS4zNDYgMCA2NC0yOC42NTQgNjQtNjRzLTI4LjY1NC02NC02NC02NC02NCAyOC42NTQtNjQgNjQgMjguNjU0IDY0IDY0IDY0eiIgZmlsbD0iI2RlNTgzMyIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im03MyAxMTEuNzVjMC0uNS4xMjMtLjYxNC0xLjQ2Ni0zLjc4Mi00LjIyNC04LjQ1OS04LjQ3LTIwLjM4NC02LjU0LTI4LjA3NS4zNTMtMS4zOTctMy45NzgtNTEuNzQ0LTcuMDQtNTMuMzY1LTMuNDAyLTEuODEzLTcuNTg4LTQuNjktMTEuNDE4LTUuMzMtMS45NDMtLjMxLTQuNDktLjE2NC02LjQ4Mi4xMDUtLjM1My4wNDctLjM2OC42ODMtLjAzLjc5OCAxLjMwOC40NDMgMi44OTUgMS4yMTIgMy44MyAyLjM3NS4xNzguMjItLjA2LjU2Ni0uMzQyLjU3Ny0uODgyLjAzMi0yLjQ4Mi40MDItNC41OTMgMi4xOTUtLjI0NC4yMDctLjA0MS41OTIuMjczLjUzIDQuNTM2LS44OTcgOS4xNy0uNDU1IDExLjkgMi4wMjcuMTc3LjE2LjA4NC40NS0uMTQ3LjUxMi0yMy42OTQgNi40NC0xOS4wMDMgMjcuMDUtMTIuNjk2IDUyLjM0NCA1LjYxOSAyMi41MyA3LjczMyAyOS43OTIgOC40IDMyLjAwNGEuNzE4LjcxOCAwIDAgMCAuNDIzLjQ2N2M4LjE1NiAzLjI0OCAyNS45MjggMy4zOTIgMjUuOTI4LTIuMTMyeiIgZmlsbD0iI2RkZCIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBkPSJtNzYuMjUgMTE2LjVjLTIuODc1IDEuMTI1LTguNSAxLjYyNS0xMS43NSAxLjYyNS00Ljc2NCAwLTExLjYyNS0uNzUtMTQuMTI1LTEuODc1LTEuNTQ0LTQuNzUxLTYuMTY0LTE5LjQ4LTEwLjcyNy0zOC4xODVsLS40NDctMS44MjctLjAwNC0uMDE1Yy01LjQyNC0yMi4xNTctOS44NTUtNDAuMjUzIDE0LjQyNy00NS45MzguMjIyLS4wNTIuMzMtLjMxNy4xODQtLjQ5Mi0yLjc4Ni0zLjMwNS04LjAwNS00LjM4OC0xNC42MDUtMi4xMTEtLjI3LjA5My0uNTA2LS4xOC0uMzM3LS40MTIgMS4yOTQtMS43ODMgMy44MjMtMy4xNTUgNS4wNzEtMy43NTYuMjU4LS4xMjQuMjQyLS41MDItLjAzLS41ODhhMjcuODc3IDI3Ljg3NyAwIDAgMCAtMy43NzItLjljLS4zNy0uMDU5LS40MDMtLjY5My0uMDMyLS43NDMgOS4zNTYtMS4yNTkgMTkuMTI1IDEuNTUgMjQuMDI4IDcuNzI2YS4zMjYuMzI2IDAgMCAwIC4xODYuMTE0YzE3Ljk1MiAzLjg1NiAxOS4yMzggMzIuMjM1IDE3LjE3IDMzLjUyOC0uNDA4LjI1NS0xLjcxNS4xMDgtMy40MzgtLjA4NS02Ljk4Ni0uNzgxLTIwLjgxOC0yLjMyOS05LjQwMiAxOC45NDguMTEzLjIxLS4wMzYuNDg4LS4yNzIuNTI1LTYuNDM4IDEgMS44MTIgMjEuMTczIDcuODc1IDM0LjQ2MXoiIGZpbGw9IiNmZmYiLz4KICAgIDxwYXRoIGQ9Im04NC4yOCA5MC42OThjLTEuMzY3LS42MzMtNi42MjEgMy4xMzUtMTAuMTEgNi4wMjgtLjcyOC0xLjAzMS0yLjEwMy0xLjc4LTUuMjAzLTEuMjQyLTIuNzEzLjQ3Mi00LjIxMSAxLjEyNi00Ljg4IDIuMjU0LTQuMjgzLTEuNjIzLTExLjQ4OC00LjEzLTEzLjIyOS0xLjcxLTEuOTAyIDIuNjQ2LjQ3NiAxNS4xNjEgMy4wMDMgMTYuNzg2IDEuMzIuODQ5IDcuNjMtMy4yMDggMTAuOTI2LTYuMDA1LjUzMi43NDkgMS4zODggMS4xNzggMy4xNDggMS4xMzcgMi42NjItLjA2MiA2Ljk3OS0uNjgxIDcuNjQ5LTEuOTIxLjA0LS4wNzUuMDc1LS4xNjQuMTA1LS4yNjYgMy4zODggMS4yNjYgOS4zNSAyLjYwNiAxMC42ODIgMi40MDYgMy40Ny0uNTIxLS40ODQtMTYuNzIzLTIuMDktMTcuNDY3eiIgZmlsbD0iIzNjYTgyYiIvPgogICAgPHBhdGggZD0ibTc0LjQ5IDk3LjA5N2MuMTQ0LjI1Ni4yNi41MjYuMzU4LjguNDgzIDEuMzUyIDEuMjcgNS42NDguNjc0IDYuNzA5LS41OTUgMS4wNjItNC40NTkgMS41NzQtNi44NDMgMS42MTVzLTIuOTItLjgzMS0zLjQwMy0yLjE4MWMtLjM4Ny0xLjA4MS0uNTc3LTMuNjIxLS41NzItNS4wNzUtLjA5OC0yLjE1OC42OS0yLjkxNiA0LjMzNC0zLjUwNiAyLjY5Ni0uNDM2IDQuMTIxLjA3MSA0Ljk0NC45NCAzLjgyOC0yLjg1NyAxMC4yMTUtNi44ODkgMTAuODM4LTYuMTUyIDMuMTA2IDMuNjc0IDMuNDk5IDEyLjQyIDIuODI2IDE1LjkzOS0uMjIgMS4xNTEtMTAuNTA1LTEuMTM5LTEwLjUwNS0yLjM4IDAtNS4xNTItMS4zMzctNi41NjUtMi42NS02Ljcxem0tMjIuNTMtMS42MDljLjg0My0xLjMzMyA3LjY3NC4zMjUgMTEuNDI0IDEuOTkzIDAgMC0uNzcgMy40OTEuNDU2IDcuNjA0LjM1OSAxLjIwMy04LjYyNyA2LjU1OC05LjggNS42MzctMS4zNTUtMS4wNjUtMy44NS0xMi40MzItMi4wOC0xNS4yMzR6IiBmaWxsPSIjNGNiYTNjIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im01NS4yNjkgNjguNDA2Yy41NTMtMi40MDMgMy4xMjctNi45MzIgMTIuMzIxLTYuODIyIDQuNjQ4LS4wMTkgMTAuNDIyLS4wMDIgMTQuMjUtLjQzNmE1MS4zMTIgNTEuMzEyIDAgMCAwIDEyLjcyNi0zLjA5NWMzLjk4LTEuNTE5IDUuMzkyLTEuMTggNS44ODctLjI3Mi41NDQuOTk5LS4wOTcgMi43MjItMS40ODggNC4zMDktMi42NTYgMy4wMy03LjQzMSA1LjM4LTE1Ljg2NSA2LjA3Ni04LjQzMy42OTgtMTQuMDItMS41NjUtMTYuNDI1IDIuMTE4LTEuMDM4IDEuNTg5LS4yMzYgNS4zMzMgNy45MiA2LjUxMiAxMS4wMiAxLjU5IDIwLjA3Mi0xLjkxNyAyMS4xOS4yMDEgMS4xMTkgMi4xMTgtNS4zMjMgNi40MjgtMTYuMzYyIDYuNTE4cy0xNy45MzQtMy44NjUtMjAuMzc5LTUuODNjLTMuMTAyLTIuNDk1LTQuNDktNi4xMzMtMy43NzUtOS4yNzl6IiBmaWxsPSIjZmMzIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KICAgIDxnIGZpbGw9IiMxNDMwN2UiIG9wYWNpdHk9Ii44Ij4KICAgICAgPHBhdGggZD0ibTY5LjMyNyA0Mi4xMjdjLjYxNi0xLjAwOCAxLjk4MS0xLjc4NiA0LjIxNi0xLjc4NiAyLjIzNCAwIDMuMjg1Ljg4OSA0LjAxMyAxLjg4LjE0OC4yMDItLjA3Ni40NC0uMzA2LjM0YTU5Ljg2OSA1OS44NjkgMCAwIDEgLS4xNjgtLjA3M2MtLjgxNy0uMzU3LTEuODItLjc5NS0zLjU0LS44Mi0xLjgzOC0uMDI2LTIuOTk3LjQzNS0zLjcyNy44MzEtLjI0Ni4xMzQtLjYzNC0uMTMzLS40ODgtLjM3MnptLTI1LjE1NyAxLjI5YzIuMTctLjkwNyAzLjg3Ni0uNzkgNS4wODEtLjUwNC4yNTQuMDYuNDMtLjIxMy4yMjctLjM3Ny0uOTM1LS43NTUtMy4wMy0xLjY5Mi01Ljc2LS42NzQtMi40MzcuOTA5LTMuNTg1IDIuNzk2LTMuNTkyIDQuMDM4LS4wMDIuMjkyLjYuMzE3Ljc1Ni4wNy40Mi0uNjcgMS4xMi0xLjY0NiAzLjI4OS0yLjU1M3oiLz4KICAgICAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtNzUuNDQgNTUuOTJhMy40NyAzLjQ3IDAgMCAxIC0zLjQ3NC0zLjQ2MiAzLjQ3IDMuNDcgMCAwIDEgMy40NzUtMy40NiAzLjQ3IDMuNDcgMCAwIDEgMy40NzQgMy40NiAzLjQ3IDMuNDcgMCAwIDEgLTMuNDc1IDMuNDYyem0yLjQ0Ny00LjYwOGEuODk5Ljg5OSAwIDAgMCAtMS43OTkgMGMwIC40OTQuNDA1Ljg5NS45Ljg5NS40OTkgMCAuOS0uNC45LS44OTV6bS0yNS40NjQgMy41NDJhNC4wNDIgNC4wNDIgMCAwIDEgLTQuMDQ5IDQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIC00LjA1LTQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIDQuMDUtNC4wMzcgNC4wNDUgNC4wNDUgMCAwIDEgNC4wNSA0LjAzN3ptLTEuMTkzLTEuMzM4YTEuMDUgMS4wNSAwIDAgMCAtMi4wOTcgMCAxLjA0OCAxLjA0OCAwIDAgMCAyLjA5NyAweiIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8L2c+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im02NCAxMTcuNzVjMjkuNjg1IDAgNTMuNzUtMjQuMDY1IDUzLjc1LTUzLjc1cy0yNC4wNjUtNTMuNzUtNTMuNzUtNTMuNzUtNTMuNzUgMjQuMDY1LTUzLjc1IDUzLjc1IDI0LjA2NSA1My43NSA1My43NSA1My43NXptMCA1YzMyLjQ0NyAwIDU4Ljc1LTI2LjMwMyA1OC43NS01OC43NXMtMjYuMzAzLTU4Ljc1LTU4Ljc1LTU4Ljc1LTU4Ljc1IDI2LjMwMy01OC43NSA1OC43NSAyNi4zMDMgNTguNzUgNTguNzUgNTguNzV6IiBmaWxsPSIjZmZmIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+');\n}\n\n/* Email tooltip specific */\n.tooltip__button--email {\n    flex-direction: column;\n    justify-content: center;\n    align-items: flex-start;\n    font-size: 14px;\n    padding: 4px 8px;\n}\n.tooltip__button--email__primary-text {\n    font-weight: bold;\n}\n.tooltip__button--email__secondary-text {\n    font-size: 12px;\n}\n\n/* Email Protection signup notice */\n:not(.top-autofill) .tooltip--email-signup {\n    text-align: left;\n    color: #222222;\n    padding: 16px 20px;\n    width: 380px;\n}\n\n.tooltip--email-signup h1 {\n    font-weight: 700;\n    font-size: 16px;\n    line-height: 1.5;\n    margin: 0;\n}\n\n.tooltip--email-signup p {\n    font-weight: 400;\n    font-size: 14px;\n    line-height: 1.4;\n}\n\n.notice-controls {\n    display: flex;\n}\n\n.tooltip--email-signup .notice-controls > * {\n    border-radius: 8px;\n    border: 0;\n    cursor: pointer;\n    display: inline-block;\n    font-family: inherit;\n    font-style: normal;\n    font-weight: bold;\n    padding: 8px 12px;\n    text-decoration: none;\n}\n\n.notice-controls .ghost {\n    margin-left: 1rem;\n}\n\n.tooltip--email-signup a.primary {\n    background: #3969EF;\n    color: #fff;\n}\n\n.tooltip--email-signup a.primary:hover,\n.tooltip--email-signup a.primary:focus {\n    background: #2b55ca;\n}\n\n.tooltip--email-signup a.primary:active {\n    background: #1e42a4;\n}\n\n.tooltip--email-signup button.ghost {\n    background: transparent;\n    color: #3969EF;\n}\n\n.tooltip--email-signup button.ghost:hover,\n.tooltip--email-signup button.ghost:focus {\n    background-color: rgba(0, 0, 0, 0.06);\n    color: #2b55ca;\n}\n\n.tooltip--email-signup button.ghost:active {\n    background-color: rgba(0, 0, 0, 0.12);\n    color: #1e42a4;\n}\n\n.tooltip--email-signup button.close-tooltip {\n    background-color: transparent;\n    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjI5Mjg5NCAwLjY1NjkwN0MwLjY4MzQxOCAwLjI2NjM4MyAxLjMxNjU4IDAuMjY2MzgzIDEuNzA3MTEgMC42NTY5MDdMNiA0Ljk0OThMMTAuMjkyOSAwLjY1NjkwN0MxMC42ODM0IDAuMjY2MzgzIDExLjMxNjYgMC4yNjYzODMgMTEuNzA3MSAwLjY1NjkwN0MxMi4wOTc2IDEuMDQ3NDMgMTIuMDk3NiAxLjY4MDYgMTEuNzA3MSAyLjA3MTEyTDcuNDE0MjEgNi4zNjQwMUwxMS43MDcxIDEwLjY1NjlDMTIuMDk3NiAxMS4wNDc0IDEyLjA5NzYgMTEuNjgwNiAxMS43MDcxIDEyLjA3MTFDMTEuMzE2NiAxMi40NjE2IDEwLjY4MzQgMTIuNDYxNiAxMC4yOTI5IDEyLjA3MTFMNiA3Ljc3ODIzTDEuNzA3MTEgMTIuMDcxMUMxLjMxNjU4IDEyLjQ2MTYgMC42ODM0MTcgMTIuNDYxNiAwLjI5Mjg5MyAxMi4wNzExQy0wLjA5NzYzMTEgMTEuNjgwNiAtMC4wOTc2MzExIDExLjA0NzQgMC4yOTI4OTMgMTAuNjU2OUw0LjU4NTc5IDYuMzY0MDFMMC4yOTI4OTQgMi4wNzExMkMtMC4wOTc2MzA2IDEuNjgwNiAtMC4wOTc2MzA2IDEuMDQ3NDMgMC4yOTI4OTQgMC42NTY5MDdaIiBmaWxsPSJibGFjayIgZmlsbC1vcGFjaXR5PSIwLjg0Ii8+Cjwvc3ZnPgo=);\n    background-position: center center;\n    background-repeat: no-repeat;\n    border: 0;\n    cursor: pointer;\n    padding: 16px;\n    position: absolute;\n    right: 12px;\n    top: 12px;\n}\n";
 exports.CSS_STYLES = CSS_STYLES;
 
-},{}],61:[function(require,module,exports){
+},{}],59:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18148,7 +18047,7 @@ function isFormLikelyToBeUsedAsPageWrapper(form) {
   return formChildrenPercentage > 50;
 }
 
-},{"./Form/matching.js":43}],62:[function(require,module,exports){
+},{"./Form/matching.js":41}],60:[function(require,module,exports){
 "use strict";
 
 require("./requestIdleCallback.js");
@@ -18183,7 +18082,7 @@ var _autofillUtils = require("./autofill-utils.js");
   }
 })();
 
-},{"./DeviceInterface.js":22,"./autofill-utils.js":61,"./requestIdleCallback.js":73}],63:[function(require,module,exports){
+},{"./DeviceInterface.js":20,"./autofill-utils.js":59,"./requestIdleCallback.js":71}],61:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18271,7 +18170,7 @@ function createGlobalConfig(overrides) {
   return config;
 }
 
-},{}],64:[function(require,module,exports){
+},{}],62:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18289,7 +18188,7 @@ const constants = {
 };
 exports.constants = constants;
 
-},{}],65:[function(require,module,exports){
+},{}],63:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18779,7 +18678,7 @@ class CloseEmailProtectionTabCall extends _deviceApi.DeviceApiCall {
 
 exports.CloseEmailProtectionTabCall = CloseEmailProtectionTabCall;
 
-},{"../../../packages/device-api":14,"./validators.zod.js":66}],66:[function(require,module,exports){
+},{"../../../packages/device-api":10,"./validators.zod.js":64}],64:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19285,7 +19184,7 @@ const apiSchema = _zod.z.object({
 
 exports.apiSchema = apiSchema;
 
-},{"zod":12}],67:[function(require,module,exports){
+},{"zod":8}],65:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19326,7 +19225,7 @@ class GetAlias extends _index.DeviceApiCall {
 
 exports.GetAlias = GetAlias;
 
-},{"../../packages/device-api/index.js":14,"./__generated__/validators.zod.js":66}],68:[function(require,module,exports){
+},{"../../packages/device-api/index.js":10,"./__generated__/validators.zod.js":64}],66:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19484,7 +19383,7 @@ function androidSpecificAvailableInputTypes(globalConfig) {
   };
 }
 
-},{"../../../packages/device-api/index.js":14,"../__generated__/deviceApiCalls.js":65}],69:[function(require,module,exports){
+},{"../../../packages/device-api/index.js":10,"../__generated__/deviceApiCalls.js":63}],67:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19492,7 +19391,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.AppleTransport = void 0;
 
-var _contentScopeUtils = require("@duckduckgo/content-scope-utils");
+var _messaging = require("../../../packages/messaging/messaging.js");
 
 var _index = require("../../../packages/device-api/index.js");
 
@@ -19503,12 +19402,12 @@ class AppleTransport extends _index.DeviceApiTransport {
   constructor(globalConfig) {
     super();
     this.config = globalConfig;
-    const webkitConfig = new _contentScopeUtils.WebkitMessagingConfig({
+    const webkitConfig = new _messaging.WebkitMessagingConfig({
       hasModernWebkitAPI: this.config.hasModernWebkitAPI,
       webkitMessageHandlerNames: this.config.webkitMessageHandlerNames,
       secret: this.config.secret
     });
-    this.messaging = new _contentScopeUtils.Messaging(webkitConfig);
+    this.messaging = new _messaging.Messaging(webkitConfig);
   }
 
   async send(deviceApiCall) {
@@ -19520,7 +19419,7 @@ class AppleTransport extends _index.DeviceApiTransport {
         return this.messaging.notify(deviceApiCall.method, deviceApiCall.params || undefined);
       }
     } catch (e) {
-      if (e instanceof _contentScopeUtils.MissingHandler) {
+      if (e instanceof _messaging.MissingHandler) {
         if (this.config.isDDGTestMode) {
           console.log('MissingWebkitHandler error for:', deviceApiCall.method);
         }
@@ -19560,7 +19459,7 @@ function appleSpecificRuntimeConfiguration(globalConfig) {
   };
 }
 
-},{"../../../packages/device-api/index.js":14,"../__generated__/deviceApiCalls.js":65,"@duckduckgo/content-scope-utils":2}],70:[function(require,module,exports){
+},{"../../../packages/device-api/index.js":10,"../../../packages/messaging/messaging.js":13,"../__generated__/deviceApiCalls.js":63}],68:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19732,7 +19631,7 @@ async function extensionSpecificSetIncontextSignupPermanentlyDismissedAtCall(par
   });
 }
 
-},{"../../../packages/device-api/index.js":14,"../../Settings.js":50,"../../autofill-utils.js":61,"../__generated__/deviceApiCalls.js":65}],71:[function(require,module,exports){
+},{"../../../packages/device-api/index.js":10,"../../Settings.js":48,"../../autofill-utils.js":59,"../__generated__/deviceApiCalls.js":63}],69:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19786,7 +19685,7 @@ function createTransport(globalConfig) {
   return new _extensionTransport.ExtensionTransport(globalConfig);
 }
 
-},{"./android.transport.js":68,"./apple.transport.js":69,"./extension.transport.js":70,"./windows.transport.js":72}],72:[function(require,module,exports){
+},{"./android.transport.js":66,"./apple.transport.js":67,"./extension.transport.js":68,"./windows.transport.js":70}],70:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19886,7 +19785,7 @@ function waitForWindowsResponse(responseId, options) {
   });
 }
 
-},{"../../../packages/device-api/index.js":14}],73:[function(require,module,exports){
+},{"../../../packages/device-api/index.js":10}],71:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -19934,4 +19833,4 @@ window.cancelIdleCallback = window.cancelIdleCallback || function (id) {
 var _default = {};
 exports.default = _default;
 
-},{}]},{},[62]);
+},{}]},{},[60]);

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -4251,25 +4251,25 @@ var _webkit = require("./webkit.js");
  */
 class Messaging {
   /**
-   * @param {WebkitMessagingConfig} config
-   */
+  * @param {WebkitMessagingConfig} config
+  */
   constructor(config) {
     this.transport = getTransport(config);
   }
   /**
-   * Send a 'fire-and-forget' message.
-   * @throws {Error}
-   * {@link MissingHandler}
-   *
-   * @example
-   *
-   * ```
-   * const messaging = new Messaging(config)
-   * messaging.notify("foo", {bar: "baz"})
-   * ```
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
+  * Send a 'fire-and-forget' message.
+  * @throws {Error}
+  * {@link MissingHandler}
+  *
+  * @example
+  *
+  * ```
+  * const messaging = new Messaging(config)
+  * messaging.notify("foo", {bar: "baz"})
+  * ```
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  */
 
 
   notify(name) {
@@ -4277,20 +4277,20 @@ class Messaging {
     this.transport.notify(name, data);
   }
   /**
-   * Send a request, and wait for a response
-   * @throws {Error}
-   * {@link MissingHandler}
-   *
-   * @example
-   * ```
-   * const messaging = new Messaging(config)
-   * const response = await messaging.request("foo", {bar: "baz"})
-   * ```
-   *
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
+  * Send a request, and wait for a response
+  * @throws {Error}
+  * {@link MissingHandler}
+  *
+  * @example
+  * ```
+  * const messaging = new Messaging(config)
+  * const response = await messaging.request("foo", {bar: "baz"})
+  * ```
+  *
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @return {Promise<any>}
+  */
 
 
   request(name) {
@@ -4308,23 +4308,21 @@ exports.Messaging = Messaging;
 
 class MessagingTransport {
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @returns {void}
-   */
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @returns {void}
+  */
   // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   notify(name) {
     let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     throw new Error("must implement 'notify'");
   }
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @return {Promise<any>}
+  */
   // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 
   request(name) {
@@ -4355,9 +4353,9 @@ function getTransport(config) {
 
 class MissingHandler extends Error {
   /**
-   * @param {string} message
-   * @param {string} handlerName
-   */
+  * @param {string} message
+  * @param {string} handlerName
+  */
   constructor(message, handlerName) {
     super(message);
     this.handlerName = handlerName;
@@ -4382,6 +4380,10 @@ exports.WebkitMessagingTransport = exports.WebkitMessagingConfig = exports.Secur
 var _messaging = require("./messaging.js");
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/**
+ * @typedef {import("./messaging").MessagingTransport} MessagingTransport
+ */
 
 /**
  * @example
@@ -4551,7 +4553,6 @@ class WebkitMessagingTransport {
    * @param {string} name
    * @param {Record<string, any>} [data]
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 
   request(name) {
@@ -4576,8 +4577,8 @@ class WebkitMessagingTransport {
       writable: false,
 
       /**
-       * @param {any[]} args
-       */
+      * @param {any[]} args
+      */
       value: function () {
         callback(...arguments); // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
 
@@ -4651,9 +4652,9 @@ class WebkitMessagingTransport {
         var _handlers$webkitMessa2;
 
         /**
-         * `bind` is used here to ensure future calls to the captured
-         * `postMessage` have the correct `this` context
-         */
+        * `bind` is used here to ensure future calls to the captured
+        * `postMessage` have the correct `this` context
+        */
         const original = handlers[webkitMessageHandlerName];
         const bound = (_handlers$webkitMessa2 = handlers[webkitMessageHandlerName].postMessage) === null || _handlers$webkitMessa2 === void 0 ? void 0 : _handlers$webkitMessa2.bind(original);
         this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
@@ -4685,11 +4686,11 @@ exports.WebkitMessagingTransport = WebkitMessagingTransport;
 
 class WebkitMessagingConfig {
   /**
-   * @param {object} params
-   * @param {boolean} params.hasModernWebkitAPI
-   * @param {string[]} params.webkitMessageHandlerNames
-   * @param {string} params.secret
-   */
+  * @param {object} params
+  * @param {boolean} params.hasModernWebkitAPI
+  * @param {string[]} params.webkitMessageHandlerNames
+  * @param {string} params.secret
+  */
   constructor(params) {
     /**
      * Whether or not the current WebKit Platform supports secure messaging
@@ -4697,14 +4698,14 @@ class WebkitMessagingConfig {
      */
     this.hasModernWebkitAPI = params.hasModernWebkitAPI;
     /**
-     * A list of WebKit message handler names that a user script can send
-     */
+    * A list of WebKit message handler names that a user script can send
+    */
 
     this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
     /**
-     * A string provided by native platforms to be sent with future outgoing
-     * messages
-     */
+    * A string provided by native platforms to be sent with future outgoing
+    * messages
+    */
 
     this.secret = params.secret;
   }
@@ -4720,30 +4721,30 @@ exports.WebkitMessagingConfig = WebkitMessagingConfig;
 
 class SecureMessagingParams {
   /**
-   * @param {object} params
-   * @param {string} params.methodName
-   * @param {string} params.secret
-   * @param {number[]} params.key
-   * @param {number[]} params.iv
-   */
+  * @param {object} params
+  * @param {string} params.methodName
+  * @param {string} params.secret
+  * @param {number[]} params.key
+  * @param {number[]} params.iv
+  */
   constructor(params) {
     /**
      * The method that's been appended to `window` to be called later
      */
     this.methodName = params.methodName;
     /**
-     * The secret used to ensure message sender validity
-     */
+    * The secret used to ensure message sender validity
+    */
 
     this.secret = params.secret;
     /**
-     * The CipherKey as number[]
-     */
+    * The CipherKey as number[]
+    */
 
     this.key = params.key;
     /**
-     * The Initial Vector as number[]
-     */
+    * The Initial Vector as number[]
+    */
 
     this.iv = params.iv;
   }

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -575,25 +575,25 @@ var _webkit = require("./webkit.js");
  */
 class Messaging {
   /**
-   * @param {WebkitMessagingConfig} config
-   */
+  * @param {WebkitMessagingConfig} config
+  */
   constructor(config) {
     this.transport = getTransport(config);
   }
   /**
-   * Send a 'fire-and-forget' message.
-   * @throws {Error}
-   * {@link MissingHandler}
-   *
-   * @example
-   *
-   * ```
-   * const messaging = new Messaging(config)
-   * messaging.notify("foo", {bar: "baz"})
-   * ```
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   */
+  * Send a 'fire-and-forget' message.
+  * @throws {Error}
+  * {@link MissingHandler}
+  *
+  * @example
+  *
+  * ```
+  * const messaging = new Messaging(config)
+  * messaging.notify("foo", {bar: "baz"})
+  * ```
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  */
 
 
   notify(name) {
@@ -601,20 +601,20 @@ class Messaging {
     this.transport.notify(name, data);
   }
   /**
-   * Send a request, and wait for a response
-   * @throws {Error}
-   * {@link MissingHandler}
-   *
-   * @example
-   * ```
-   * const messaging = new Messaging(config)
-   * const response = await messaging.request("foo", {bar: "baz"})
-   * ```
-   *
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
+  * Send a request, and wait for a response
+  * @throws {Error}
+  * {@link MissingHandler}
+  *
+  * @example
+  * ```
+  * const messaging = new Messaging(config)
+  * const response = await messaging.request("foo", {bar: "baz"})
+  * ```
+  *
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @return {Promise<any>}
+  */
 
 
   request(name) {
@@ -632,23 +632,21 @@ exports.Messaging = Messaging;
 
 class MessagingTransport {
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @returns {void}
-   */
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @returns {void}
+  */
   // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   notify(name) {
     let data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     throw new Error("must implement 'notify'");
   }
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [data]
-   * @return {Promise<any>}
-   */
+  * @param {string} name
+  * @param {Record<string, any>} [data]
+  * @return {Promise<any>}
+  */
   // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 
   request(name) {
@@ -679,9 +677,9 @@ function getTransport(config) {
 
 class MissingHandler extends Error {
   /**
-   * @param {string} message
-   * @param {string} handlerName
-   */
+  * @param {string} message
+  * @param {string} handlerName
+  */
   constructor(message, handlerName) {
     super(message);
     this.handlerName = handlerName;
@@ -706,6 +704,10 @@ exports.WebkitMessagingTransport = exports.WebkitMessagingConfig = exports.Secur
 var _messaging = require("./messaging.js");
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/**
+ * @typedef {import("./messaging").MessagingTransport} MessagingTransport
+ */
 
 /**
  * @example
@@ -875,7 +877,6 @@ class WebkitMessagingTransport {
    * @param {string} name
    * @param {Record<string, any>} [data]
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 
   request(name) {
@@ -900,8 +901,8 @@ class WebkitMessagingTransport {
       writable: false,
 
       /**
-       * @param {any[]} args
-       */
+      * @param {any[]} args
+      */
       value: function () {
         callback(...arguments); // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
 
@@ -975,9 +976,9 @@ class WebkitMessagingTransport {
         var _handlers$webkitMessa2;
 
         /**
-         * `bind` is used here to ensure future calls to the captured
-         * `postMessage` have the correct `this` context
-         */
+        * `bind` is used here to ensure future calls to the captured
+        * `postMessage` have the correct `this` context
+        */
         const original = handlers[webkitMessageHandlerName];
         const bound = (_handlers$webkitMessa2 = handlers[webkitMessageHandlerName].postMessage) === null || _handlers$webkitMessa2 === void 0 ? void 0 : _handlers$webkitMessa2.bind(original);
         this.globals.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
@@ -1009,11 +1010,11 @@ exports.WebkitMessagingTransport = WebkitMessagingTransport;
 
 class WebkitMessagingConfig {
   /**
-   * @param {object} params
-   * @param {boolean} params.hasModernWebkitAPI
-   * @param {string[]} params.webkitMessageHandlerNames
-   * @param {string} params.secret
-   */
+  * @param {object} params
+  * @param {boolean} params.hasModernWebkitAPI
+  * @param {string[]} params.webkitMessageHandlerNames
+  * @param {string} params.secret
+  */
   constructor(params) {
     /**
      * Whether or not the current WebKit Platform supports secure messaging
@@ -1021,14 +1022,14 @@ class WebkitMessagingConfig {
      */
     this.hasModernWebkitAPI = params.hasModernWebkitAPI;
     /**
-     * A list of WebKit message handler names that a user script can send
-     */
+    * A list of WebKit message handler names that a user script can send
+    */
 
     this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
     /**
-     * A string provided by native platforms to be sent with future outgoing
-     * messages
-     */
+    * A string provided by native platforms to be sent with future outgoing
+    * messages
+    */
 
     this.secret = params.secret;
   }
@@ -1044,30 +1045,30 @@ exports.WebkitMessagingConfig = WebkitMessagingConfig;
 
 class SecureMessagingParams {
   /**
-   * @param {object} params
-   * @param {string} params.methodName
-   * @param {string} params.secret
-   * @param {number[]} params.key
-   * @param {number[]} params.iv
-   */
+  * @param {object} params
+  * @param {string} params.methodName
+  * @param {string} params.secret
+  * @param {number[]} params.key
+  * @param {number[]} params.iv
+  */
   constructor(params) {
     /**
      * The method that's been appended to `window` to be called later
      */
     this.methodName = params.methodName;
     /**
-     * The secret used to ensure message sender validity
-     */
+    * The secret used to ensure message sender validity
+    */
 
     this.secret = params.secret;
     /**
-     * The CipherKey as number[]
-     */
+    * The CipherKey as number[]
+    */
 
     this.key = params.key;
     /**
-     * The Initial Vector as number[]
-     */
+    * The Initial Vector as number[]
+    */
 
     this.iv = params.iv;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,12 +27,12 @@
     "maxNodeModuleJsDepth": 1
   },
   "include": [
-    "node_modules/@duckduckgo/content-scope-utils",
     "src",
     "scripts",
     "packages/password",
     "integration-test",
     "packages/device-api",
+    "packages/messaging",
     "*.js",
     "types.d.ts"
   ],


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** 

## Description

content-scope-utils is no longer a benefit here, since only Autofill is using it, so I'm bringing into this codebase to reduce the maintenance burden of another dependency

Next up, we'll remove this too and use the *truly* shared lib from C-S-S, but for now this is a good step forward.

## Steps to test
