### PR TITLE
Don't call getAvailableInputTypes from topFrame

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -14400,6 +14400,10 @@ class Settings {
    */
   async getAvailableInputTypes() {
     try {
+      // This info is not needed in the topFrame, so we avoid calling the native app
+      if (this.globalConfig.isTopFrame) {
+        return Settings.defaults.availableInputTypes;
+      }
       return await this.deviceApi.request(new _deviceApiCalls.GetAvailableInputTypesCall(null));
     } catch (e) {
       if (this.globalConfig.isDDGTestMode) {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -10234,6 +10234,10 @@ class Settings {
    */
   async getAvailableInputTypes() {
     try {
+      // This info is not needed in the topFrame, so we avoid calling the native app
+      if (this.globalConfig.isTopFrame) {
+        return Settings.defaults.availableInputTypes;
+      }
       return await this.deviceApi.request(new _deviceApiCalls.GetAvailableInputTypesCall(null));
     } catch (e) {
       if (this.globalConfig.isDDGTestMode) {

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -119,6 +119,10 @@ export class Settings {
      */
     async getAvailableInputTypes () {
         try {
+            // This info is not needed in the topFrame, so we avoid calling the native app
+            if (this.globalConfig.isTopFrame) {
+                return Settings.defaults.availableInputTypes
+            }
             return await this.deviceApi.request(new GetAvailableInputTypesCall(null))
         } catch (e) {
             if (this.globalConfig.isDDGTestMode) {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -14400,6 +14400,10 @@ class Settings {
    */
   async getAvailableInputTypes() {
     try {
+      // This info is not needed in the topFrame, so we avoid calling the native app
+      if (this.globalConfig.isTopFrame) {
+        return Settings.defaults.availableInputTypes;
+      }
       return await this.deviceApi.request(new _deviceApiCalls.GetAvailableInputTypesCall(null));
     } catch (e) {
       if (this.globalConfig.isDDGTestMode) {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -10234,6 +10234,10 @@ class Settings {
    */
   async getAvailableInputTypes() {
     try {
+      // This info is not needed in the topFrame, so we avoid calling the native app
+      if (this.globalConfig.isTopFrame) {
+        return Settings.defaults.availableInputTypes;
+      }
       return await this.deviceApi.request(new _deviceApiCalls.GetAvailableInputTypesCall(null));
     } catch (e) {
       if (this.globalConfig.isDDGTestMode) {


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/0/1205907543853472/f

## Description
Short-circuits `getAvailableInputTypes` in the topFrame to avoid calling the native app unnecessarily. That data is only needed for page scanning which we don't do in that context. Another instance where that architectural decision back then creates unintended problems 😔.

## Steps to test
Everything should just work as usual in all autofill scenarios. Tom is testing specifically the Bitwarden integration.