### PR TITLE
l10n: add basic localization support to device abstraction

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8618,7 +8618,7 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Block email trackers'
+        title: this.t('blockEmailTrackers')
       });
     }
     newIdentities.push({
@@ -15293,9 +15293,11 @@ ${this.options.css}
     <div class="tooltip tooltip--email">
         <button class="tooltip__button tooltip__button--email js-use-personal">
             <span class="tooltip__button--email__primary-text">
-                Use <span class="js-address">${(0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))}</span>
+                ${this.device.t('usePersonalDuckAddr', {
+      email: (0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))
+    })}
             </span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('blockEmailTrackers')}</span>
         </button>
         <button class="tooltip__button tooltip__button--email js-use-private">
             <span class="tooltip__button--email__primary-text">Generate a Private Duck Address</span>
@@ -15308,11 +15310,13 @@ ${this.options.css}
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');
     this.usePrivateButton = this.shadow.querySelector('.js-use-private');
-    this.addressEl = this.shadow.querySelector('.js-address');
+    this.usePersonalCta = this.shadow.querySelector('.js-use-personal > span:first-of-type');
     this.updateAddresses = addresses => {
-      if (addresses && this.addressEl) {
+      if (addresses && this.usePersonalCta) {
         this.addresses = addresses;
-        this.addressEl.textContent = (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress);
+        this.usePersonalCta.textContent = this.device.t('usePersonalDuckAddr', {
+          email: (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress)
+        });
       }
     };
     const firePixel = this.device.firePixel.bind(this.device);

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -14722,6 +14722,35 @@ class Settings {
   }
 
   /**
+   * Retrieves the user's language from the current platform's `RuntimeConfiguration`. If the
+   * platform doesn't include a two-character `.userPreferences.language` property in its runtime
+   * configuration, or if an error occurs, 'en' is used as a fallback.
+   *
+   * NOTE: This function returns the two-character 'language' code of a typical POSIX locale
+   * (e.g. 'en', 'de', 'fr') listed in ISO 639-1[1].
+   *
+   * [1] https://en.wikipedia.org/wiki/ISO_639-1
+   *
+   * @returns {Promise<string>} the device's current language code, or 'en' if something goes wrong
+   */
+  async getLanguage() {
+    try {
+      const conf = await this._getRuntimeConfiguration();
+      const language = conf.userPreferences.language ?? 'en';
+      if (language.length !== 2) {
+        console.warn(`config.userPreferences.language must be two characters, but received '${language}'`);
+        return 'en';
+      }
+      return language;
+    } catch (e) {
+      if (this.globalConfig.isDDGTestMode) {
+        console.log('isDDGTestMode: getLanguage: ❌', e);
+      }
+      return 'en';
+    }
+  }
+
+  /**
    * Get runtime configuration, but only once.
    *
    * Some platforms may be reading this directly from inlined variables, whilst others
@@ -17736,6 +17765,7 @@ const userPreferencesSchema = exports.userPreferencesSchema = _zod.z.object({
   globalPrivacyControlValue: _zod.z.boolean().optional(),
   sessionKey: _zod.z.string().optional(),
   debug: _zod.z.boolean(),
+  language: _zod.z.string().optional(),
   platform: _zod.z.object({
     name: _zod.z.union([_zod.z.literal("ios"), _zod.z.literal("macos"), _zod.z.literal("windows"), _zod.z.literal("extension"), _zod.z.literal("android"), _zod.z.literal("unknown")])
   }),

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -18275,6 +18275,8 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
       contentScope: contentScope,
       // @ts-ignore
       userPreferences: {
+        // Copy locale to user preferences as 'language' to match expected payload
+        language: contentScope.locale,
         features: {
           autofill: {
             settings: {

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8462,6 +8462,7 @@ var _index = require("../../packages/device-api/index.js");
 var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
 var _initFormSubmissionsApi = require("./initFormSubmissionsApi.js");
 var _EmailProtection = require("../EmailProtection.js");
+var _strings = require("../locales/strings.js");
 /**
  * @typedef {import('../deviceApiCalls/__generated__/validators-ts').StoreFormData} StoreFormData
  */
@@ -8507,6 +8508,13 @@ class InterfacePrototype {
   /** @type {import("../../packages/device-api").DeviceApi} */
   deviceApi;
 
+  /**
+   * Translates a string to the current language, replacing each placeholder
+   * with a key present in `opts` with the corresponding value.
+   * @type {import('../locales/strings').TranslateFn}
+   */
+  t;
+
   /** @type {boolean} */
   isInitializationStarted;
 
@@ -8522,6 +8530,7 @@ class InterfacePrototype {
     this.globalConfig = config;
     this.deviceApi = deviceApi;
     this.settings = settings;
+    this.t = (0, _strings.getTranslator)(settings);
     this.uiController = null;
     this.scanner = (0, _Scanner.createScanner)(this, {
       initialDelay: this.initialSetupDelayMs
@@ -9275,7 +9284,7 @@ class InterfacePrototype {
 }
 var _default = exports.default = InterfacePrototype;
 
-},{"../../packages/device-api/index.js":12,"../EmailProtection.js":33,"../Form/formatters.js":37,"../Form/matching.js":44,"../InputTypes/Credentials.js":46,"../PasswordGenerator.js":49,"../Scanner.js":50,"../Settings.js":51,"../UI/controllers/NativeUIController.js":58,"../autofill-utils.js":63,"../config.js":65,"../deviceApiCalls/__generated__/deviceApiCalls.js":67,"../deviceApiCalls/transports/transports.js":73,"./initFormSubmissionsApi.js":31}],29:[function(require,module,exports){
+},{"../../packages/device-api/index.js":12,"../EmailProtection.js":33,"../Form/formatters.js":37,"../Form/matching.js":44,"../InputTypes/Credentials.js":46,"../PasswordGenerator.js":49,"../Scanner.js":50,"../Settings.js":51,"../UI/controllers/NativeUIController.js":58,"../autofill-utils.js":63,"../config.js":65,"../deviceApiCalls/__generated__/deviceApiCalls.js":67,"../deviceApiCalls/transports/transports.js":73,"../locales/strings.js":75,"./initFormSubmissionsApi.js":31}],29:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14665,6 +14674,8 @@ class Settings {
   _runtimeConfiguration = null;
   /** @type {boolean | null} */
   _enabled = null;
+  /** @type {string} */
+  _language = 'en';
 
   /**
    * @param {GlobalConfig} config
@@ -14801,7 +14812,8 @@ class Settings {
 
   /**
    * To 'refresh' settings means to re-call APIs to determine new state. This may
-   * only occur once per page, but it must be done before any page scanning/decorating can happen
+   * only occur once per page, but it must be done before any page scanning/decorating
+   * or translation can happen.
    *
    * @returns {Promise<{
    *      availableInputTypes: AvailableInputTypes,
@@ -14813,6 +14825,7 @@ class Settings {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
     this.setAvailableInputTypes(await this.getAvailableInputTypes());
+    this.setLanguage(await this.getLanguage());
 
     // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
     if (typeof this.enabled === 'boolean') {
@@ -14958,6 +14971,19 @@ class Settings {
       ...this._availableInputTypes,
       ...value
     };
+  }
+
+  /** @returns {string} the user's current two-character language code, as provided by the platform */
+  get language() {
+    return this._language;
+  }
+
+  /**
+   * Sets the current two-character language code.
+   * @param {string} language - the language
+   */
+  setLanguage(language) {
+    this._language = language;
   }
   static defaults = {
     /** @type {AutofillFeatureToggles} */
@@ -17287,7 +17313,7 @@ var _autofillUtils = require("./autofill-utils.js");
   }
 })();
 
-},{"./DeviceInterface.js":23,"./autofill-utils.js":63,"./requestIdleCallback.js":75}],65:[function(require,module,exports){
+},{"./DeviceInterface.js":23,"./autofill-utils.js":63,"./requestIdleCallback.js":76}],65:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18470,6 +18496,127 @@ function waitForWindowsResponse(responseId, options) {
 }
 
 },{"../../../packages/device-api/index.js":12}],75:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getTranslator = getTranslator;
+// TODO(sjbarag): read from JS module generated from JSON files, probably.
+const translations = {
+  en: {
+    'hello': {
+      title: 'Hello world',
+      note: 'Static text for testing.'
+    },
+    'lipsum': {
+      title: 'Lorem ipsum dolor sit amet, {foo} {bar}',
+      note: 'Placeholder text.'
+    },
+    'usePersonalDuckAddr': {
+      title: 'Use {email}',
+      note: 'Button that fills a form using a specific email address. The placeholder is the email address, e.g. "Use test@duck.com".'
+    },
+    'blockEmailTrackers': {
+      title: 'Block email trackers',
+      note: 'Label explaining that by using a duck.com address, email trackers will be blocked. "Block" is a verb in imperative form.'
+    }
+  },
+  xa: {
+    'hello': {
+      title: 'H33ll00 wºrrld',
+      note: 'Static text for testing.'
+    },
+    'lipsum': {
+      title: 'Lºrr3e3m 1p$$$um d00l1loor s!t @@mett, {foo} {bar}',
+      note: 'Placeholder text.'
+    },
+    'usePersonalDuckAddr': {
+      title: 'Ü55££ {email}',
+      note: 'Shown when a user can choose their personal @duck.com address.'
+    },
+    'blockEmailTrackers': {
+      title: 'Bl000ck €m@@@i1il1l träáåck33rr55',
+      note: 'Shown when a user can choose their personal @duck.com address on native platforms.'
+    }
+  }
+};
+
+/**
+ * @callback TranslateFn
+ * Translates a string with the provided ID to the current language, replacing
+ * each placeholder with a key present in `opts` with the corresponding value.
+ *
+ * @param {string} id - the string ID to look up
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+
+/**
+ * Builds a reusable translation function bound to the language provided by
+ * `settings`. That language isn't read until the first translation is
+ * requested, so it's safe to use this statically and assign `settings.language`
+ * later.
+ *
+ * @param {{ language: string }} settings - a settings object containing the current language
+ * @returns {TranslateFn} a translation function
+ */
+function getTranslator(settings) {
+  let library;
+  return function t(id, opts) {
+    // Retrieve the library when the first string is translated, to allow
+    // InterfacePrototype.t() to be statically initialized.
+    if (!library) {
+      const {
+        language
+      } = settings;
+      library = translations[language];
+      if (!library) {
+        console.warn(`Received unsupported locale '${language}'. Falling back to 'en'.`);
+        library = translations.en;
+      }
+    }
+    return translateImpl(library, id, opts);
+  };
+}
+
+/**
+ * @typedef {object} Translation
+ * @prop {string} title - the translated string
+ * @prop {string} note - a description of `title` used to aid translators
+ */
+
+/**
+ * Looks up the string with the provided `id` in a `library`, performing
+ * key-value replacements on the translated string. If no string with ID `id` is
+ * found, `id` is returned unmodified.
+ * @param {Record<string, Translation>} library - a map of string IDs to translation
+ * @param {string} id - the string ID to translate
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+function translateImpl(library, id, opts) {
+  const msg = library[id];
+  // Fall back to the message ID if an unsupported message is provided.
+  if (!msg) {
+    return id;
+  }
+
+  // Fast path: don't loop over opts if no replacements are provided.
+  if (!opts) {
+    return msg.title;
+  }
+
+  // Repeatedly replace all instances of '{SOME_REPLACEMENT_NAME}' with the
+  // corresponding value.
+  let out = msg.title;
+  for (const [name, value] of Object.entries(opts)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+}
+
+},{}],76:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -13739,6 +13739,8 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
       contentScope: contentScope,
       // @ts-ignore
       userPreferences: {
+        // Copy locale to user preferences as 'language' to match expected payload
+        language: contentScope.locale,
         features: {
           autofill: {
             settings: {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4296,6 +4296,7 @@ var _index = require("../../packages/device-api/index.js");
 var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
 var _initFormSubmissionsApi = require("./initFormSubmissionsApi.js");
 var _EmailProtection = require("../EmailProtection.js");
+var _strings = require("../locales/strings.js");
 /**
  * @typedef {import('../deviceApiCalls/__generated__/validators-ts').StoreFormData} StoreFormData
  */
@@ -4341,6 +4342,13 @@ class InterfacePrototype {
   /** @type {import("../../packages/device-api").DeviceApi} */
   deviceApi;
 
+  /**
+   * Translates a string to the current language, replacing each placeholder
+   * with a key present in `opts` with the corresponding value.
+   * @type {import('../locales/strings').TranslateFn}
+   */
+  t;
+
   /** @type {boolean} */
   isInitializationStarted;
 
@@ -4356,6 +4364,7 @@ class InterfacePrototype {
     this.globalConfig = config;
     this.deviceApi = deviceApi;
     this.settings = settings;
+    this.t = (0, _strings.getTranslator)(settings);
     this.uiController = null;
     this.scanner = (0, _Scanner.createScanner)(this, {
       initialDelay: this.initialSetupDelayMs
@@ -5109,7 +5118,7 @@ class InterfacePrototype {
 }
 var _default = exports.default = InterfacePrototype;
 
-},{"../../packages/device-api/index.js":2,"../EmailProtection.js":23,"../Form/formatters.js":27,"../Form/matching.js":34,"../InputTypes/Credentials.js":36,"../PasswordGenerator.js":39,"../Scanner.js":40,"../Settings.js":41,"../UI/controllers/NativeUIController.js":48,"../autofill-utils.js":53,"../config.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":57,"../deviceApiCalls/transports/transports.js":63,"./initFormSubmissionsApi.js":21}],19:[function(require,module,exports){
+},{"../../packages/device-api/index.js":2,"../EmailProtection.js":23,"../Form/formatters.js":27,"../Form/matching.js":34,"../InputTypes/Credentials.js":36,"../PasswordGenerator.js":39,"../Scanner.js":40,"../Settings.js":41,"../UI/controllers/NativeUIController.js":48,"../autofill-utils.js":53,"../config.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":57,"../deviceApiCalls/transports/transports.js":63,"../locales/strings.js":65,"./initFormSubmissionsApi.js":21}],19:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -10499,6 +10508,8 @@ class Settings {
   _runtimeConfiguration = null;
   /** @type {boolean | null} */
   _enabled = null;
+  /** @type {string} */
+  _language = 'en';
 
   /**
    * @param {GlobalConfig} config
@@ -10635,7 +10646,8 @@ class Settings {
 
   /**
    * To 'refresh' settings means to re-call APIs to determine new state. This may
-   * only occur once per page, but it must be done before any page scanning/decorating can happen
+   * only occur once per page, but it must be done before any page scanning/decorating
+   * or translation can happen.
    *
    * @returns {Promise<{
    *      availableInputTypes: AvailableInputTypes,
@@ -10647,6 +10659,7 @@ class Settings {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
     this.setAvailableInputTypes(await this.getAvailableInputTypes());
+    this.setLanguage(await this.getLanguage());
 
     // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
     if (typeof this.enabled === 'boolean') {
@@ -10792,6 +10805,19 @@ class Settings {
       ...this._availableInputTypes,
       ...value
     };
+  }
+
+  /** @returns {string} the user's current two-character language code, as provided by the platform */
+  get language() {
+    return this._language;
+  }
+
+  /**
+   * Sets the current two-character language code.
+   * @param {string} language - the language
+   */
+  setLanguage(language) {
+    this._language = language;
   }
   static defaults = {
     /** @type {AutofillFeatureToggles} */
@@ -13121,7 +13147,7 @@ var _autofillUtils = require("./autofill-utils.js");
   }
 })();
 
-},{"./DeviceInterface.js":13,"./autofill-utils.js":53,"./requestIdleCallback.js":65}],55:[function(require,module,exports){
+},{"./DeviceInterface.js":13,"./autofill-utils.js":53,"./requestIdleCallback.js":66}],55:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -13934,6 +13960,127 @@ function waitForWindowsResponse(responseId, options) {
 }
 
 },{"../../../packages/device-api/index.js":2}],65:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getTranslator = getTranslator;
+// TODO(sjbarag): read from JS module generated from JSON files, probably.
+const translations = {
+  en: {
+    'hello': {
+      title: 'Hello world',
+      note: 'Static text for testing.'
+    },
+    'lipsum': {
+      title: 'Lorem ipsum dolor sit amet, {foo} {bar}',
+      note: 'Placeholder text.'
+    },
+    'usePersonalDuckAddr': {
+      title: 'Use {email}',
+      note: 'Button that fills a form using a specific email address. The placeholder is the email address, e.g. "Use test@duck.com".'
+    },
+    'blockEmailTrackers': {
+      title: 'Block email trackers',
+      note: 'Label explaining that by using a duck.com address, email trackers will be blocked. "Block" is a verb in imperative form.'
+    }
+  },
+  xa: {
+    'hello': {
+      title: 'H33ll00 wºrrld',
+      note: 'Static text for testing.'
+    },
+    'lipsum': {
+      title: 'Lºrr3e3m 1p$$$um d00l1loor s!t @@mett, {foo} {bar}',
+      note: 'Placeholder text.'
+    },
+    'usePersonalDuckAddr': {
+      title: 'Ü55££ {email}',
+      note: 'Shown when a user can choose their personal @duck.com address.'
+    },
+    'blockEmailTrackers': {
+      title: 'Bl000ck €m@@@i1il1l träáåck33rr55',
+      note: 'Shown when a user can choose their personal @duck.com address on native platforms.'
+    }
+  }
+};
+
+/**
+ * @callback TranslateFn
+ * Translates a string with the provided ID to the current language, replacing
+ * each placeholder with a key present in `opts` with the corresponding value.
+ *
+ * @param {string} id - the string ID to look up
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+
+/**
+ * Builds a reusable translation function bound to the language provided by
+ * `settings`. That language isn't read until the first translation is
+ * requested, so it's safe to use this statically and assign `settings.language`
+ * later.
+ *
+ * @param {{ language: string }} settings - a settings object containing the current language
+ * @returns {TranslateFn} a translation function
+ */
+function getTranslator(settings) {
+  let library;
+  return function t(id, opts) {
+    // Retrieve the library when the first string is translated, to allow
+    // InterfacePrototype.t() to be statically initialized.
+    if (!library) {
+      const {
+        language
+      } = settings;
+      library = translations[language];
+      if (!library) {
+        console.warn(`Received unsupported locale '${language}'. Falling back to 'en'.`);
+        library = translations.en;
+      }
+    }
+    return translateImpl(library, id, opts);
+  };
+}
+
+/**
+ * @typedef {object} Translation
+ * @prop {string} title - the translated string
+ * @prop {string} note - a description of `title` used to aid translators
+ */
+
+/**
+ * Looks up the string with the provided `id` in a `library`, performing
+ * key-value replacements on the translated string. If no string with ID `id` is
+ * found, `id` is returned unmodified.
+ * @param {Record<string, Translation>} library - a map of string IDs to translation
+ * @param {string} id - the string ID to translate
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+function translateImpl(library, id, opts) {
+  const msg = library[id];
+  // Fall back to the message ID if an unsupported message is provided.
+  if (!msg) {
+    return id;
+  }
+
+  // Fast path: don't loop over opts if no replacements are provided.
+  if (!opts) {
+    return msg.title;
+  }
+
+  // Repeatedly replace all instances of '{SOME_REPLACEMENT_NAME}' with the
+  // corresponding value.
+  let out = msg.title;
+  for (const [name, value] of Object.entries(opts)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+}
+
+},{}],66:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -10556,6 +10556,35 @@ class Settings {
   }
 
   /**
+   * Retrieves the user's language from the current platform's `RuntimeConfiguration`. If the
+   * platform doesn't include a two-character `.userPreferences.language` property in its runtime
+   * configuration, or if an error occurs, 'en' is used as a fallback.
+   *
+   * NOTE: This function returns the two-character 'language' code of a typical POSIX locale
+   * (e.g. 'en', 'de', 'fr') listed in ISO 639-1[1].
+   *
+   * [1] https://en.wikipedia.org/wiki/ISO_639-1
+   *
+   * @returns {Promise<string>} the device's current language code, or 'en' if something goes wrong
+   */
+  async getLanguage() {
+    try {
+      const conf = await this._getRuntimeConfiguration();
+      const language = conf.userPreferences.language ?? 'en';
+      if (language.length !== 2) {
+        console.warn(`config.userPreferences.language must be two characters, but received '${language}'`);
+        return 'en';
+      }
+      return language;
+    } catch (e) {
+      if (this.globalConfig.isDDGTestMode) {
+        console.log('isDDGTestMode: getLanguage: ❌', e);
+      }
+      return 'en';
+    }
+  }
+
+  /**
    * Get runtime configuration, but only once.
    *
    * Some platforms may be reading this directly from inlined variables, whilst others

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4452,7 +4452,7 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Block email trackers'
+        title: this.t('blockEmailTrackers')
       });
     }
     newIdentities.push({
@@ -11127,9 +11127,11 @@ ${this.options.css}
     <div class="tooltip tooltip--email">
         <button class="tooltip__button tooltip__button--email js-use-personal">
             <span class="tooltip__button--email__primary-text">
-                Use <span class="js-address">${(0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))}</span>
+                ${this.device.t('usePersonalDuckAddr', {
+      email: (0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))
+    })}
             </span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('blockEmailTrackers')}</span>
         </button>
         <button class="tooltip__button tooltip__button--email js-use-private">
             <span class="tooltip__button--email__primary-text">Generate a Private Duck Address</span>
@@ -11142,11 +11144,13 @@ ${this.options.css}
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');
     this.usePrivateButton = this.shadow.querySelector('.js-use-private');
-    this.addressEl = this.shadow.querySelector('.js-address');
+    this.usePersonalCta = this.shadow.querySelector('.js-use-personal > span:first-of-type');
     this.updateAddresses = addresses => {
-      if (addresses && this.addressEl) {
+      if (addresses && this.usePersonalCta) {
         this.addresses = addresses;
-        this.addressEl.textContent = (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress);
+        this.usePersonalCta.textContent = this.device.t('usePersonalDuckAddr', {
+          email: (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress)
+        });
       }
     };
     const firePixel = this.device.firePixel.bind(this.device);

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -175,7 +175,7 @@ class InterfacePrototype {
             newIdentities.push({
                 id: 'personalAddress',
                 emailAddress: personalAddress,
-                title: 'Block email trackers'
+                title: this.t('blockEmailTrackers')
             })
         }
 

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -23,6 +23,7 @@ import {
 } from '../deviceApiCalls/__generated__/deviceApiCalls.js'
 import {initFormSubmissionsApi} from './initFormSubmissionsApi.js'
 import {EmailProtection} from '../EmailProtection.js'
+import { getTranslator } from '../locales/strings.js'
 
 /**
  * @typedef {import('../deviceApiCalls/__generated__/validators-ts').StoreFormData} StoreFormData
@@ -70,6 +71,13 @@ class InterfacePrototype {
     /** @type {import("../../packages/device-api").DeviceApi} */
     deviceApi
 
+    /**
+     * Translates a string to the current language, replacing each placeholder
+     * with a key present in `opts` with the corresponding value.
+     * @type {import('../locales/strings').TranslateFn}
+     */
+    t
+
     /** @type {boolean} */
     isInitializationStarted
 
@@ -85,6 +93,7 @@ class InterfacePrototype {
         this.globalConfig = config
         this.deviceApi = deviceApi
         this.settings = settings
+        this.t = getTranslator(settings)
         this.uiController = null
         this.scanner = createScanner(this, {
             initialDelay: this.initialSetupDelayMs

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -91,6 +91,35 @@ export class Settings {
     }
 
     /**
+     * Retrieves the user's language from the current platform's `RuntimeConfiguration`. If the
+     * platform doesn't include a two-character `.userPreferences.language` property in its runtime
+     * configuration, or if an error occurs, 'en' is used as a fallback.
+     *
+     * NOTE: This function returns the two-character 'language' code of a typical POSIX locale
+     * (e.g. 'en', 'de', 'fr') listed in ISO 639-1[1].
+     *
+     * [1] https://en.wikipedia.org/wiki/ISO_639-1
+     *
+     * @returns {Promise<string>} the device's current language code, or 'en' if something goes wrong
+     */
+    async getLanguage () {
+        try {
+            const conf = await this._getRuntimeConfiguration()
+            const language = conf.userPreferences.language ?? 'en'
+            if (language.length !== 2) {
+                console.warn(`config.userPreferences.language must be two characters, but received '${language}'`)
+                return 'en'
+            }
+            return language
+        } catch (e) {
+            if (this.globalConfig.isDDGTestMode) {
+                console.log('isDDGTestMode: getLanguage: ❌', e)
+            }
+            return 'en'
+        }
+    }
+
+    /**
      * Get runtime configuration, but only once.
      *
      * Some platforms may be reading this directly from inlined variables, whilst others

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -34,6 +34,8 @@ export class Settings {
     _runtimeConfiguration = null
     /** @type {boolean | null} */
     _enabled = null
+    /** @type {string} */
+    _language = 'en'
 
     /**
      * @param {GlobalConfig} config
@@ -173,7 +175,8 @@ export class Settings {
 
     /**
      * To 'refresh' settings means to re-call APIs to determine new state. This may
-     * only occur once per page, but it must be done before any page scanning/decorating can happen
+     * only occur once per page, but it must be done before any page scanning/decorating
+     * or translation can happen.
      *
      * @returns {Promise<{
      *      availableInputTypes: AvailableInputTypes,
@@ -185,6 +188,7 @@ export class Settings {
         this.setEnabled(await this.getEnabled())
         this.setFeatureToggles(await this.getFeatureToggles())
         this.setAvailableInputTypes(await this.getAvailableInputTypes())
+        this.setLanguage(await this.getLanguage())
 
         // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
         if (typeof this.enabled === 'boolean') {
@@ -310,6 +314,19 @@ export class Settings {
     /** @param {AvailableInputTypes} value */
     setAvailableInputTypes (value) {
         this._availableInputTypes = {...this._availableInputTypes, ...value}
+    }
+
+    /** @returns {string} the user's current two-character language code, as provided by the platform */
+    get language () {
+        return this._language
+    }
+
+    /**
+     * Sets the current two-character language code.
+     * @param {string} language - the language
+     */
+    setLanguage (language) {
+        this._language = language
     }
 
     static defaults = {

--- a/src/UI/EmailHTMLTooltip.js
+++ b/src/UI/EmailHTMLTooltip.js
@@ -15,9 +15,9 @@ ${this.options.css}
     <div class="tooltip tooltip--email">
         <button class="tooltip__button tooltip__button--email js-use-personal">
             <span class="tooltip__button--email__primary-text">
-                Use <span class="js-address">${formatDuckAddress(escapeXML(this.addresses.personalAddress))}</span>
+                ${this.device.t('usePersonalDuckAddr', {email: formatDuckAddress(escapeXML(this.addresses.personalAddress))})}
             </span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('blockEmailTrackers')}</span>
         </button>
         <button class="tooltip__button tooltip__button--email js-use-private">
             <span class="tooltip__button--email__primary-text">Generate a Private Duck Address</span>
@@ -30,12 +30,12 @@ ${this.options.css}
         this.tooltip = this.shadow.querySelector('.tooltip')
         this.usePersonalButton = this.shadow.querySelector('.js-use-personal')
         this.usePrivateButton = this.shadow.querySelector('.js-use-private')
-        this.addressEl = this.shadow.querySelector('.js-address')
+        this.usePersonalCta = this.shadow.querySelector('.js-use-personal > span:first-of-type')
 
         this.updateAddresses = (addresses) => {
-            if (addresses && this.addressEl) {
+            if (addresses && this.usePersonalCta) {
                 this.addresses = addresses
-                this.addressEl.textContent = formatDuckAddress(addresses.personalAddress)
+                this.usePersonalCta.textContent = this.device.t('usePersonalDuckAddr', {email: formatDuckAddress(addresses.personalAddress)})
             }
         }
 

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -359,6 +359,7 @@ export interface UserPreferences {
   globalPrivacyControlValue?: boolean;
   sessionKey?: string;
   debug: boolean;
+  language?: string;
   platform: {
     name: "ios" | "macos" | "windows" | "extension" | "android" | "unknown";
   };

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -123,6 +123,7 @@ export const userPreferencesSchema = z.object({
     globalPrivacyControlValue: z.boolean().optional(),
     sessionKey: z.string().optional(),
     debug: z.boolean(),
+    language: z.string().optional(),
     platform: z.object({
         name: z.union([z.literal("ios"), z.literal("macos"), z.literal("windows"), z.literal("extension"), z.literal("android"), z.literal("unknown")])
     }),

--- a/src/deviceApiCalls/schemas/runtime-configuration.json
+++ b/src/deviceApiCalls/schemas/runtime-configuration.json
@@ -64,6 +64,9 @@
         "debug": {
           "type": "boolean"
         },
+        "language": {
+          "type": "string"
+        },
         "platform": {
           "type": "object",
           "additionalProperties": false,

--- a/src/deviceApiCalls/transports/extension.transport.js
+++ b/src/deviceApiCalls/transports/extension.transport.js
@@ -69,6 +69,8 @@ async function extensionSpecificRuntimeConfiguration (deviceApi) {
             contentScope: contentScope,
             // @ts-ignore
             userPreferences: {
+                // Copy locale to user preferences as 'language' to match expected payload
+                language: contentScope.locale,
                 features: {
                     autofill: {
                         settings: {

--- a/src/locales/strings.js
+++ b/src/locales/strings.js
@@ -1,0 +1,109 @@
+// TODO(sjbarag): read from JS module generated from JSON files, probably.
+const translations = {
+    en: {
+        'hello': {
+            title: 'Hello world',
+            note: 'Static text for testing.'
+        },
+        'lipsum': {
+            title: 'Lorem ipsum dolor sit amet, {foo} {bar}',
+            note: 'Placeholder text.'
+        },
+        'usePersonalDuckAddr': {
+            title: 'Use {email}',
+            note: 'Button that fills a form using a specific email address. The placeholder is the email address, e.g. "Use test@duck.com".'
+        },
+        'blockEmailTrackers': {
+            title: 'Block email trackers',
+            note: 'Label explaining that by using a duck.com address, email trackers will be blocked. "Block" is a verb in imperative form.'
+        }
+    },
+    xa: {
+        'hello': {
+            title: 'H33ll00 wºrrld',
+            note: 'Static text for testing.'
+        },
+        'lipsum': {
+            title: 'Lºrr3e3m 1p$$$um d00l1loor s!t @@mett, {foo} {bar}',
+            note: 'Placeholder text.'
+        },
+        'usePersonalDuckAddr': {
+            title: 'Ü55££ {email}',
+            note: 'Shown when a user can choose their personal @duck.com address.'
+        },
+        'blockEmailTrackers': {
+            title: 'Bl000ck €m@@@i1il1l träáåck33rr55',
+            note: 'Shown when a user can choose their personal @duck.com address on native platforms.'
+        }
+    }
+}
+
+/**
+ * @callback TranslateFn
+ * Translates a string with the provided ID to the current language, replacing
+ * each placeholder with a key present in `opts` with the corresponding value.
+ *
+ * @param {string} id - the string ID to look up
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+
+/**
+ * Builds a reusable translation function bound to the language provided by
+ * `settings`. That language isn't read until the first translation is
+ * requested, so it's safe to use this statically and assign `settings.language`
+ * later.
+ *
+ * @param {{ language: string }} settings - a settings object containing the current language
+ * @returns {TranslateFn} a translation function
+ */
+export function getTranslator (settings) {
+    let library
+
+    return function t (id, opts) {
+        // Retrieve the library when the first string is translated, to allow
+        // InterfacePrototype.t() to be statically initialized.
+        if (!library) {
+            const { language } = settings
+            library = translations[language]
+            if (!library) {
+                console.warn(`Received unsupported locale '${language}'. Falling back to 'en'.`)
+                library = translations.en
+            }
+        }
+
+        return translateImpl(library, id, opts)
+    }
+}
+
+/**
+ * @typedef {object} Translation
+ * @prop {string} title - the translated string
+ * @prop {string} note - a description of `title` used to aid translators
+ */
+
+/**
+ * Looks up the string with the provided `id` in a `library`, performing
+ * key-value replacements on the translated string. If no string with ID `id` is
+ * found, `id` is returned unmodified.
+ * @param {Record<string, Translation>} library - a map of string IDs to translation
+ * @param {string} id - the string ID to translate
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+function translateImpl (library, id, opts) {
+    const msg = library[id]
+    // Fall back to the message ID if an unsupported message is provided.
+    if (!msg) { return id }
+
+    // Fast path: don't loop over opts if no replacements are provided.
+    if (!opts) { return msg.title }
+
+    // Repeatedly replace all instances of '{SOME_REPLACEMENT_NAME}' with the
+    // corresponding value.
+    let out = msg.title
+    for (const [ name, value ] of Object.entries(opts)) {
+        out = out.replaceAll(`{${name}}`, value)
+    }
+    return out
+}

--- a/src/locales/strings.test.js
+++ b/src/locales/strings.test.js
@@ -1,0 +1,48 @@
+import { getTranslator } from './strings.js'
+
+describe('TranslateFn', () => {
+    it('uses the provided language', () => {
+        const en = getTranslator({ language: 'en' })
+        expect(en('hello')).toBe('Hello world')
+
+        const xa = getTranslator({ language: 'xa' })
+        expect(xa('hello')).toBe('H33ll00 wºrrld')
+    })
+
+    it('defaults to en for unsupported languages', () => {
+    // Silence warnings, since we expect one here.
+        jest.spyOn(console, 'warn').mockImplementation(() => {})
+        const t = getTranslator({ language: 'does-not-exist' })
+        expect(t('hello')).toBe('Hello world')
+    })
+
+    it('reads language just in time', () => {
+        const settings = { language: 'does-not-exist' }
+        // Get a translator, but don't call it until after setting a valid language.
+        const t = getTranslator(settings)
+        settings.language = 'xa'
+        expect(t('hello')).toBe('H33ll00 wºrrld')
+    })
+
+    it('only reads language once', () => {
+        const settings = { language: 'en' }
+        // Get a translator and use it.
+        const t = getTranslator(settings)
+        expect(t('hello')).toBe('Hello world')
+
+        // Change the language in settings and ensure the translator *doesn't*
+        // change.
+        settings.language = 'xa'
+        expect(t('hello')).toBe('Hello world')
+
+        // Change to an invalid language as well, just to be sure.
+        settings.language = 'does-not-exist'
+        expect(t('hello')).toBe('Hello world')
+    })
+
+    it('performs simple replacements', () => {
+        const t = getTranslator({ language: 'xa' })
+        const s = t('lipsum', { foo: 'one', bar: 'two' })
+        expect(s).toBe('Lºrr3e3m 1p$$$um d00l1loor s!t @@mett, one two')
+    })
+})

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8618,7 +8618,7 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Block email trackers'
+        title: this.t('blockEmailTrackers')
       });
     }
     newIdentities.push({
@@ -15293,9 +15293,11 @@ ${this.options.css}
     <div class="tooltip tooltip--email">
         <button class="tooltip__button tooltip__button--email js-use-personal">
             <span class="tooltip__button--email__primary-text">
-                Use <span class="js-address">${(0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))}</span>
+                ${this.device.t('usePersonalDuckAddr', {
+      email: (0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))
+    })}
             </span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('blockEmailTrackers')}</span>
         </button>
         <button class="tooltip__button tooltip__button--email js-use-private">
             <span class="tooltip__button--email__primary-text">Generate a Private Duck Address</span>
@@ -15308,11 +15310,13 @@ ${this.options.css}
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');
     this.usePrivateButton = this.shadow.querySelector('.js-use-private');
-    this.addressEl = this.shadow.querySelector('.js-address');
+    this.usePersonalCta = this.shadow.querySelector('.js-use-personal > span:first-of-type');
     this.updateAddresses = addresses => {
-      if (addresses && this.addressEl) {
+      if (addresses && this.usePersonalCta) {
         this.addresses = addresses;
-        this.addressEl.textContent = (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress);
+        this.usePersonalCta.textContent = this.device.t('usePersonalDuckAddr', {
+          email: (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress)
+        });
       }
     };
     const firePixel = this.device.firePixel.bind(this.device);

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -14722,6 +14722,35 @@ class Settings {
   }
 
   /**
+   * Retrieves the user's language from the current platform's `RuntimeConfiguration`. If the
+   * platform doesn't include a two-character `.userPreferences.language` property in its runtime
+   * configuration, or if an error occurs, 'en' is used as a fallback.
+   *
+   * NOTE: This function returns the two-character 'language' code of a typical POSIX locale
+   * (e.g. 'en', 'de', 'fr') listed in ISO 639-1[1].
+   *
+   * [1] https://en.wikipedia.org/wiki/ISO_639-1
+   *
+   * @returns {Promise<string>} the device's current language code, or 'en' if something goes wrong
+   */
+  async getLanguage() {
+    try {
+      const conf = await this._getRuntimeConfiguration();
+      const language = conf.userPreferences.language ?? 'en';
+      if (language.length !== 2) {
+        console.warn(`config.userPreferences.language must be two characters, but received '${language}'`);
+        return 'en';
+      }
+      return language;
+    } catch (e) {
+      if (this.globalConfig.isDDGTestMode) {
+        console.log('isDDGTestMode: getLanguage: ❌', e);
+      }
+      return 'en';
+    }
+  }
+
+  /**
    * Get runtime configuration, but only once.
    *
    * Some platforms may be reading this directly from inlined variables, whilst others
@@ -17736,6 +17765,7 @@ const userPreferencesSchema = exports.userPreferencesSchema = _zod.z.object({
   globalPrivacyControlValue: _zod.z.boolean().optional(),
   sessionKey: _zod.z.string().optional(),
   debug: _zod.z.boolean(),
+  language: _zod.z.string().optional(),
   platform: _zod.z.object({
     name: _zod.z.union([_zod.z.literal("ios"), _zod.z.literal("macos"), _zod.z.literal("windows"), _zod.z.literal("extension"), _zod.z.literal("android"), _zod.z.literal("unknown")])
   }),

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -18275,6 +18275,8 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
       contentScope: contentScope,
       // @ts-ignore
       userPreferences: {
+        // Copy locale to user preferences as 'language' to match expected payload
+        language: contentScope.locale,
         features: {
           autofill: {
             settings: {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8462,6 +8462,7 @@ var _index = require("../../packages/device-api/index.js");
 var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
 var _initFormSubmissionsApi = require("./initFormSubmissionsApi.js");
 var _EmailProtection = require("../EmailProtection.js");
+var _strings = require("../locales/strings.js");
 /**
  * @typedef {import('../deviceApiCalls/__generated__/validators-ts').StoreFormData} StoreFormData
  */
@@ -8507,6 +8508,13 @@ class InterfacePrototype {
   /** @type {import("../../packages/device-api").DeviceApi} */
   deviceApi;
 
+  /**
+   * Translates a string to the current language, replacing each placeholder
+   * with a key present in `opts` with the corresponding value.
+   * @type {import('../locales/strings').TranslateFn}
+   */
+  t;
+
   /** @type {boolean} */
   isInitializationStarted;
 
@@ -8522,6 +8530,7 @@ class InterfacePrototype {
     this.globalConfig = config;
     this.deviceApi = deviceApi;
     this.settings = settings;
+    this.t = (0, _strings.getTranslator)(settings);
     this.uiController = null;
     this.scanner = (0, _Scanner.createScanner)(this, {
       initialDelay: this.initialSetupDelayMs
@@ -9275,7 +9284,7 @@ class InterfacePrototype {
 }
 var _default = exports.default = InterfacePrototype;
 
-},{"../../packages/device-api/index.js":12,"../EmailProtection.js":33,"../Form/formatters.js":37,"../Form/matching.js":44,"../InputTypes/Credentials.js":46,"../PasswordGenerator.js":49,"../Scanner.js":50,"../Settings.js":51,"../UI/controllers/NativeUIController.js":58,"../autofill-utils.js":63,"../config.js":65,"../deviceApiCalls/__generated__/deviceApiCalls.js":67,"../deviceApiCalls/transports/transports.js":73,"./initFormSubmissionsApi.js":31}],29:[function(require,module,exports){
+},{"../../packages/device-api/index.js":12,"../EmailProtection.js":33,"../Form/formatters.js":37,"../Form/matching.js":44,"../InputTypes/Credentials.js":46,"../PasswordGenerator.js":49,"../Scanner.js":50,"../Settings.js":51,"../UI/controllers/NativeUIController.js":58,"../autofill-utils.js":63,"../config.js":65,"../deviceApiCalls/__generated__/deviceApiCalls.js":67,"../deviceApiCalls/transports/transports.js":73,"../locales/strings.js":75,"./initFormSubmissionsApi.js":31}],29:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -14665,6 +14674,8 @@ class Settings {
   _runtimeConfiguration = null;
   /** @type {boolean | null} */
   _enabled = null;
+  /** @type {string} */
+  _language = 'en';
 
   /**
    * @param {GlobalConfig} config
@@ -14801,7 +14812,8 @@ class Settings {
 
   /**
    * To 'refresh' settings means to re-call APIs to determine new state. This may
-   * only occur once per page, but it must be done before any page scanning/decorating can happen
+   * only occur once per page, but it must be done before any page scanning/decorating
+   * or translation can happen.
    *
    * @returns {Promise<{
    *      availableInputTypes: AvailableInputTypes,
@@ -14813,6 +14825,7 @@ class Settings {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
     this.setAvailableInputTypes(await this.getAvailableInputTypes());
+    this.setLanguage(await this.getLanguage());
 
     // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
     if (typeof this.enabled === 'boolean') {
@@ -14958,6 +14971,19 @@ class Settings {
       ...this._availableInputTypes,
       ...value
     };
+  }
+
+  /** @returns {string} the user's current two-character language code, as provided by the platform */
+  get language() {
+    return this._language;
+  }
+
+  /**
+   * Sets the current two-character language code.
+   * @param {string} language - the language
+   */
+  setLanguage(language) {
+    this._language = language;
   }
   static defaults = {
     /** @type {AutofillFeatureToggles} */
@@ -17287,7 +17313,7 @@ var _autofillUtils = require("./autofill-utils.js");
   }
 })();
 
-},{"./DeviceInterface.js":23,"./autofill-utils.js":63,"./requestIdleCallback.js":75}],65:[function(require,module,exports){
+},{"./DeviceInterface.js":23,"./autofill-utils.js":63,"./requestIdleCallback.js":76}],65:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -18470,6 +18496,127 @@ function waitForWindowsResponse(responseId, options) {
 }
 
 },{"../../../packages/device-api/index.js":12}],75:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getTranslator = getTranslator;
+// TODO(sjbarag): read from JS module generated from JSON files, probably.
+const translations = {
+  en: {
+    'hello': {
+      title: 'Hello world',
+      note: 'Static text for testing.'
+    },
+    'lipsum': {
+      title: 'Lorem ipsum dolor sit amet, {foo} {bar}',
+      note: 'Placeholder text.'
+    },
+    'usePersonalDuckAddr': {
+      title: 'Use {email}',
+      note: 'Button that fills a form using a specific email address. The placeholder is the email address, e.g. "Use test@duck.com".'
+    },
+    'blockEmailTrackers': {
+      title: 'Block email trackers',
+      note: 'Label explaining that by using a duck.com address, email trackers will be blocked. "Block" is a verb in imperative form.'
+    }
+  },
+  xa: {
+    'hello': {
+      title: 'H33ll00 wºrrld',
+      note: 'Static text for testing.'
+    },
+    'lipsum': {
+      title: 'Lºrr3e3m 1p$$$um d00l1loor s!t @@mett, {foo} {bar}',
+      note: 'Placeholder text.'
+    },
+    'usePersonalDuckAddr': {
+      title: 'Ü55££ {email}',
+      note: 'Shown when a user can choose their personal @duck.com address.'
+    },
+    'blockEmailTrackers': {
+      title: 'Bl000ck €m@@@i1il1l träáåck33rr55',
+      note: 'Shown when a user can choose their personal @duck.com address on native platforms.'
+    }
+  }
+};
+
+/**
+ * @callback TranslateFn
+ * Translates a string with the provided ID to the current language, replacing
+ * each placeholder with a key present in `opts` with the corresponding value.
+ *
+ * @param {string} id - the string ID to look up
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+
+/**
+ * Builds a reusable translation function bound to the language provided by
+ * `settings`. That language isn't read until the first translation is
+ * requested, so it's safe to use this statically and assign `settings.language`
+ * later.
+ *
+ * @param {{ language: string }} settings - a settings object containing the current language
+ * @returns {TranslateFn} a translation function
+ */
+function getTranslator(settings) {
+  let library;
+  return function t(id, opts) {
+    // Retrieve the library when the first string is translated, to allow
+    // InterfacePrototype.t() to be statically initialized.
+    if (!library) {
+      const {
+        language
+      } = settings;
+      library = translations[language];
+      if (!library) {
+        console.warn(`Received unsupported locale '${language}'. Falling back to 'en'.`);
+        library = translations.en;
+      }
+    }
+    return translateImpl(library, id, opts);
+  };
+}
+
+/**
+ * @typedef {object} Translation
+ * @prop {string} title - the translated string
+ * @prop {string} note - a description of `title` used to aid translators
+ */
+
+/**
+ * Looks up the string with the provided `id` in a `library`, performing
+ * key-value replacements on the translated string. If no string with ID `id` is
+ * found, `id` is returned unmodified.
+ * @param {Record<string, Translation>} library - a map of string IDs to translation
+ * @param {string} id - the string ID to translate
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+function translateImpl(library, id, opts) {
+  const msg = library[id];
+  // Fall back to the message ID if an unsupported message is provided.
+  if (!msg) {
+    return id;
+  }
+
+  // Fast path: don't loop over opts if no replacements are provided.
+  if (!opts) {
+    return msg.title;
+  }
+
+  // Repeatedly replace all instances of '{SOME_REPLACEMENT_NAME}' with the
+  // corresponding value.
+  let out = msg.title;
+  for (const [name, value] of Object.entries(opts)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+}
+
+},{}],76:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -13739,6 +13739,8 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
       contentScope: contentScope,
       // @ts-ignore
       userPreferences: {
+        // Copy locale to user preferences as 'language' to match expected payload
+        language: contentScope.locale,
         features: {
           autofill: {
             settings: {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4296,6 +4296,7 @@ var _index = require("../../packages/device-api/index.js");
 var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
 var _initFormSubmissionsApi = require("./initFormSubmissionsApi.js");
 var _EmailProtection = require("../EmailProtection.js");
+var _strings = require("../locales/strings.js");
 /**
  * @typedef {import('../deviceApiCalls/__generated__/validators-ts').StoreFormData} StoreFormData
  */
@@ -4341,6 +4342,13 @@ class InterfacePrototype {
   /** @type {import("../../packages/device-api").DeviceApi} */
   deviceApi;
 
+  /**
+   * Translates a string to the current language, replacing each placeholder
+   * with a key present in `opts` with the corresponding value.
+   * @type {import('../locales/strings').TranslateFn}
+   */
+  t;
+
   /** @type {boolean} */
   isInitializationStarted;
 
@@ -4356,6 +4364,7 @@ class InterfacePrototype {
     this.globalConfig = config;
     this.deviceApi = deviceApi;
     this.settings = settings;
+    this.t = (0, _strings.getTranslator)(settings);
     this.uiController = null;
     this.scanner = (0, _Scanner.createScanner)(this, {
       initialDelay: this.initialSetupDelayMs
@@ -5109,7 +5118,7 @@ class InterfacePrototype {
 }
 var _default = exports.default = InterfacePrototype;
 
-},{"../../packages/device-api/index.js":2,"../EmailProtection.js":23,"../Form/formatters.js":27,"../Form/matching.js":34,"../InputTypes/Credentials.js":36,"../PasswordGenerator.js":39,"../Scanner.js":40,"../Settings.js":41,"../UI/controllers/NativeUIController.js":48,"../autofill-utils.js":53,"../config.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":57,"../deviceApiCalls/transports/transports.js":63,"./initFormSubmissionsApi.js":21}],19:[function(require,module,exports){
+},{"../../packages/device-api/index.js":2,"../EmailProtection.js":23,"../Form/formatters.js":27,"../Form/matching.js":34,"../InputTypes/Credentials.js":36,"../PasswordGenerator.js":39,"../Scanner.js":40,"../Settings.js":41,"../UI/controllers/NativeUIController.js":48,"../autofill-utils.js":53,"../config.js":55,"../deviceApiCalls/__generated__/deviceApiCalls.js":57,"../deviceApiCalls/transports/transports.js":63,"../locales/strings.js":65,"./initFormSubmissionsApi.js":21}],19:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -10499,6 +10508,8 @@ class Settings {
   _runtimeConfiguration = null;
   /** @type {boolean | null} */
   _enabled = null;
+  /** @type {string} */
+  _language = 'en';
 
   /**
    * @param {GlobalConfig} config
@@ -10635,7 +10646,8 @@ class Settings {
 
   /**
    * To 'refresh' settings means to re-call APIs to determine new state. This may
-   * only occur once per page, but it must be done before any page scanning/decorating can happen
+   * only occur once per page, but it must be done before any page scanning/decorating
+   * or translation can happen.
    *
    * @returns {Promise<{
    *      availableInputTypes: AvailableInputTypes,
@@ -10647,6 +10659,7 @@ class Settings {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
     this.setAvailableInputTypes(await this.getAvailableInputTypes());
+    this.setLanguage(await this.getLanguage());
 
     // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
     if (typeof this.enabled === 'boolean') {
@@ -10792,6 +10805,19 @@ class Settings {
       ...this._availableInputTypes,
       ...value
     };
+  }
+
+  /** @returns {string} the user's current two-character language code, as provided by the platform */
+  get language() {
+    return this._language;
+  }
+
+  /**
+   * Sets the current two-character language code.
+   * @param {string} language - the language
+   */
+  setLanguage(language) {
+    this._language = language;
   }
   static defaults = {
     /** @type {AutofillFeatureToggles} */
@@ -13121,7 +13147,7 @@ var _autofillUtils = require("./autofill-utils.js");
   }
 })();
 
-},{"./DeviceInterface.js":13,"./autofill-utils.js":53,"./requestIdleCallback.js":65}],55:[function(require,module,exports){
+},{"./DeviceInterface.js":13,"./autofill-utils.js":53,"./requestIdleCallback.js":66}],55:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -13934,6 +13960,127 @@ function waitForWindowsResponse(responseId, options) {
 }
 
 },{"../../../packages/device-api/index.js":2}],65:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getTranslator = getTranslator;
+// TODO(sjbarag): read from JS module generated from JSON files, probably.
+const translations = {
+  en: {
+    'hello': {
+      title: 'Hello world',
+      note: 'Static text for testing.'
+    },
+    'lipsum': {
+      title: 'Lorem ipsum dolor sit amet, {foo} {bar}',
+      note: 'Placeholder text.'
+    },
+    'usePersonalDuckAddr': {
+      title: 'Use {email}',
+      note: 'Button that fills a form using a specific email address. The placeholder is the email address, e.g. "Use test@duck.com".'
+    },
+    'blockEmailTrackers': {
+      title: 'Block email trackers',
+      note: 'Label explaining that by using a duck.com address, email trackers will be blocked. "Block" is a verb in imperative form.'
+    }
+  },
+  xa: {
+    'hello': {
+      title: 'H33ll00 wºrrld',
+      note: 'Static text for testing.'
+    },
+    'lipsum': {
+      title: 'Lºrr3e3m 1p$$$um d00l1loor s!t @@mett, {foo} {bar}',
+      note: 'Placeholder text.'
+    },
+    'usePersonalDuckAddr': {
+      title: 'Ü55££ {email}',
+      note: 'Shown when a user can choose their personal @duck.com address.'
+    },
+    'blockEmailTrackers': {
+      title: 'Bl000ck €m@@@i1il1l träáåck33rr55',
+      note: 'Shown when a user can choose their personal @duck.com address on native platforms.'
+    }
+  }
+};
+
+/**
+ * @callback TranslateFn
+ * Translates a string with the provided ID to the current language, replacing
+ * each placeholder with a key present in `opts` with the corresponding value.
+ *
+ * @param {string} id - the string ID to look up
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+
+/**
+ * Builds a reusable translation function bound to the language provided by
+ * `settings`. That language isn't read until the first translation is
+ * requested, so it's safe to use this statically and assign `settings.language`
+ * later.
+ *
+ * @param {{ language: string }} settings - a settings object containing the current language
+ * @returns {TranslateFn} a translation function
+ */
+function getTranslator(settings) {
+  let library;
+  return function t(id, opts) {
+    // Retrieve the library when the first string is translated, to allow
+    // InterfacePrototype.t() to be statically initialized.
+    if (!library) {
+      const {
+        language
+      } = settings;
+      library = translations[language];
+      if (!library) {
+        console.warn(`Received unsupported locale '${language}'. Falling back to 'en'.`);
+        library = translations.en;
+      }
+    }
+    return translateImpl(library, id, opts);
+  };
+}
+
+/**
+ * @typedef {object} Translation
+ * @prop {string} title - the translated string
+ * @prop {string} note - a description of `title` used to aid translators
+ */
+
+/**
+ * Looks up the string with the provided `id` in a `library`, performing
+ * key-value replacements on the translated string. If no string with ID `id` is
+ * found, `id` is returned unmodified.
+ * @param {Record<string, Translation>} library - a map of string IDs to translation
+ * @param {string} id - the string ID to translate
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+function translateImpl(library, id, opts) {
+  const msg = library[id];
+  // Fall back to the message ID if an unsupported message is provided.
+  if (!msg) {
+    return id;
+  }
+
+  // Fast path: don't loop over opts if no replacements are provided.
+  if (!opts) {
+    return msg.title;
+  }
+
+  // Repeatedly replace all instances of '{SOME_REPLACEMENT_NAME}' with the
+  // corresponding value.
+  let out = msg.title;
+  for (const [name, value] of Object.entries(opts)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+}
+
+},{}],66:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -10556,6 +10556,35 @@ class Settings {
   }
 
   /**
+   * Retrieves the user's language from the current platform's `RuntimeConfiguration`. If the
+   * platform doesn't include a two-character `.userPreferences.language` property in its runtime
+   * configuration, or if an error occurs, 'en' is used as a fallback.
+   *
+   * NOTE: This function returns the two-character 'language' code of a typical POSIX locale
+   * (e.g. 'en', 'de', 'fr') listed in ISO 639-1[1].
+   *
+   * [1] https://en.wikipedia.org/wiki/ISO_639-1
+   *
+   * @returns {Promise<string>} the device's current language code, or 'en' if something goes wrong
+   */
+  async getLanguage() {
+    try {
+      const conf = await this._getRuntimeConfiguration();
+      const language = conf.userPreferences.language ?? 'en';
+      if (language.length !== 2) {
+        console.warn(`config.userPreferences.language must be two characters, but received '${language}'`);
+        return 'en';
+      }
+      return language;
+    } catch (e) {
+      if (this.globalConfig.isDDGTestMode) {
+        console.log('isDDGTestMode: getLanguage: ❌', e);
+      }
+      return 'en';
+    }
+  }
+
+  /**
    * Get runtime configuration, but only once.
    *
    * Some platforms may be reading this directly from inlined variables, whilst others

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4452,7 +4452,7 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Block email trackers'
+        title: this.t('blockEmailTrackers')
       });
     }
     newIdentities.push({
@@ -11127,9 +11127,11 @@ ${this.options.css}
     <div class="tooltip tooltip--email">
         <button class="tooltip__button tooltip__button--email js-use-personal">
             <span class="tooltip__button--email__primary-text">
-                Use <span class="js-address">${(0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))}</span>
+                ${this.device.t('usePersonalDuckAddr', {
+      email: (0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))
+    })}
             </span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('blockEmailTrackers')}</span>
         </button>
         <button class="tooltip__button tooltip__button--email js-use-private">
             <span class="tooltip__button--email__primary-text">Generate a Private Duck Address</span>
@@ -11142,11 +11144,13 @@ ${this.options.css}
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');
     this.usePrivateButton = this.shadow.querySelector('.js-use-private');
-    this.addressEl = this.shadow.querySelector('.js-address');
+    this.usePersonalCta = this.shadow.querySelector('.js-use-personal > span:first-of-type');
     this.updateAddresses = addresses => {
-      if (addresses && this.addressEl) {
+      if (addresses && this.usePersonalCta) {
         this.addresses = addresses;
-        this.addressEl.textContent = (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress);
+        this.usePersonalCta.textContent = this.device.t('usePersonalDuckAddr', {
+          email: (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress)
+        });
       }
     };
     const firePixel = this.device.firePixel.bind(this.device);


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/72649045549333/1206933877192895

## Description
(Reimplements #540 in a mergeable state 😄)

This is a series of four commits (each individually buildable and testable, ready for a rebase merge or merge commit) that add support for localization to the autofill HTML UI. Check each commit message for more details, but the TL;DR is:

1. Add `.userPreferences.language` to runtime configuration
2. Implement basic translation and wire it up to the Device abstraction
3. Copy the already-provided language from the extension's runtime config
4. Translate two strings as a small demo

## Steps to test
1. The usual `npm run verify:local` on each commit
2. On the final commit, test end-to-end with the `xa` pseudolanguage:
    1. `npm run build` in this repo
    2. Clone https://github.com/duckduckgo/duckduckgo-privacy-extension next to this repo if you haven't yet
    3. Apply [this patch](https://gist.github.com/sjbarag/bbeec6b10c3e89d1b48e5ba70af75c1d)
    4. `npm install && npm link ../duckduckgo-autofill && npm run dev-chrome` in that repo
    5. Launch Google Chrome and load a signup page
    6. You should see translated (in a pseudolocale) text for the "Use personal duck address" button
