### PR TITLE
Revert mutation observer for forms

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -9411,7 +9411,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const {
   ATTR_AUTOFILL,
   ATTR_INPUT_TYPE,
-  MAX_FORM_MUT_OBS_COUNT,
   MAX_INPUTS_PER_FORM
 } = _constants.constants;
 class Form {
@@ -9460,29 +9459,6 @@ class Form {
         if (!entry.isIntersecting) this.removeTooltip();
       }
     });
-    this.mutObsCount = 0;
-    this.mutObsConfig = {
-      childList: true,
-      subtree: true
-    };
-    this.mutObs = new MutationObserver(records => {
-      const anythingRemoved = records.some(record => record.removedNodes.length > 0);
-      if (anythingRemoved) {
-        // Must check for inputs because a parent may be removed and not show up in record.removedNodes
-        if ([...this.inputs.all].some(input => !input.isConnected)) {
-          // If any known input has been removed from the DOM, reanalyze the whole form
-          window.requestIdleCallback(() => {
-            this.formAnalyzer = new _FormAnalyzer.default(this.form, input, this.matching);
-            this.recategorizeAllInputs();
-          });
-          this.mutObsCount++;
-          // If the form mutates too much, disconnect to avoid performance issues
-          if (this.mutObsCount >= MAX_FORM_MUT_OBS_COUNT) {
-            this.mutObs.disconnect();
-          }
-        }
-      }
-    });
 
     // This ensures we fire the handler again if the form is changed
     this.addListener(form, 'input', () => {
@@ -9492,7 +9468,6 @@ class Form {
       }
     });
     this.categorizeInputs();
-    this.mutObs.observe(this.form, this.mutObsConfig);
     this.logFormInfo();
     if (shouldAutoprompt) {
       this.promptLoginIfNeeded();
@@ -9723,7 +9698,6 @@ class Form {
     this.removeAllDecorations();
     this.removeTooltip();
     this.forgetAllInputs();
-    this.mutObs.disconnect();
     this.matching.clear();
     this.intObs = null;
   }
@@ -9802,13 +9776,6 @@ class Form {
         console.log('The form has too many inputs, destroying.');
       }
       this.destroy();
-      return this;
-    }
-
-    // When new inputs are added after the initial scan, reanalyze the whole form
-    if (this.initialScanComplete) {
-      this.formAnalyzer = new _FormAnalyzer.default(this.form, input, this.matching);
-      this.recategorizeAllInputs();
       return this;
     }
 
@@ -13868,9 +13835,14 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
-      // We've met the form, add the input
-      this.forms.get(parentForm)?.addInput(input);
+    if (parentForm && parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+      const foundForm = this.forms.get(parentForm);
+      // We've met the form, add the input provided it's below the max input limit
+      if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {
+        foundForm.addInput(input);
+      } else {
+        this.stopScanner('The form has too many inputs, destroying.');
+      }
       return;
     }
 

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -13835,7 +13835,7 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    if (parentForm && parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
       const foundForm = this.forms.get(parentForm);
       // We've met the form, add the input provided it's below the max input limit
       if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -5466,7 +5466,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const {
   ATTR_AUTOFILL,
   ATTR_INPUT_TYPE,
-  MAX_FORM_MUT_OBS_COUNT,
   MAX_INPUTS_PER_FORM
 } = _constants.constants;
 class Form {
@@ -5515,29 +5514,6 @@ class Form {
         if (!entry.isIntersecting) this.removeTooltip();
       }
     });
-    this.mutObsCount = 0;
-    this.mutObsConfig = {
-      childList: true,
-      subtree: true
-    };
-    this.mutObs = new MutationObserver(records => {
-      const anythingRemoved = records.some(record => record.removedNodes.length > 0);
-      if (anythingRemoved) {
-        // Must check for inputs because a parent may be removed and not show up in record.removedNodes
-        if ([...this.inputs.all].some(input => !input.isConnected)) {
-          // If any known input has been removed from the DOM, reanalyze the whole form
-          window.requestIdleCallback(() => {
-            this.formAnalyzer = new _FormAnalyzer.default(this.form, input, this.matching);
-            this.recategorizeAllInputs();
-          });
-          this.mutObsCount++;
-          // If the form mutates too much, disconnect to avoid performance issues
-          if (this.mutObsCount >= MAX_FORM_MUT_OBS_COUNT) {
-            this.mutObs.disconnect();
-          }
-        }
-      }
-    });
 
     // This ensures we fire the handler again if the form is changed
     this.addListener(form, 'input', () => {
@@ -5547,7 +5523,6 @@ class Form {
       }
     });
     this.categorizeInputs();
-    this.mutObs.observe(this.form, this.mutObsConfig);
     this.logFormInfo();
     if (shouldAutoprompt) {
       this.promptLoginIfNeeded();
@@ -5778,7 +5753,6 @@ class Form {
     this.removeAllDecorations();
     this.removeTooltip();
     this.forgetAllInputs();
-    this.mutObs.disconnect();
     this.matching.clear();
     this.intObs = null;
   }
@@ -5857,13 +5831,6 @@ class Form {
         console.log('The form has too many inputs, destroying.');
       }
       this.destroy();
-      return this;
-    }
-
-    // When new inputs are added after the initial scan, reanalyze the whole form
-    if (this.initialScanComplete) {
-      this.formAnalyzer = new _FormAnalyzer.default(this.form, input, this.matching);
-      this.recategorizeAllInputs();
       return this;
     }
 
@@ -9923,9 +9890,14 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
-      // We've met the form, add the input
-      this.forms.get(parentForm)?.addInput(input);
+    if (parentForm && parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+      const foundForm = this.forms.get(parentForm);
+      // We've met the form, add the input provided it's below the max input limit
+      if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {
+        foundForm.addInput(input);
+      } else {
+        this.stopScanner('The form has too many inputs, destroying.');
+      }
       return;
     }
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -9890,7 +9890,7 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    if (parentForm && parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
       const foundForm = this.forms.get(parentForm);
       // We've met the form, add the input provided it's below the max input limit
       if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {

--- a/integration-test/tests/mutating-form.macos.spec.js
+++ b/integration-test/tests/mutating-form.macos.spec.js
@@ -8,7 +8,7 @@ import {test as base} from '@playwright/test'
  */
 const test = base.extend({})
 
-test.describe('Mutating form page', () => {
+test.describe.skip('Mutating form page', () => {
     async function applyScript (page) {
         await createAutofillScript()
             .replaceAll(macosContentScopeReplacements())

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -226,8 +226,13 @@ class DefaultScanner {
         const parentForm = this.getParentForm(input)
 
         if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
-            // We've met the form, add the input
-            this.forms.get(parentForm)?.addInput(input)
+            const foundForm = this.forms.get(parentForm)
+            // We've met the form, add the input provided it's below the max input limit
+            if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {
+                foundForm.addInput(input)
+            } else {
+                this.stopScanner('The form has too many inputs, destroying.')
+            }
             return
         }
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -9411,7 +9411,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const {
   ATTR_AUTOFILL,
   ATTR_INPUT_TYPE,
-  MAX_FORM_MUT_OBS_COUNT,
   MAX_INPUTS_PER_FORM
 } = _constants.constants;
 class Form {
@@ -9460,29 +9459,6 @@ class Form {
         if (!entry.isIntersecting) this.removeTooltip();
       }
     });
-    this.mutObsCount = 0;
-    this.mutObsConfig = {
-      childList: true,
-      subtree: true
-    };
-    this.mutObs = new MutationObserver(records => {
-      const anythingRemoved = records.some(record => record.removedNodes.length > 0);
-      if (anythingRemoved) {
-        // Must check for inputs because a parent may be removed and not show up in record.removedNodes
-        if ([...this.inputs.all].some(input => !input.isConnected)) {
-          // If any known input has been removed from the DOM, reanalyze the whole form
-          window.requestIdleCallback(() => {
-            this.formAnalyzer = new _FormAnalyzer.default(this.form, input, this.matching);
-            this.recategorizeAllInputs();
-          });
-          this.mutObsCount++;
-          // If the form mutates too much, disconnect to avoid performance issues
-          if (this.mutObsCount >= MAX_FORM_MUT_OBS_COUNT) {
-            this.mutObs.disconnect();
-          }
-        }
-      }
-    });
 
     // This ensures we fire the handler again if the form is changed
     this.addListener(form, 'input', () => {
@@ -9492,7 +9468,6 @@ class Form {
       }
     });
     this.categorizeInputs();
-    this.mutObs.observe(this.form, this.mutObsConfig);
     this.logFormInfo();
     if (shouldAutoprompt) {
       this.promptLoginIfNeeded();
@@ -9723,7 +9698,6 @@ class Form {
     this.removeAllDecorations();
     this.removeTooltip();
     this.forgetAllInputs();
-    this.mutObs.disconnect();
     this.matching.clear();
     this.intObs = null;
   }
@@ -9802,13 +9776,6 @@ class Form {
         console.log('The form has too many inputs, destroying.');
       }
       this.destroy();
-      return this;
-    }
-
-    // When new inputs are added after the initial scan, reanalyze the whole form
-    if (this.initialScanComplete) {
-      this.formAnalyzer = new _FormAnalyzer.default(this.form, input, this.matching);
-      this.recategorizeAllInputs();
       return this;
     }
 
@@ -13868,9 +13835,14 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
-      // We've met the form, add the input
-      this.forms.get(parentForm)?.addInput(input);
+    if (parentForm && parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+      const foundForm = this.forms.get(parentForm);
+      // We've met the form, add the input provided it's below the max input limit
+      if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {
+        foundForm.addInput(input);
+      } else {
+        this.stopScanner('The form has too many inputs, destroying.');
+      }
       return;
     }
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -13835,7 +13835,7 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    if (parentForm && parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
       const foundForm = this.forms.get(parentForm);
       // We've met the form, add the input provided it's below the max input limit
       if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -5466,7 +5466,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const {
   ATTR_AUTOFILL,
   ATTR_INPUT_TYPE,
-  MAX_FORM_MUT_OBS_COUNT,
   MAX_INPUTS_PER_FORM
 } = _constants.constants;
 class Form {
@@ -5515,29 +5514,6 @@ class Form {
         if (!entry.isIntersecting) this.removeTooltip();
       }
     });
-    this.mutObsCount = 0;
-    this.mutObsConfig = {
-      childList: true,
-      subtree: true
-    };
-    this.mutObs = new MutationObserver(records => {
-      const anythingRemoved = records.some(record => record.removedNodes.length > 0);
-      if (anythingRemoved) {
-        // Must check for inputs because a parent may be removed and not show up in record.removedNodes
-        if ([...this.inputs.all].some(input => !input.isConnected)) {
-          // If any known input has been removed from the DOM, reanalyze the whole form
-          window.requestIdleCallback(() => {
-            this.formAnalyzer = new _FormAnalyzer.default(this.form, input, this.matching);
-            this.recategorizeAllInputs();
-          });
-          this.mutObsCount++;
-          // If the form mutates too much, disconnect to avoid performance issues
-          if (this.mutObsCount >= MAX_FORM_MUT_OBS_COUNT) {
-            this.mutObs.disconnect();
-          }
-        }
-      }
-    });
 
     // This ensures we fire the handler again if the form is changed
     this.addListener(form, 'input', () => {
@@ -5547,7 +5523,6 @@ class Form {
       }
     });
     this.categorizeInputs();
-    this.mutObs.observe(this.form, this.mutObsConfig);
     this.logFormInfo();
     if (shouldAutoprompt) {
       this.promptLoginIfNeeded();
@@ -5778,7 +5753,6 @@ class Form {
     this.removeAllDecorations();
     this.removeTooltip();
     this.forgetAllInputs();
-    this.mutObs.disconnect();
     this.matching.clear();
     this.intObs = null;
   }
@@ -5857,13 +5831,6 @@ class Form {
         console.log('The form has too many inputs, destroying.');
       }
       this.destroy();
-      return this;
-    }
-
-    // When new inputs are added after the initial scan, reanalyze the whole form
-    if (this.initialScanComplete) {
-      this.formAnalyzer = new _FormAnalyzer.default(this.form, input, this.matching);
-      this.recategorizeAllInputs();
       return this;
     }
 
@@ -9923,9 +9890,14 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
-      // We've met the form, add the input
-      this.forms.get(parentForm)?.addInput(input);
+    if (parentForm && parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+      const foundForm = this.forms.get(parentForm);
+      // We've met the form, add the input provided it's below the max input limit
+      if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {
+        foundForm.addInput(input);
+      } else {
+        this.stopScanner('The form has too many inputs, destroying.');
+      }
       return;
     }
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -9890,7 +9890,7 @@ class DefaultScanner {
   addInput(input) {
     if (this.stopped) return;
     const parentForm = this.getParentForm(input);
-    if (parentForm && parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
+    if (parentForm instanceof HTMLFormElement && this.forms.has(parentForm)) {
       const foundForm = this.forms.get(parentForm);
       // We've met the form, add the input provided it's below the max input limit
       if (foundForm && foundForm.inputs.all.size < MAX_INPUTS_PER_FORM) {


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/0/1205690199450910/f
**CC:** @kzar

## Description
Reverts the code that observes for form changes. This was causing the script to spin out of control in certain cases. To clarify, it wasn't the observer itself, but the way we were re-scanning the page when new fields were added (added in version 8.1.0). This is just a patch to stop the bleeding, I will follow up with a more comprehensive set of fixes as roughly outlined [here](https://app.asana.com/0/0/1205688498594652/f).

## Steps to test
To repro the issue:
1. Go to your Asana inbox
2. Refresh the page (so autofill starts from scratch)
3. Then from the Asana search bar, search for macOS Feedback and go there
4. On the macOS Feedback project, scroll a few times back and forth and wait for the items to load (usually a couple of scrolls are enough to trigger the warning in Firefox)

With this version it should not trigger the warning or freeze the page.