### PR TITLE
Fix handler regression

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15048,7 +15048,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     super();
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
-    // Use pointerup to mimic click behaviour when we're in the top-frame webview
+    // Use pointerup to mimic native click behaviour when we're in the top-frame webview
     if (options.device.globalConfig.isTopFrame) {
       window.addEventListener('pointerup', this, true);
     } else {

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12096,15 +12096,15 @@ const matchingConfiguration = exports.matchingConfiguration = {
         },
         expirationMonth: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(month|\bmm\b(?![.\s/-]yy))/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expirationYear: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(year|yy)/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expiration: {
           match: /(\bmm\b|\b\d\d\b)[/\s.\-_—–](\byy|\bjj|\baa|\b\d\d)|\bexp|\bvalid(idity| through| until)/iu,
-          skip: /invalid|^dd\//iu
+          skip: /invalid|^dd\/|check/iu
         },
         firstName: {
           match: /(first|given|fore).?name|\bnome/iu,
@@ -15048,8 +15048,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
     super();
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
-    window.addEventListener('pointerdown', this, true);
-    window.addEventListener('pointerup', this, true);
+    // Use pointerup to mimic click behaviour when we're in the top-frame webview
+    if (options.device.globalConfig.isTopFrame) {
+      window.addEventListener('pointerup', this, true);
+    } else {
+      // Pointerdown is needed here to avoid self-closing modals disappearing because this even happens in the page
+      window.addEventListener('pointerdown', this, true);
+    }
   }
   _activeInput;
   _activeInputOriginalAutocomplete;
@@ -15214,9 +15219,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     // @ts-ignore
     if (e.target.nodeName === 'DDG-AUTOFILL') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      // Ignore pointer down events, we'll handle them on pointer up
+      this._handleClickInTooltip(e);
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
@@ -15232,13 +15235,16 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     // @ts-ignore
     if (e.target.nodeName === 'DDG-AUTOFILL') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-      activeTooltip?.dispatchClick();
+      this._handleClickInTooltip(e);
     }
+  }
+  _handleClickInTooltip(e) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    const isMainMouseButton = e.button === 0;
+    if (!isMainMouseButton) return;
+    const activeTooltip = this.getActiveTooltip();
+    activeTooltip?.dispatchClick();
   }
   async removeTooltip(_via) {
     this._htmlTooltipOptions.remove();

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -11103,7 +11103,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     super();
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
-    // Use pointerup to mimic click behaviour when we're in the top-frame webview
+    // Use pointerup to mimic native click behaviour when we're in the top-frame webview
     if (options.device.globalConfig.isTopFrame) {
       window.addEventListener('pointerup', this, true);
     } else {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8151,15 +8151,15 @@ const matchingConfiguration = exports.matchingConfiguration = {
         },
         expirationMonth: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(month|\bmm\b(?![.\s/-]yy))/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expirationYear: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(year|yy)/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expiration: {
           match: /(\bmm\b|\b\d\d\b)[/\s.\-_—–](\byy|\bjj|\baa|\b\d\d)|\bexp|\bvalid(idity| through| until)/iu,
-          skip: /invalid|^dd\//iu
+          skip: /invalid|^dd\/|check/iu
         },
         firstName: {
           match: /(first|given|fore).?name|\bnome/iu,
@@ -11103,8 +11103,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
     super();
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
-    window.addEventListener('pointerdown', this, true);
-    window.addEventListener('pointerup', this, true);
+    // Use pointerup to mimic click behaviour when we're in the top-frame webview
+    if (options.device.globalConfig.isTopFrame) {
+      window.addEventListener('pointerup', this, true);
+    } else {
+      // Pointerdown is needed here to avoid self-closing modals disappearing because this even happens in the page
+      window.addEventListener('pointerdown', this, true);
+    }
   }
   _activeInput;
   _activeInputOriginalAutocomplete;
@@ -11269,9 +11274,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     // @ts-ignore
     if (e.target.nodeName === 'DDG-AUTOFILL') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      // Ignore pointer down events, we'll handle them on pointer up
+      this._handleClickInTooltip(e);
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
@@ -11287,13 +11290,16 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     // @ts-ignore
     if (e.target.nodeName === 'DDG-AUTOFILL') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-      activeTooltip?.dispatchClick();
+      this._handleClickInTooltip(e);
     }
+  }
+  _handleClickInTooltip(e) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    const isMainMouseButton = e.button === 0;
+    if (!isMainMouseButton) return;
+    const activeTooltip = this.getActiveTooltip();
+    activeTooltip?.dispatchClick();
   }
   async removeTooltip(_via) {
     this._htmlTooltipOptions.remove();

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -16,6 +16,7 @@ export const constants = {
         'loginWithPoorForm': 'pages/login-poor-form.html',
         'loginWithText': 'pages/login-with-text.html',
         'loginWithFormInModal': 'pages/login-in-modal.html',
+        'signupWithFormInModal': 'pages/signup-in-modal.html',
         'loginCovered': 'pages/login-covered.html',
         'loginMultistep': 'pages/login-multistep.html'
     },

--- a/integration-test/helpers/pages.js
+++ b/integration-test/helpers/pages.js
@@ -579,16 +579,16 @@ export function loginPage (page, opts = {}) {
             expect(mockCalls).toHaveLength(0)
         }
         async openDialog () {
-            const button = await page.waitForSelector(`button:has-text("Click here to Login")`)
+            const button = await page.waitForSelector(`button:has-text("Click here to open dialog")`)
             await button.click({ force: true })
             await this.assertDialogOpen()
         }
         async assertDialogClose () {
-            const form = await page.locator('#login')
+            const form = await page.locator('.dialog')
             await expect(form).toBeHidden()
         }
         async assertDialogOpen () {
-            const form = await page.locator('#login')
+            const form = await page.locator('.dialog')
             await expect(form).toBeVisible()
         }
         async hitEscapeKey () {

--- a/integration-test/pages/signup-in-modal.html
+++ b/integration-test/pages/signup-in-modal.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>Login form within a modal</title>
+  <title>Signup form within a modal</title>
   <link rel="stylesheet" href="./style.css" />
 </head>
 
@@ -16,14 +16,14 @@
 <p id="random-text">Some random text to use as "something outside the dialog element". Clicking here should close the dialog (if open).</p>
 
 <div class="dialog" hidden>
-  <form action="/login" id="login">
-    <h2>Log in</h2>
+  <form action="/signup" id="signup">
+    <h2>Signup</h2>
     <fieldset>
       <label for="email">Email</label>
       <input id="email" type="email">
       <label for="password">Password</label>
       <input id="password" type="password">
-      <button type="submit">Log in</button>
+      <button type="submit">Signup</button>
     </fieldset>
   </form>
 </div>

--- a/src/Form/matching-config/__generated__/compiled-matching-config.js
+++ b/src/Form/matching-config/__generated__/compiled-matching-config.js
@@ -266,15 +266,15 @@ const matchingConfiguration = {
         },
         expirationMonth: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(month|\bmm\b(?![.\s/-]yy))/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expirationYear: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(year|yy)/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expiration: {
           match: /(\bmm\b|\b\d\d\b)[/\s.\-_—–](\byy|\bjj|\baa|\b\d\d)|\bexp|\bvalid(idity| through| until)/iu,
-          skip: /invalid|^dd\//iu
+          skip: /invalid|^dd\/|check/iu
         },
         firstName: {
           match: /(first|given|fore).?name|\bnome/iu,

--- a/src/Form/matching-config/matching-config-source.js
+++ b/src/Form/matching-config/matching-config-source.js
@@ -293,12 +293,12 @@ const matchingConfiguration = {
                 cardSecurityCode: {match: 'security.?code|card.?verif|cvv|csc|cvc|cv2|card id'},
                 expirationMonth: {
                     match: '(card|\\bcc\\b)?.?(exp(iry|iration)?)?.?(month|\\bmm\\b(?![.\\s/-]yy))',
-                    skip: 'mm[/\\s.\\-_—–]'
+                    skip: 'mm[/\\s.\\-_—–]|check'
                 },
-                expirationYear: {match: '(card|\\bcc\\b)?.?(exp(iry|iration)?)?.?(year|yy)', skip: 'mm[/\\s.\\-_—–]'},
+                expirationYear: {match: '(card|\\bcc\\b)?.?(exp(iry|iration)?)?.?(year|yy)', skip: 'mm[/\\s.\\-_—–]|check'},
                 expiration: {
                     match: '(\\bmm\\b|\\b\\d\\d\\b)[/\\s.\\-_—–](\\byy|\\bjj|\\baa|\\b\\d\\d)|\\bexp|\\bvalid(idity| through| until)',
-                    skip: 'invalid|^dd/'
+                    skip: 'invalid|^dd/|check'
                 },
 
                 // Identities

--- a/src/Form/test-cases/accor_hotel-booking.html
+++ b/src/Form/test-cases/accor_hotel-booking.html
@@ -1,0 +1,241 @@
+<!-- https://all.accor.com/hotel/5011/index.en.shtml#section-rooms -->
+<form action="/identification/identify.action" autocomplete="off" class="booking form" id="booking-form" method="post">
+    <div><input id="search-destination" name="search.destination" type="hidden" value="5011"><!--Dates-->
+        <div class="booking__dates">
+            <div class="date"><label for="booking-date-in">Check-In <span class="label__helper">e.g.: 29/09/2023</span></label>
+                <input aria-required="true" class="hasDatepicker" data-manual-scoring="unknown" data-event-action="search - click on cta"
+                       data-event-label="arrival date" id="booking-date-in" name="search.dateIn"
+                       type="text"> <input id="search-date-in-day" name="search.dayIn" type="hidden"
+                                                            value=""> <input id="search-date-in-month"
+                                                                             name="search.monthIn" type="hidden"
+                                                                             value=""> <input id="search-date-in-year"
+                                                                                              name="search.yearIn"
+                                                                                              type="hidden" value="">
+                <svg aria-hidden="true" class="calendar lazysvg-loaded"
+                     data-url="/fact-sheet/assets/icons/graphics/icons.htm" focusable="false">
+                    <use xlink:href="#icon-calendar"></use>
+                </svg>
+            </div>
+            <div class="date disabled">
+                <label for="booking-date-out">Check-out <span class="label__helper">e.g.: 29/09/2023</span></label>
+                <input aria-required="true" class="hasDatepicker" data-manual-scoring="unknown" data-event-action="search - click on cta" data-event-label="departure date"
+                       disabled="disabled" id="booking-date-out" name="search.dateOut"
+                       type="text"><input id="search-date-out-day" name="search.dayOut" type="hidden"
+                                                            value=""> <input id="search-date-out-month"
+                                                                             name="search.monthOut" type="hidden"
+                                                                             value=""> <input id="search-date-out-year"
+                                                                                              name="search.yearOut"
+                                                                                              type="hidden" value="">
+                <input id="search-nightNb" name="search.nightNb" type="hidden" value="">
+                <svg aria-hidden="true" class="calendar lazysvg-loaded"
+                     data-url="/fact-sheet/assets/icons/graphics/icons.htm" focusable="false">
+                    <use xlink:href="#icon-calendar"></use>
+                </svg>
+            </div>
+            <div aria-hidden="true"
+                 class="ui-datepicker ui-widget ui-widget-content ui-helper-clearfix ui-corner-all open-date-in"
+                 id="ui-datepicker-div" style="position: absolute; top: 1357px; left: 125px; z-index: 1; display: block;">
+                <div class="ui-datepicker-header ui-widget-header ui-helper-clearfix ui-corner-all"><a
+                        class="ui-datepicker-prev ui-corner-all ui-state-disabled" title="Previous"><span
+                        class="ui-icon ui-icon-circle-triangle-w">Previous</span></a><a
+                        class="ui-datepicker-next ui-corner-all" data-event="click" data-handler="next"
+                        title="Next"><span class="ui-icon ui-icon-circle-triangle-e">Next</span></a>
+                    <div class="ui-datepicker-title"><span class="ui-datepicker-month">September</span>&nbsp;<span
+                            class="ui-datepicker-year">2023</span></div>
+                </div>
+                <table class="ui-datepicker-calendar">
+                    <thead>
+                    <tr>
+                        <th scope="col"><span title="Monday">Mo</span></th>
+                        <th scope="col"><span title="Tuesday">Tu</span></th>
+                        <th scope="col"><span title="Wednesday">We</span></th>
+                        <th scope="col"><span title="Thursday">Th</span></th>
+                        <th scope="col"><span title="Friday">Fr</span></th>
+                        <th class="ui-datepicker-week-end" scope="col"><span title="Saturday">Sa</span></th>
+                        <th class="ui-datepicker-week-end" scope="col"><span title="Sunday">Su</span></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td class=" ui-datepicker-other-month ui-datepicker-unselectable ui-state-disabled">&nbsp;</td>
+                        <td class=" ui-datepicker-other-month ui-datepicker-unselectable ui-state-disabled">&nbsp;</td>
+                        <td class=" ui-datepicker-other-month ui-datepicker-unselectable ui-state-disabled">&nbsp;</td>
+                        <td class=" ui-datepicker-other-month ui-datepicker-unselectable ui-state-disabled">&nbsp;</td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">1</span></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">2</span></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">3</span></td>
+                    </tr>
+                    <tr>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">4</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">5</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">6</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">7</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">8</span></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">9</span></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">10</span></td>
+                    </tr>
+                    <tr>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">11</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">12</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">13</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">14</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">15</span></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">16</span></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">17</span></td>
+                    </tr>
+                    <tr>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">18</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">19</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">20</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">21</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">22</span></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">23</span></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">24</span></td>
+                    </tr>
+                    <tr>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">25</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">26</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">27</span></td>
+                        <td class=" ui-datepicker-unselectable ui-state-disabled "><span
+                                class="ui-state-default">28</span></td>
+                        <td class=" ui-datepicker-days-cell-over  ui-datepicker-today" data-event="click"
+                            data-handler="selectDay" data-month="8" data-year="2023"><a
+                                class="ui-state-default ui-state-highlight ui-state-hover" href="#">29</a></td>
+                        <td class=" ui-datepicker-week-end " data-event="click" data-handler="selectDay" data-month="8"
+                            data-year="2023"><a class="ui-state-default" href="#">30</a></td>
+                        <td class=" ui-datepicker-week-end ui-datepicker-other-month ui-datepicker-unselectable ui-state-disabled">
+                            &nbsp;
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div><!-- Rooms's -->
+        <div class="hideshow hideshow--closable" data-role="hideshow" id="booking-composition"><!-- Rooms -->
+            <button aria-controls="booking-compo" aria-expanded="false" class="fake-input hideshow__button" id="compo-summary"
+                    type="button">1 Room, 1 Adult
+            </button>
+            <div aria-hidden="true" class="hideshow__content booking__compo" id="booking-compo">
+                <div><input data-manual-scoring="unknown" hidden="" id="search-room-number" name="search.roomNumber" readonly="readonly"
+                            type="text" value="1">
+                    <fieldset class="booking__room" id="compo-room-0">
+                        <legend>Room <span>1</span></legend>
+
+                        <div class="form__selector js-selector-adult" data-max="9" data-min="1" id="selector-adults-0">
+                            <label for="search-adult-room-0">
+                                Adults
+                            </label>
+                            <div>
+                                <button class="button button-secondary button--less" data-event-action="search - click on cta"
+                                        data-event-label="adults" disabled="disabled"
+                                        type="button">
+                                    <span class="sr-only">Remove an adult</span>
+                                </button>
+                                <input data-manual-scoring="unknown" id="search-adult-room-0" name="search.roomCriteria[0].adultNumber"
+                                       readonly="" tabindex="-1" type="text" value="1">
+                                <button class="button button-secondary button--more" data-event-action="search - click on cta"
+                                        data-event-label="adults" type="button">
+                                    <span class="sr-only">Add an adult</span>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="form__selector js-selector-children" data-max="6" data-min="0"
+                             id="selector-children-0">
+                            <label for="search-children-room-0">
+                                Children
+                            </label>
+                            <div>
+                                <button class="button button-secondary button--less" data-event-action="search - click on cta"
+                                        data-event-label="children" disabled="disabled"
+                                        type="button">
+                                    <span class="sr-only">Remove a child</span>
+                                </button>
+                                <input data-manual-scoring="unknown" id="search-children-room-0"
+                                       name="search.roomCriteria[0].childrenNumber" readonly="" tabindex="-1" type="text"
+                                       value="0">
+                                <button class="button button-secondary button--more" data-event-action="search - click on cta"
+                                        data-event-label="children" type="button">
+                                    <span class="sr-only">Add a child</span>
+                                </button>
+                            </div>
+                        </div>
+
+                        <fieldset class="booking__compo--children" hidden="" id="children-age-room-0">
+                            <legend>Children's age</legend>
+                        </fieldset>
+
+                        <button class="text-link js-remove-room" data-room="0" style="display: none;" type="button">
+                            Remove the room
+                        </button>
+                    </fieldset>
+                </div>
+                <button class="text-link btn__add-room" id="compo-add-room" type="button">Add a room</button>
+            </div>
+        </div><!-- Spécial Rates -->
+        <div class="hideshow hideshow--closable booking__specialrates" data-role="hideshow" id="booking-special-rates">
+            <hr>
+            <button aria-controls="booking-specialrates" aria-expanded="false" class="button button-expand hideshow__button"
+                    data-event-action="search - click on cta" data-event-label="special rates" id="booking-special-rates-btn"
+                    type="button"><span>Special rates</span></button>
+            <div aria-hidden="true" class="hideshow__content" id="booking-specialrates"><!-- Loyalty card -->
+                <div><label for="loyalty-card">Loyalty or subscription number <span class="label__helper">16-digit number on your card</span></label>
+                    <input data-manual-scoring="cardNumber" data-event-action="search - click on cta"
+                           data-event-label="loyalty card" id="loyalty-card"
+                           name="identification.fidelityCard.number" type="text"></div>
+                <!-- Preferential code -->
+                <div><label for="pref-code">Preferential code</label> <input data-manual-scoring="unknown"
+                                                                             data-event-action="search - click on cta"
+                                                                             data-event-label="preferential code"
+                                                                             id="pref-code"
+                                                                             name="identification.preferredCode.code"
+                                                                             type="text"></div>
+                <!-- Client ID -->
+                <div><label for="client-code">Business client with contract <span class="label__helper">Client code (SC, AS...)</span></label>
+                    <input data-manual-scoring="unknown" data-event-action="search - click on cta" data-event-label="business contract" id="client-code"
+                           name="identification.reserverId" placeholder="10 characters"
+                           type="text"></div><!-- Access-code -->
+                <div><label for="access-code">Access code <span class="label__helper">10 characters</span></label>
+                    <input data-manual-scoring="unknown" data-event-action="search - click on cta" data-event-label="access code"
+                           id="access-code" name="identification.reserverContract"
+                           type="text"></div>
+                <input id="identification-reserverType" name="identification.reserverType" type="hidden" value=""></div>
+        </div>
+        <input name="filter.hotelRatingClass" type="hidden" value="ALL"> <input name="filter.forkPrice.bound"
+                                                                                type="hidden" value="ALL"> <input
+                name="filter.brands" type="hidden" value=""> <input name="search.freeNight" type="hidden" value="no">
+        <input name="search.snu" type="hidden" value="no">
+        <button class="button button-accent button--submit" data-event-action="search - click on cta" data-event-label="search"
+                id="trigger-search" type="submit" data-manual-submit>See rates
+        </button>
+    </div>
+    <div class="snu-stay-plus">
+        <div id="snu-stay-plus"></div>
+    </div>
+</form>

--- a/src/Form/test-cases/index.json
+++ b/src/Form/test-cases/index.json
@@ -502,5 +502,6 @@
   { "html": "morningstar_login.html" },
   { "html": "alrincon_login.html" },
   { "html": "metalarchives_login.html" },
+  { "html": "accor_hotel-booking.html" },
   { "html": "flytap_login.html" }
 ]

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -44,8 +44,13 @@ export class HTMLTooltipUIController extends UIController {
         super()
         this._options = options
         this._htmlTooltipOptions = Object.assign({}, defaultOptions, htmlTooltipOptions)
-        window.addEventListener('pointerdown', this, true)
-        window.addEventListener('pointerup', this, true)
+        // Use pointerup to mimic click behaviour when we're in the top-frame webview
+        if (options.device.globalConfig.isTopFrame) {
+            window.addEventListener('pointerup', this, true)
+        } else {
+            // Pointerdown is needed here to avoid self-closing modals disappearing because this even happens in the page
+            window.addEventListener('pointerdown', this, true)
+        }
     }
 
     _activeInput
@@ -214,9 +219,7 @@ export class HTMLTooltipUIController extends UIController {
 
         // @ts-ignore
         if (e.target.nodeName === 'DDG-AUTOFILL') {
-            e.preventDefault()
-            e.stopImmediatePropagation()
-            // Ignore pointer down events, we'll handle them on pointer up
+            this._handleClickInTooltip(e)
         } else {
             this.removeTooltip().catch(e => {
                 console.error('error removing tooltip', e)
@@ -232,15 +235,19 @@ export class HTMLTooltipUIController extends UIController {
 
         // @ts-ignore
         if (e.target.nodeName === 'DDG-AUTOFILL') {
-            e.preventDefault()
-            e.stopImmediatePropagation()
-
-            const isMainMouseButton = e.button === 0
-            if (!isMainMouseButton) return
-
-            const activeTooltip = this.getActiveTooltip()
-            activeTooltip?.dispatchClick()
+            this._handleClickInTooltip(e)
         }
+    }
+
+    _handleClickInTooltip (e) {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+
+        const isMainMouseButton = e.button === 0
+        if (!isMainMouseButton) return
+
+        const activeTooltip = this.getActiveTooltip()
+        activeTooltip?.dispatchClick()
     }
 
     async removeTooltip (_via) {

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -44,7 +44,7 @@ export class HTMLTooltipUIController extends UIController {
         super()
         this._options = options
         this._htmlTooltipOptions = Object.assign({}, defaultOptions, htmlTooltipOptions)
-        // Use pointerup to mimic click behaviour when we're in the top-frame webview
+        // Use pointerup to mimic native click behaviour when we're in the top-frame webview
         if (options.device.globalConfig.isTopFrame) {
             window.addEventListener('pointerup', this, true)
         } else {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15048,7 +15048,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     super();
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
-    // Use pointerup to mimic click behaviour when we're in the top-frame webview
+    // Use pointerup to mimic native click behaviour when we're in the top-frame webview
     if (options.device.globalConfig.isTopFrame) {
       window.addEventListener('pointerup', this, true);
     } else {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -12096,15 +12096,15 @@ const matchingConfiguration = exports.matchingConfiguration = {
         },
         expirationMonth: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(month|\bmm\b(?![.\s/-]yy))/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expirationYear: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(year|yy)/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expiration: {
           match: /(\bmm\b|\b\d\d\b)[/\s.\-_—–](\byy|\bjj|\baa|\b\d\d)|\bexp|\bvalid(idity| through| until)/iu,
-          skip: /invalid|^dd\//iu
+          skip: /invalid|^dd\/|check/iu
         },
         firstName: {
           match: /(first|given|fore).?name|\bnome/iu,
@@ -15048,8 +15048,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
     super();
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
-    window.addEventListener('pointerdown', this, true);
-    window.addEventListener('pointerup', this, true);
+    // Use pointerup to mimic click behaviour when we're in the top-frame webview
+    if (options.device.globalConfig.isTopFrame) {
+      window.addEventListener('pointerup', this, true);
+    } else {
+      // Pointerdown is needed here to avoid self-closing modals disappearing because this even happens in the page
+      window.addEventListener('pointerdown', this, true);
+    }
   }
   _activeInput;
   _activeInputOriginalAutocomplete;
@@ -15214,9 +15219,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     // @ts-ignore
     if (e.target.nodeName === 'DDG-AUTOFILL') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      // Ignore pointer down events, we'll handle them on pointer up
+      this._handleClickInTooltip(e);
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
@@ -15232,13 +15235,16 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     // @ts-ignore
     if (e.target.nodeName === 'DDG-AUTOFILL') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-      activeTooltip?.dispatchClick();
+      this._handleClickInTooltip(e);
     }
+  }
+  _handleClickInTooltip(e) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    const isMainMouseButton = e.button === 0;
+    if (!isMainMouseButton) return;
+    const activeTooltip = this.getActiveTooltip();
+    activeTooltip?.dispatchClick();
   }
   async removeTooltip(_via) {
     this._htmlTooltipOptions.remove();

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -11103,7 +11103,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     super();
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
-    // Use pointerup to mimic click behaviour when we're in the top-frame webview
+    // Use pointerup to mimic native click behaviour when we're in the top-frame webview
     if (options.device.globalConfig.isTopFrame) {
       window.addEventListener('pointerup', this, true);
     } else {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -8151,15 +8151,15 @@ const matchingConfiguration = exports.matchingConfiguration = {
         },
         expirationMonth: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(month|\bmm\b(?![.\s/-]yy))/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expirationYear: {
           match: /(card|\bcc\b)?.?(exp(iry|iration)?)?.?(year|yy)/iu,
-          skip: /mm[/\s.\-_—–]/iu
+          skip: /mm[/\s.\-_—–]|check/iu
         },
         expiration: {
           match: /(\bmm\b|\b\d\d\b)[/\s.\-_—–](\byy|\bjj|\baa|\b\d\d)|\bexp|\bvalid(idity| through| until)/iu,
-          skip: /invalid|^dd\//iu
+          skip: /invalid|^dd\/|check/iu
         },
         firstName: {
           match: /(first|given|fore).?name|\bnome/iu,
@@ -11103,8 +11103,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
     super();
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
-    window.addEventListener('pointerdown', this, true);
-    window.addEventListener('pointerup', this, true);
+    // Use pointerup to mimic click behaviour when we're in the top-frame webview
+    if (options.device.globalConfig.isTopFrame) {
+      window.addEventListener('pointerup', this, true);
+    } else {
+      // Pointerdown is needed here to avoid self-closing modals disappearing because this even happens in the page
+      window.addEventListener('pointerdown', this, true);
+    }
   }
   _activeInput;
   _activeInputOriginalAutocomplete;
@@ -11269,9 +11274,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     // @ts-ignore
     if (e.target.nodeName === 'DDG-AUTOFILL') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      // Ignore pointer down events, we'll handle them on pointer up
+      this._handleClickInTooltip(e);
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
@@ -11287,13 +11290,16 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     // @ts-ignore
     if (e.target.nodeName === 'DDG-AUTOFILL') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-      activeTooltip?.dispatchClick();
+      this._handleClickInTooltip(e);
     }
+  }
+  _handleClickInTooltip(e) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    const isMainMouseButton = e.button === 0;
+    if (!isMainMouseButton) return;
+    const activeTooltip = this.getActiveTooltip();
+    activeTooltip?.dispatchClick();
   }
   async removeTooltip(_via) {
     this._htmlTooltipOptions.remove();


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/1200930669568058/1205581668483223/f

## Description
We [recently](https://github.com/duckduckgo/duckduckgo-autofill/pull/333) introduced a regression on extensions where we were no longer protecting against self-closing modals, meaning trying to autofill would also close the modal in certain cases. This fixes the regression and the tests that didn't catch it 🙃. I've also slipped in a minor accuracy update.

## Steps to test
Tests now actually work. To see this in action, you can try this in https://privacy-test-pages.site/autofill/autoprompt/2-form-in-modal.html using the extension. The production extension will close the modal, but this version won't.