### PR TITLE
remove device-specifc 'isEnabled' checks

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8597,10 +8597,8 @@ class InterfacePrototype {
   }
   async init() {
     // bail very early if we can
-    const isEnabledInitiallyViaConfig = (0, _autofillUtils.autofillEnabled)(this.globalConfig);
-    if (!isEnabledInitiallyViaConfig) {
-      return;
-    }
+    const settings = await this.settings.refresh();
+    if (!settings.enabled) return;
     const handler = async () => {
       if (document.readyState === 'complete') {
         window.removeEventListener('load', handler);

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4431,10 +4431,8 @@ class InterfacePrototype {
   }
   async init() {
     // bail very early if we can
-    const isEnabledInitiallyViaConfig = (0, _autofillUtils.autofillEnabled)(this.globalConfig);
-    if (!isEnabledInitiallyViaConfig) {
-      return;
-    }
+    const settings = await this.settings.refresh();
+    if (!settings.enabled) return;
     const handler = async () => {
       if (document.readyState === 'complete') {
         window.removeEventListener('load', handler);

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -3341,15 +3341,11 @@ exports.AndroidInterface = void 0;
 var _InterfacePrototype = _interopRequireDefault(require("./InterfacePrototype.js"));
 var _autofillUtils = require("../autofill-utils.js");
 var _NativeUIController = require("../UI/controllers/NativeUIController.js");
-var _appleUtils = require("@duckduckgo/content-scope-scripts/src/apple-utils");
 var _InContextSignup = require("../InContextSignup.js");
 var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 class AndroidInterface extends _InterfacePrototype.default {
   inContextSignup = new _InContextSignup.InContextSignup(this);
-  async isEnabled() {
-    return (0, _autofillUtils.autofillEnabled)(this.globalConfig, _appleUtils.processConfig);
-  }
 
   /**
    * @returns {Promise<string|undefined>}
@@ -3483,7 +3479,7 @@ class AndroidInterface extends _InterfacePrototype.default {
 }
 exports.AndroidInterface = AndroidInterface;
 
-},{"../InContextSignup.js":34,"../UI/controllers/NativeUIController.js":47,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"./InterfacePrototype.js":17,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],14:[function(require,module,exports){
+},{"../InContextSignup.js":34,"../UI/controllers/NativeUIController.js":47,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"./InterfacePrototype.js":17}],14:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -3492,7 +3488,6 @@ Object.defineProperty(exports, "__esModule", {
 exports.AppleDeviceInterface = void 0;
 var _InterfacePrototype = _interopRequireDefault(require("./InterfacePrototype.js"));
 var _autofillUtils = require("../autofill-utils.js");
-var _appleUtils = require("@duckduckgo/content-scope-scripts/src/apple-utils");
 var _HTMLTooltip = require("../UI/HTMLTooltip.js");
 var _HTMLTooltipUIController = require("../UI/controllers/HTMLTooltipUIController.js");
 var _OverlayUIController = require("../UI/controllers/OverlayUIController.js");
@@ -3514,9 +3509,6 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   /** @override */
   initialSetupDelayMs = 300;
   thirdPartyProvider = new _ThirdPartyProvider.ThirdPartyProvider(this);
-  async isEnabled() {
-    return (0, _autofillUtils.autofillEnabled)(this.globalConfig, _appleUtils.processConfig);
-  }
 
   /**
    * The default functionality of this class is to operate as an 'overlay controller' -
@@ -3828,7 +3820,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
 }
 exports.AppleDeviceInterface = AppleDeviceInterface;
 
-},{"../../packages/device-api/index.js":2,"../Form/matching.js":33,"../InContextSignup.js":34,"../ThirdPartyProvider.js":41,"../UI/HTMLTooltip.js":45,"../UI/controllers/HTMLTooltipUIController.js":46,"../UI/controllers/NativeUIController.js":47,"../UI/controllers/OverlayUIController.js":48,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"../deviceApiCalls/additionalDeviceApiCalls.js":58,"./InterfacePrototype.js":17,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],15:[function(require,module,exports){
+},{"../../packages/device-api/index.js":2,"../Form/matching.js":33,"../InContextSignup.js":34,"../ThirdPartyProvider.js":41,"../UI/HTMLTooltip.js":45,"../UI/controllers/HTMLTooltipUIController.js":46,"../UI/controllers/NativeUIController.js":47,"../UI/controllers/OverlayUIController.js":48,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"../deviceApiCalls/additionalDeviceApiCalls.js":58,"./InterfacePrototype.js":17}],15:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4004,18 +3996,6 @@ class ExtensionInterface extends _InterfacePrototype.default {
     if (callback) await callback();
     this.uiController = this.createUIController();
     await this.postInit();
-  }
-  async isEnabled() {
-    return new Promise(resolve => {
-      chrome?.runtime?.sendMessage({
-        registeredTempAutofillContentScript: true,
-        documentUrl: window.location.href
-      }, response => {
-        if (response && 'site' in response) {
-          resolve((0, _autofillUtils.isAutofillEnabledFromProcessedConfig)(response));
-        }
-      });
-    });
   }
   isDeviceSignedIn() {
     return this.hasLocalAddresses;
@@ -4433,14 +4413,14 @@ class InterfacePrototype {
   async startInit() {
     if (this.isInitializationStarted) return;
     this.alreadyInitialized = true;
-    await this.refreshSettings();
+    await this.settings.refresh();
     this.addDeviceListeners();
     await this.setupAutofill();
     this.uiController = this.createUIController();
 
     // this is the temporary measure to support windows whilst we still have 'setupAutofill'
     // eventually all interfaces will use this
-    if (!this.isEnabledViaSettings()) {
+    if (!this.settings.enabled) {
       return;
     }
     await this.setupSettingsPage();
@@ -4449,39 +4429,12 @@ class InterfacePrototype {
       (0, _initFormSubmissionsApi.initFormSubmissionsApi)(this.scanner.forms, this.scanner.matching);
     }
   }
-
-  /**
-   * This is to aid the migration to all platforms using Settings.enabled.
-   *
-   * For now, Windows is the only platform that can be 'enabled' or 'disabled' via
-   * the new Settings - which is why in that interface it has `return this.settings.enabled`
-   *
-   * Whilst we wait for other platforms to catch up, we offer this default implementation
-   * of just returning true.
-   *
-   * @returns {boolean}
-   */
-  isEnabledViaSettings() {
-    return true;
-  }
-
-  /**
-   * This is a fall-back situation for macOS since it was the only
-   * platform to support anything none-email based in the past.
-   *
-   * Once macOS fully supports 'getAvailableInputTypes' this can be removed
-   *
-   * @returns {Promise<void>}
-   */
-  async refreshSettings() {
-    await this.settings.refresh();
-  }
-  async isEnabled() {
-    return (0, _autofillUtils.autofillEnabled)(this.globalConfig);
-  }
   async init() {
-    const isEnabled = await this.isEnabled();
-    if (!isEnabled) return;
+    // bail very early if we can
+    const isEnabledInitiallyViaConfig = (0, _autofillUtils.autofillEnabled)(this.globalConfig);
+    if (!isEnabledInitiallyViaConfig) {
+      return;
+    }
     const handler = async () => {
       if (document.readyState === 'complete') {
         window.removeEventListener('load', handler);
@@ -4856,7 +4809,7 @@ class InterfacePrototype {
         // This call doesn't send a response, so we can't know if it succeeded
         this.storeUserData(data);
         await this.setupAutofill();
-        await this.refreshSettings();
+        await this.settings.refresh();
         await this.setupSettingsPage({
           shouldLog: true
         });
@@ -5042,21 +4995,11 @@ class WindowsInterface extends _InterfacePrototype.default {
   ready = false;
   /** @type {AbortController|null} */
   _abortController = null;
-  /**
-   * @deprecated This runs too early, and will be removed eventually.
-   * @returns {Promise<boolean>}
-   */
-  async isEnabled() {
-    return true;
-  }
   async setupAutofill() {
     const loggedIn = await this._getIsLoggedIn();
     if (loggedIn) {
       await this.getAddresses();
     }
-  }
-  isEnabledViaSettings() {
-    return Boolean(this.settings.enabled);
   }
   postInit() {
     super.postInit();
@@ -10376,7 +10319,6 @@ var _index = require("../packages/device-api/index.js");
 var _deviceApiCalls = require("./deviceApiCalls/__generated__/deviceApiCalls.js");
 var _validatorsZod = require("./deviceApiCalls/__generated__/validators.zod.js");
 var _autofillUtils = require("./autofill-utils.js");
-var _appleUtils = require("@duckduckgo/content-scope-scripts/src/apple-utils");
 /**
  * Some Type helpers to prevent duplication
  * @typedef {import("./deviceApiCalls/__generated__/validators-ts").AutofillFeatureToggles} AutofillFeatureToggles
@@ -10453,7 +10395,7 @@ class Settings {
   async getEnabled() {
     try {
       const runtimeConfig = await this._getRuntimeConfiguration();
-      const enabled = (0, _autofillUtils.autofillEnabled)(runtimeConfig, _appleUtils.processConfig);
+      const enabled = (0, _autofillUtils.autofillEnabled)(runtimeConfig);
       return enabled;
     } catch (e) {
       // these are the fallbacks for when a platform hasn't implemented the calls above. (like on android)
@@ -10714,7 +10656,7 @@ class Settings {
 }
 exports.Settings = Settings;
 
-},{"../packages/device-api/index.js":2,"./autofill-utils.js":52,"./deviceApiCalls/__generated__/deviceApiCalls.js":56,"./deviceApiCalls/__generated__/validators.zod.js":57,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],41:[function(require,module,exports){
+},{"../packages/device-api/index.js":2,"./autofill-utils.js":52,"./deviceApiCalls/__generated__/deviceApiCalls.js":56,"./deviceApiCalls/__generated__/validators.zod.js":57}],41:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12349,6 +12291,7 @@ exports.wasAutofilledByChrome = void 0;
 exports.whenIdle = whenIdle;
 var _matching = require("./Form/matching.js");
 var _constants = require("./constants.js");
+var _appleUtils = require("@duckduckgo/content-scope-scripts/src/apple-utils");
 const SIGN_IN_MSG = exports.SIGN_IN_MSG = {
   signMeIn: true
 };
@@ -12383,14 +12326,18 @@ const sendAndWaitForAnswer = (msgOrFn, expectedResponse) => {
 
 /**
  * @param {Pick<GlobalConfig, 'contentScope' | 'userUnprotectedDomains' | 'userPreferences'>} globalConfig
- * @param [processConfig]
  * @return {boolean}
  */
 exports.sendAndWaitForAnswer = sendAndWaitForAnswer;
-const autofillEnabled = (globalConfig, processConfig) => {
+const autofillEnabled = globalConfig => {
   if (!globalConfig.contentScope) {
     // Return enabled for platforms that haven't implemented the config yet
     return true;
+  }
+  // already processed? this handles an edgecase in the extension where the config is already processed
+  if ('site' in globalConfig.contentScope) {
+    const enabled = isAutofillEnabledFromProcessedConfig(globalConfig.contentScope);
+    return enabled;
   }
   const {
     contentScope,
@@ -12399,7 +12346,7 @@ const autofillEnabled = (globalConfig, processConfig) => {
   } = globalConfig;
 
   // Check config on Apple platforms
-  const processedConfig = processConfig(contentScope, userUnprotectedDomains, userPreferences);
+  const processedConfig = (0, _appleUtils.processConfig)(contentScope, userUnprotectedDomains, userPreferences);
   return isAutofillEnabledFromProcessedConfig(processedConfig);
 };
 exports.autofillEnabled = autofillEnabled;
@@ -12934,7 +12881,7 @@ function getActiveElement() {
   return innerActiveElement;
 }
 
-},{"./Form/matching.js":33,"./constants.js":55}],53:[function(require,module,exports){
+},{"./Form/matching.js":33,"./constants.js":55,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],53:[function(require,module,exports){
 "use strict";
 
 require("./requestIdleCallback.js");
@@ -13647,7 +13594,7 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
         }
       },
       // @ts-ignore
-      userUnprotectedDomains: deviceApi.config?.userUnprotectedDomains
+      userUnprotectedDomains: deviceApi.config?.userUnprotectedDomains || []
     }
   };
 }

--- a/integration-test/helpers/harness.js
+++ b/integration-test/helpers/harness.js
@@ -25,7 +25,7 @@ export async function setupMockedDomain (page, domain) {
 }
 
 export async function withEmailProtectionExtensionSignedInAs (page, username) {
-    const [backgroundPage] = await page.context().backgroundPages()
+    const [backgroundPage] = page.context().backgroundPages()
     await backgroundPage.evaluateHandle((personalAddress) => {
         // eslint-disable-next-line no-undef
         globalThis.setEmailProtectionUserData(personalAddress)

--- a/src/DeviceInterface/AndroidInterface.js
+++ b/src/DeviceInterface/AndroidInterface.js
@@ -1,16 +1,11 @@
 import InterfacePrototype from './InterfacePrototype.js'
-import {autofillEnabled, sendAndWaitForAnswer} from '../autofill-utils.js'
+import {sendAndWaitForAnswer} from '../autofill-utils.js'
 import { NativeUIController } from '../UI/controllers/NativeUIController.js'
-import {processConfig} from '@duckduckgo/content-scope-scripts/src/apple-utils'
 import { InContextSignup } from '../InContextSignup.js'
 import { CloseEmailProtectionTabCall, ShowInContextEmailProtectionSignupPromptCall } from '../deviceApiCalls/__generated__/deviceApiCalls.js'
 
 class AndroidInterface extends InterfacePrototype {
     inContextSignup = new InContextSignup(this)
-
-    async isEnabled () {
-        return autofillEnabled(this.globalConfig, processConfig)
-    }
 
     /**
      * @returns {Promise<string|undefined>}

--- a/src/DeviceInterface/AppleDeviceInterface.js
+++ b/src/DeviceInterface/AppleDeviceInterface.js
@@ -1,6 +1,5 @@
 import InterfacePrototype from './InterfacePrototype.js'
-import { formatDuckAddress, autofillEnabled } from '../autofill-utils.js'
-import { processConfig } from '@duckduckgo/content-scope-scripts/src/apple-utils'
+import { formatDuckAddress } from '../autofill-utils.js'
 import { defaultOptions } from '../UI/HTMLTooltip.js'
 import { HTMLTooltipUIController } from '../UI/controllers/HTMLTooltipUIController.js'
 import { OverlayUIController } from '../UI/controllers/OverlayUIController.js'
@@ -23,10 +22,6 @@ class AppleDeviceInterface extends InterfacePrototype {
     initialSetupDelayMs = 300
 
     thirdPartyProvider = new ThirdPartyProvider(this)
-
-    async isEnabled () {
-        return autofillEnabled(this.globalConfig, processConfig)
-    }
 
     /**
      * The default functionality of this class is to operate as an 'overlay controller' -

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -5,7 +5,6 @@ import {
     sendAndWaitForAnswer,
     setValue,
     formatDuckAddress,
-    isAutofillEnabledFromProcessedConfig,
     notifyWebApp
 } from '../autofill-utils.js'
 import {HTMLTooltipUIController} from '../UI/controllers/HTMLTooltipUIController.js'
@@ -66,22 +65,6 @@ class ExtensionInterface extends InterfacePrototype {
 
         this.uiController = this.createUIController()
         await this.postInit()
-    }
-
-    async isEnabled () {
-        return new Promise(resolve => {
-            chrome?.runtime?.sendMessage(
-                {
-                    registeredTempAutofillContentScript: true,
-                    documentUrl: window.location.href
-                },
-                (response) => {
-                    if (response && 'site' in response) {
-                        resolve(isAutofillEnabledFromProcessedConfig(response))
-                    }
-                }
-            )
-        })
     }
 
     isDeviceSignedIn () {

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -261,7 +261,7 @@ class InterfacePrototype {
 
         this.alreadyInitialized = true
 
-        await this.refreshSettings()
+        await this.settings.refresh()
 
         this.addDeviceListeners()
 
@@ -271,7 +271,7 @@ class InterfacePrototype {
 
         // this is the temporary measure to support windows whilst we still have 'setupAutofill'
         // eventually all interfaces will use this
-        if (!this.isEnabledViaSettings()) {
+        if (!this.settings.enabled) {
             return
         }
 
@@ -283,40 +283,12 @@ class InterfacePrototype {
         }
     }
 
-    /**
-     * This is to aid the migration to all platforms using Settings.enabled.
-     *
-     * For now, Windows is the only platform that can be 'enabled' or 'disabled' via
-     * the new Settings - which is why in that interface it has `return this.settings.enabled`
-     *
-     * Whilst we wait for other platforms to catch up, we offer this default implementation
-     * of just returning true.
-     *
-     * @returns {boolean}
-     */
-    isEnabledViaSettings () {
-        return true
-    }
-
-    /**
-     * This is a fall-back situation for macOS since it was the only
-     * platform to support anything none-email based in the past.
-     *
-     * Once macOS fully supports 'getAvailableInputTypes' this can be removed
-     *
-     * @returns {Promise<void>}
-     */
-    async refreshSettings () {
-        await this.settings.refresh()
-    }
-
-    async isEnabled () {
-        return autofillEnabled(this.globalConfig)
-    }
-
     async init () {
-        const isEnabled = await this.isEnabled()
-        if (!isEnabled) return
+        // bail very early if we can
+        const isEnabledInitiallyViaConfig = autofillEnabled(this.globalConfig)
+        if (!isEnabledInitiallyViaConfig) {
+            return
+        }
 
         const handler = async () => {
             if (document.readyState === 'complete') {
@@ -684,7 +656,7 @@ class InterfacePrototype {
                 this.storeUserData(data)
 
                 await this.setupAutofill()
-                await this.refreshSettings()
+                await this.settings.refresh()
                 await this.setupSettingsPage({shouldLog: true})
                 await this.postInit()
             } else {

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -3,7 +3,6 @@ import {
     SIGN_IN_MSG,
     sendAndWaitForAnswer,
     formatDuckAddress,
-    autofillEnabled,
     notifyWebApp, getDaxBoundingBox
 } from '../autofill-utils.js'
 
@@ -285,10 +284,8 @@ class InterfacePrototype {
 
     async init () {
         // bail very early if we can
-        const isEnabledInitiallyViaConfig = autofillEnabled(this.globalConfig)
-        if (!isEnabledInitiallyViaConfig) {
-            return
-        }
+        const settings = await this.settings.refresh()
+        if (!settings.enabled) return;
 
         const handler = async () => {
             if (document.readyState === 'complete') {

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -285,7 +285,7 @@ class InterfacePrototype {
     async init () {
         // bail very early if we can
         const settings = await this.settings.refresh()
-        if (!settings.enabled) return;
+        if (!settings.enabled) return
 
         const handler = async () => {
             if (document.readyState === 'complete') {

--- a/src/DeviceInterface/WindowsInterface.js
+++ b/src/DeviceInterface/WindowsInterface.js
@@ -22,23 +22,12 @@ export class WindowsInterface extends InterfacePrototype {
     ready = false
     /** @type {AbortController|null} */
     _abortController = null
-    /**
-     * @deprecated This runs too early, and will be removed eventually.
-     * @returns {Promise<boolean>}
-     */
-    async isEnabled () {
-        return true
-    }
 
     async setupAutofill () {
         const loggedIn = await this._getIsLoggedIn()
         if (loggedIn) {
             await this.getAddresses()
         }
-    }
-
-    isEnabledViaSettings () {
-        return Boolean(this.settings.enabled)
     }
 
     postInit () {

--- a/src/DeviceInterface/tests/InterfacePrototype.test.js
+++ b/src/DeviceInterface/tests/InterfacePrototype.test.js
@@ -16,7 +16,11 @@ describe('InterfacePrototype', function () {
         const mockedDoc = jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
 
         const device = InterfacePrototype.default()
-        jest.spyOn(device, 'refreshSettings').mockImplementation(() => Promise.resolve())
+        jest.spyOn(device.settings, 'refresh').mockImplementation(() => Promise.resolve({
+            enabled: true,
+            featureToggles: {},
+            availableInputTypes: {}
+        }))
         await device.init()
 
         const uiController = /** @type {import("../../UI/controllers/UIController.js").UIController } */ (device.uiController)

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -2,7 +2,6 @@ import {validate} from '../packages/device-api/index.js'
 import {GetAvailableInputTypesCall, GetRuntimeConfigurationCall} from './deviceApiCalls/__generated__/deviceApiCalls.js'
 import {autofillSettingsSchema} from './deviceApiCalls/__generated__/validators.zod.js'
 import {autofillEnabled} from './autofill-utils.js'
-import {processConfig} from '@duckduckgo/content-scope-scripts/src/apple-utils'
 
 /**
  * Some Type helpers to prevent duplication
@@ -80,7 +79,7 @@ export class Settings {
     async getEnabled () {
         try {
             const runtimeConfig = await this._getRuntimeConfiguration()
-            const enabled = autofillEnabled(runtimeConfig, processConfig)
+            const enabled = autofillEnabled(runtimeConfig)
             return enabled
         } catch (e) {
             // these are the fallbacks for when a platform hasn't implemented the calls above. (like on android)

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -1,5 +1,6 @@
 import {getInputSubtype, removeExcessWhitespace} from './Form/matching.js'
 import {constants} from './constants.js'
+import {processConfig} from '@duckduckgo/content-scope-scripts/src/apple-utils'
 
 const SIGN_IN_MSG = { signMeIn: true }
 
@@ -34,13 +35,17 @@ const sendAndWaitForAnswer = (msgOrFn, expectedResponse) => {
 
 /**
  * @param {Pick<GlobalConfig, 'contentScope' | 'userUnprotectedDomains' | 'userPreferences'>} globalConfig
- * @param [processConfig]
  * @return {boolean}
  */
-const autofillEnabled = (globalConfig, processConfig) => {
+const autofillEnabled = (globalConfig) => {
     if (!globalConfig.contentScope) {
         // Return enabled for platforms that haven't implemented the config yet
         return true
+    }
+    // already processed? this handles an edgecase in the extension where the config is already processed
+    if ('site' in globalConfig.contentScope) {
+        const enabled = isAutofillEnabledFromProcessedConfig(globalConfig.contentScope)
+        return enabled
     }
 
     const { contentScope, userUnprotectedDomains, userPreferences } = globalConfig

--- a/src/deviceApiCalls/transports/extension.transport.js
+++ b/src/deviceApiCalls/transports/extension.transport.js
@@ -82,7 +82,7 @@ async function extensionSpecificRuntimeConfiguration (deviceApi) {
                 }
             },
             // @ts-ignore
-            userUnprotectedDomains: deviceApi.config?.userUnprotectedDomains
+            userUnprotectedDomains: deviceApi.config?.userUnprotectedDomains || []
         }
     }
 }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8597,10 +8597,8 @@ class InterfacePrototype {
   }
   async init() {
     // bail very early if we can
-    const isEnabledInitiallyViaConfig = (0, _autofillUtils.autofillEnabled)(this.globalConfig);
-    if (!isEnabledInitiallyViaConfig) {
-      return;
-    }
+    const settings = await this.settings.refresh();
+    if (!settings.enabled) return;
     const handler = async () => {
       if (document.readyState === 'complete') {
         window.removeEventListener('load', handler);

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4431,10 +4431,8 @@ class InterfacePrototype {
   }
   async init() {
     // bail very early if we can
-    const isEnabledInitiallyViaConfig = (0, _autofillUtils.autofillEnabled)(this.globalConfig);
-    if (!isEnabledInitiallyViaConfig) {
-      return;
-    }
+    const settings = await this.settings.refresh();
+    if (!settings.enabled) return;
     const handler = async () => {
       if (document.readyState === 'complete') {
         window.removeEventListener('load', handler);

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -3341,15 +3341,11 @@ exports.AndroidInterface = void 0;
 var _InterfacePrototype = _interopRequireDefault(require("./InterfacePrototype.js"));
 var _autofillUtils = require("../autofill-utils.js");
 var _NativeUIController = require("../UI/controllers/NativeUIController.js");
-var _appleUtils = require("@duckduckgo/content-scope-scripts/src/apple-utils");
 var _InContextSignup = require("../InContextSignup.js");
 var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 class AndroidInterface extends _InterfacePrototype.default {
   inContextSignup = new _InContextSignup.InContextSignup(this);
-  async isEnabled() {
-    return (0, _autofillUtils.autofillEnabled)(this.globalConfig, _appleUtils.processConfig);
-  }
 
   /**
    * @returns {Promise<string|undefined>}
@@ -3483,7 +3479,7 @@ class AndroidInterface extends _InterfacePrototype.default {
 }
 exports.AndroidInterface = AndroidInterface;
 
-},{"../InContextSignup.js":34,"../UI/controllers/NativeUIController.js":47,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"./InterfacePrototype.js":17,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],14:[function(require,module,exports){
+},{"../InContextSignup.js":34,"../UI/controllers/NativeUIController.js":47,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"./InterfacePrototype.js":17}],14:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -3492,7 +3488,6 @@ Object.defineProperty(exports, "__esModule", {
 exports.AppleDeviceInterface = void 0;
 var _InterfacePrototype = _interopRequireDefault(require("./InterfacePrototype.js"));
 var _autofillUtils = require("../autofill-utils.js");
-var _appleUtils = require("@duckduckgo/content-scope-scripts/src/apple-utils");
 var _HTMLTooltip = require("../UI/HTMLTooltip.js");
 var _HTMLTooltipUIController = require("../UI/controllers/HTMLTooltipUIController.js");
 var _OverlayUIController = require("../UI/controllers/OverlayUIController.js");
@@ -3514,9 +3509,6 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   /** @override */
   initialSetupDelayMs = 300;
   thirdPartyProvider = new _ThirdPartyProvider.ThirdPartyProvider(this);
-  async isEnabled() {
-    return (0, _autofillUtils.autofillEnabled)(this.globalConfig, _appleUtils.processConfig);
-  }
 
   /**
    * The default functionality of this class is to operate as an 'overlay controller' -
@@ -3828,7 +3820,7 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
 }
 exports.AppleDeviceInterface = AppleDeviceInterface;
 
-},{"../../packages/device-api/index.js":2,"../Form/matching.js":33,"../InContextSignup.js":34,"../ThirdPartyProvider.js":41,"../UI/HTMLTooltip.js":45,"../UI/controllers/HTMLTooltipUIController.js":46,"../UI/controllers/NativeUIController.js":47,"../UI/controllers/OverlayUIController.js":48,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"../deviceApiCalls/additionalDeviceApiCalls.js":58,"./InterfacePrototype.js":17,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],15:[function(require,module,exports){
+},{"../../packages/device-api/index.js":2,"../Form/matching.js":33,"../InContextSignup.js":34,"../ThirdPartyProvider.js":41,"../UI/HTMLTooltip.js":45,"../UI/controllers/HTMLTooltipUIController.js":46,"../UI/controllers/NativeUIController.js":47,"../UI/controllers/OverlayUIController.js":48,"../autofill-utils.js":52,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"../deviceApiCalls/additionalDeviceApiCalls.js":58,"./InterfacePrototype.js":17}],15:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -4004,18 +3996,6 @@ class ExtensionInterface extends _InterfacePrototype.default {
     if (callback) await callback();
     this.uiController = this.createUIController();
     await this.postInit();
-  }
-  async isEnabled() {
-    return new Promise(resolve => {
-      chrome?.runtime?.sendMessage({
-        registeredTempAutofillContentScript: true,
-        documentUrl: window.location.href
-      }, response => {
-        if (response && 'site' in response) {
-          resolve((0, _autofillUtils.isAutofillEnabledFromProcessedConfig)(response));
-        }
-      });
-    });
   }
   isDeviceSignedIn() {
     return this.hasLocalAddresses;
@@ -4433,14 +4413,14 @@ class InterfacePrototype {
   async startInit() {
     if (this.isInitializationStarted) return;
     this.alreadyInitialized = true;
-    await this.refreshSettings();
+    await this.settings.refresh();
     this.addDeviceListeners();
     await this.setupAutofill();
     this.uiController = this.createUIController();
 
     // this is the temporary measure to support windows whilst we still have 'setupAutofill'
     // eventually all interfaces will use this
-    if (!this.isEnabledViaSettings()) {
+    if (!this.settings.enabled) {
       return;
     }
     await this.setupSettingsPage();
@@ -4449,39 +4429,12 @@ class InterfacePrototype {
       (0, _initFormSubmissionsApi.initFormSubmissionsApi)(this.scanner.forms, this.scanner.matching);
     }
   }
-
-  /**
-   * This is to aid the migration to all platforms using Settings.enabled.
-   *
-   * For now, Windows is the only platform that can be 'enabled' or 'disabled' via
-   * the new Settings - which is why in that interface it has `return this.settings.enabled`
-   *
-   * Whilst we wait for other platforms to catch up, we offer this default implementation
-   * of just returning true.
-   *
-   * @returns {boolean}
-   */
-  isEnabledViaSettings() {
-    return true;
-  }
-
-  /**
-   * This is a fall-back situation for macOS since it was the only
-   * platform to support anything none-email based in the past.
-   *
-   * Once macOS fully supports 'getAvailableInputTypes' this can be removed
-   *
-   * @returns {Promise<void>}
-   */
-  async refreshSettings() {
-    await this.settings.refresh();
-  }
-  async isEnabled() {
-    return (0, _autofillUtils.autofillEnabled)(this.globalConfig);
-  }
   async init() {
-    const isEnabled = await this.isEnabled();
-    if (!isEnabled) return;
+    // bail very early if we can
+    const isEnabledInitiallyViaConfig = (0, _autofillUtils.autofillEnabled)(this.globalConfig);
+    if (!isEnabledInitiallyViaConfig) {
+      return;
+    }
     const handler = async () => {
       if (document.readyState === 'complete') {
         window.removeEventListener('load', handler);
@@ -4856,7 +4809,7 @@ class InterfacePrototype {
         // This call doesn't send a response, so we can't know if it succeeded
         this.storeUserData(data);
         await this.setupAutofill();
-        await this.refreshSettings();
+        await this.settings.refresh();
         await this.setupSettingsPage({
           shouldLog: true
         });
@@ -5042,21 +4995,11 @@ class WindowsInterface extends _InterfacePrototype.default {
   ready = false;
   /** @type {AbortController|null} */
   _abortController = null;
-  /**
-   * @deprecated This runs too early, and will be removed eventually.
-   * @returns {Promise<boolean>}
-   */
-  async isEnabled() {
-    return true;
-  }
   async setupAutofill() {
     const loggedIn = await this._getIsLoggedIn();
     if (loggedIn) {
       await this.getAddresses();
     }
-  }
-  isEnabledViaSettings() {
-    return Boolean(this.settings.enabled);
   }
   postInit() {
     super.postInit();
@@ -10376,7 +10319,6 @@ var _index = require("../packages/device-api/index.js");
 var _deviceApiCalls = require("./deviceApiCalls/__generated__/deviceApiCalls.js");
 var _validatorsZod = require("./deviceApiCalls/__generated__/validators.zod.js");
 var _autofillUtils = require("./autofill-utils.js");
-var _appleUtils = require("@duckduckgo/content-scope-scripts/src/apple-utils");
 /**
  * Some Type helpers to prevent duplication
  * @typedef {import("./deviceApiCalls/__generated__/validators-ts").AutofillFeatureToggles} AutofillFeatureToggles
@@ -10453,7 +10395,7 @@ class Settings {
   async getEnabled() {
     try {
       const runtimeConfig = await this._getRuntimeConfiguration();
-      const enabled = (0, _autofillUtils.autofillEnabled)(runtimeConfig, _appleUtils.processConfig);
+      const enabled = (0, _autofillUtils.autofillEnabled)(runtimeConfig);
       return enabled;
     } catch (e) {
       // these are the fallbacks for when a platform hasn't implemented the calls above. (like on android)
@@ -10714,7 +10656,7 @@ class Settings {
 }
 exports.Settings = Settings;
 
-},{"../packages/device-api/index.js":2,"./autofill-utils.js":52,"./deviceApiCalls/__generated__/deviceApiCalls.js":56,"./deviceApiCalls/__generated__/validators.zod.js":57,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],41:[function(require,module,exports){
+},{"../packages/device-api/index.js":2,"./autofill-utils.js":52,"./deviceApiCalls/__generated__/deviceApiCalls.js":56,"./deviceApiCalls/__generated__/validators.zod.js":57}],41:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12349,6 +12291,7 @@ exports.wasAutofilledByChrome = void 0;
 exports.whenIdle = whenIdle;
 var _matching = require("./Form/matching.js");
 var _constants = require("./constants.js");
+var _appleUtils = require("@duckduckgo/content-scope-scripts/src/apple-utils");
 const SIGN_IN_MSG = exports.SIGN_IN_MSG = {
   signMeIn: true
 };
@@ -12383,14 +12326,18 @@ const sendAndWaitForAnswer = (msgOrFn, expectedResponse) => {
 
 /**
  * @param {Pick<GlobalConfig, 'contentScope' | 'userUnprotectedDomains' | 'userPreferences'>} globalConfig
- * @param [processConfig]
  * @return {boolean}
  */
 exports.sendAndWaitForAnswer = sendAndWaitForAnswer;
-const autofillEnabled = (globalConfig, processConfig) => {
+const autofillEnabled = globalConfig => {
   if (!globalConfig.contentScope) {
     // Return enabled for platforms that haven't implemented the config yet
     return true;
+  }
+  // already processed? this handles an edgecase in the extension where the config is already processed
+  if ('site' in globalConfig.contentScope) {
+    const enabled = isAutofillEnabledFromProcessedConfig(globalConfig.contentScope);
+    return enabled;
   }
   const {
     contentScope,
@@ -12399,7 +12346,7 @@ const autofillEnabled = (globalConfig, processConfig) => {
   } = globalConfig;
 
   // Check config on Apple platforms
-  const processedConfig = processConfig(contentScope, userUnprotectedDomains, userPreferences);
+  const processedConfig = (0, _appleUtils.processConfig)(contentScope, userUnprotectedDomains, userPreferences);
   return isAutofillEnabledFromProcessedConfig(processedConfig);
 };
 exports.autofillEnabled = autofillEnabled;
@@ -12934,7 +12881,7 @@ function getActiveElement() {
   return innerActiveElement;
 }
 
-},{"./Form/matching.js":33,"./constants.js":55}],53:[function(require,module,exports){
+},{"./Form/matching.js":33,"./constants.js":55,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],53:[function(require,module,exports){
 "use strict";
 
 require("./requestIdleCallback.js");
@@ -13647,7 +13594,7 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
         }
       },
       // @ts-ignore
-      userUnprotectedDomains: deviceApi.config?.userUnprotectedDomains
+      userUnprotectedDomains: deviceApi.config?.userUnprotectedDomains || []
     }
   };
 }


### PR DESCRIPTION
**Reviewer:** 
**Asana:** 

## Description

All platforms provide `RuntimeConfiguration` now - either async or via global config variable replacements, so we should remove all device-specific implementations and defer only to `device.settings.enabled`. This gives a single place check/debug.

Now the mental model matches on every platform:

- 1) each platform provides RuntimeConfiguration via their transport (can be async or sync)
- 2) `Settings.enabled` is then derived from it
- 3) then `device.settings.enabled` is the single go-to source of truth

The only original call I left in place, is within the very first first stage of initialization, as that acts as a nice early return when possible

## Steps to test

- tested in the extension + macos + windows
  - I verified that remote config still takes effect
  - I verified that email signup still works correctly
  - I verified that all autofill functionality still works as expected
