### PR TITLE
fix tracker radar kit reference

### DIFF
--- a/scripts/release/tests/project.pbxproj
+++ b/scripts/release/tests/project.pbxproj
@@ -7111,7 +7111,7 @@
 		};
 		4B82E97E25B634B800656FE7 /* XCRemoteSwiftPackageReference "TrackerRadarKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/duckduckgo/TrackerRadarKit.git";
+			repositoryURL = "https://github.com/duckduckgo/TrackerRadarKit";
 			requirement = {
 				kind = exactVersion;
 				version = 1.1.1;


### PR DESCRIPTION
**Reviewer:** 
**Asana:** https://app.asana.com/0/414709148257752/1206667738648872/f

## Description

Updates TrackerRadarKit repo location to match usage elsewhere to avoid package.resolved changes when Swift Package manager determines the dependency graph. 

## Steps to test

* Build, run, smoke test autofill on iOS/macOS.
* If package.resolved is updated to remove the `.git` this is fine, as someone will eventually commit the correct version 
