### PR TITLE
sketch: add device.t()

### DIFF
--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -23,6 +23,7 @@ import {
 } from '../deviceApiCalls/__generated__/deviceApiCalls.js'
 import {initFormSubmissionsApi} from './initFormSubmissionsApi.js'
 import {EmailProtection} from '../EmailProtection.js'
+import { getTranslator } from '../locales/strings.js'
 
 /**
  * @typedef {import('../deviceApiCalls/__generated__/validators-ts').StoreFormData} StoreFormData
@@ -69,6 +70,9 @@ class InterfacePrototype {
 
     /** @type {import("../../packages/device-api").DeviceApi} */
     deviceApi
+
+    /** @type {ReturnType<import("../locales/strings").getTranslator>} */
+    t = () => {}
 
     /** @type {boolean} */
     isInitializationStarted
@@ -166,7 +170,7 @@ class InterfacePrototype {
             newIdentities.push({
                 id: 'personalAddress',
                 emailAddress: personalAddress,
-                title: 'Block email trackers'
+                title: this.t('blockEmailTrackers')
             })
         }
 
@@ -262,6 +266,8 @@ class InterfacePrototype {
 
         await this.settings.refresh()
 
+        console.warn("[InterfacePrototype::startInit] DBG: this.settings.locale", this.settings.locale)
+        this.t = getTranslator(this.settings.locale)
         this.addDeviceListeners()
 
         await this.setupAutofill()

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -34,6 +34,8 @@ export class Settings {
     _runtimeConfiguration = null
     /** @type {boolean | null} */
     _enabled = null
+    /** @type {string | null} */
+    _locale = null
 
     /**
      * @param {GlobalConfig} config
@@ -87,6 +89,23 @@ export class Settings {
                 console.log('isDDGTestMode: getEnabled: ❌', e)
             }
             return null
+        }
+    }
+
+    async getLocale() {
+        console.log('[Settings::getLocale]')
+        try {
+            const conf = await this._getRuntimeConfiguration()
+            const out = conf.userPreferences.locale
+            if (out == null) {
+                console.error('[Settings::getLocale] no locale in runtime config.userPreferences :(', conf)
+            }
+            return out
+        } catch (e) {
+            if (this.globalConfig.isDDGTestMode) {
+                console.log('isDDGTestMode: getLocale: ❌', e)
+            }
+            return 'en'
         }
     }
 
@@ -145,6 +164,7 @@ export class Settings {
         this.setEnabled(await this.getEnabled())
         this.setFeatureToggles(await this.getFeatureToggles())
         this.setAvailableInputTypes(await this.getAvailableInputTypes())
+        this.setLocale(await this.getLocale())
 
         // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
         if (typeof this.enabled === 'boolean') {
@@ -262,6 +282,15 @@ export class Settings {
     /** @param {AvailableInputTypes} value */
     setAvailableInputTypes (value) {
         this._availableInputTypes = {...this._availableInputTypes, ...value}
+    }
+
+    get locale () {
+        if (this._locale === null) throw new Error('locale accessed before being set')
+        return this._locale
+    }
+
+    setLocale (locale) {
+        this._locale = locale
     }
 
     static defaults = {

--- a/src/UI/EmailHTMLTooltip.js
+++ b/src/UI/EmailHTMLTooltip.js
@@ -15,7 +15,7 @@ ${this.options.css}
     <div class="tooltip tooltip--email">
         <button class="tooltip__button tooltip__button--email js-use-personal">
             <span class="tooltip__button--email__primary-text">
-                Use <span class="js-address">${formatDuckAddress(escapeXML(this.addresses.personalAddress))}</span>
+                ${this.device.t("usePersonalDuckAddr", { email: formatDuckAddress(escapeXML(this.addresses.personalAddress))})}
             </span>
             <span class="tooltip__button--email__secondary-text">Block email trackers</span>
         </button>
@@ -30,12 +30,12 @@ ${this.options.css}
         this.tooltip = this.shadow.querySelector('.tooltip')
         this.usePersonalButton = this.shadow.querySelector('.js-use-personal')
         this.usePrivateButton = this.shadow.querySelector('.js-use-private')
-        this.addressEl = this.shadow.querySelector('.js-address')
+        this.usePersonalCta = this.shadow.querySelector('.js-use-personal > span:first-of-type')
 
         this.updateAddresses = (addresses) => {
-            if (addresses && this.addressEl) {
+            if (addresses && this.usePersonalCta) {
                 this.addresses = addresses
-                this.addressEl.textContent = formatDuckAddress(addresses.personalAddress)
+                this.usePersonalCta.textContent = this.device.t("usePersonalDuckAddr", { email: formatDuckAddress(addresses.personalAddress)})
             }
         }
 

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -349,6 +349,7 @@ export interface UserPreferences {
   globalPrivacyControlValue?: boolean;
   sessionKey?: string;
   debug: boolean;
+  locale?: string;
   platform: {
     name: "ios" | "macos" | "windows" | "extension" | "android" | "unknown";
   };

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -117,6 +117,7 @@ export const userPreferencesSchema = z.object({
     globalPrivacyControlValue: z.boolean().optional(),
     sessionKey: z.string().optional(),
     debug: z.boolean(),
+    locale: z.string().optional(),
     platform: z.object({
         name: z.union([z.literal("ios"), z.literal("macos"), z.literal("windows"), z.literal("extension"), z.literal("android"), z.literal("unknown")])
     }),

--- a/src/deviceApiCalls/schemas/runtime-configuration.json
+++ b/src/deviceApiCalls/schemas/runtime-configuration.json
@@ -64,6 +64,9 @@
         "debug": {
           "type": "boolean"
         },
+        "locale": {
+          "type": "string"
+        },
         "platform": {
           "type": "object",
           "additionalProperties": false,

--- a/src/deviceApiCalls/transports/extension.transport.js
+++ b/src/deviceApiCalls/transports/extension.transport.js
@@ -69,6 +69,8 @@ async function extensionSpecificRuntimeConfiguration (deviceApi) {
             contentScope: contentScope,
             // @ts-ignore
             userPreferences: {
+                // Copy to user preferences to match schema from CSS
+                locale: contentScope.locale,
                 features: {
                     autofill: {
                         settings: {

--- a/src/locales/strings.js
+++ b/src/locales/strings.js
@@ -1,0 +1,61 @@
+ // TODO(sjbarag): read from JS module generated from JSON files, probably.
+const translations = {
+  en: {
+    "hello": {
+      title: "hello, {name}",
+      note: "Says hi to a person.",
+    },
+    "usePersonalDuckAddr": {
+      title: "Use {email}",
+      note: "Shown when a user can choose their personal @duck.com address.",
+    },
+    "blockEmailTrackers": {
+      title: "Block email trackers",
+      note: "Shown when a user can choose their personal @duck.com address on native platforms.",
+    }
+  },
+  xa: {
+    "hello": {
+      title: "h33llllo, {name}",
+      note: "Says hi to a person.",
+    },
+    "usePersonalDuckAddr": {
+      title: "Ü55££ {email}",
+      note: "Shown when a user can choose their personal @duck.com address.",
+    },
+    "blockEmailTrackers": {
+      title: "Bl000ck €m@@@i1il1l träáåck33rr55",
+      note: "Shown when a user can choose their personal @duck.com address on native platforms.",
+    }
+  },
+};
+
+export function getTranslator(locale) {
+  let library = translations[locale];
+  if (library == null) {
+    console.warn(`Received unsupported locale '${locale}'. Falling back to 'en'.`);
+    library = translations.en;
+  }
+
+  return function t(id, opts) {
+    return translateImpl(library, id, opts);
+  }
+};
+
+function translateImpl(library, id, opts) {
+  const msg = library[id];
+  // Fall back to the message ID if an unsupported message is provided.
+  if (!msg) { return id; }
+
+  // Fast path: return the translated string directly if no replacements are provided.
+  if (opts == null) {
+    return msg.title;
+  }
+
+  // Repeatedly replace all instances of '{ SOME_REPLACEMENT_NAME }' with the corresponding value.
+  let out = msg.title;
+  for (const [ name, value ] of Object.entries(opts)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+}


### PR DESCRIPTION
**Reviewer:** @shakyShane
**Asana:** https://app.asana.com/0/0/1206915527872885/f

## Description
Just a directional vertical slice to ensure I'm on the right track. I'll leave some comments below.

I don't love hanging translation off of the device object, but the device object is currently plumbed through the codebase pretty thoroughly and is responsible for providing the current locale. For a PoC, it feels reasonable.

## Steps to test
N/A

## Screenshots
Both with a hardcoded `xa` language for pseudolocalization (for now). That hardcoding occurs in the macos app source and extension source, respectively.

### macOS
![image](https://github.com/duckduckgo/duckduckgo-autofill/assets/665775/351063d7-1026-4889-9102-950221aa937a)

### Extension
![image](https://github.com/duckduckgo/duckduckgo-autofill/assets/665775/288dc4f8-9897-4f46-84f0-90a7d8b54df3)
