### PR TITLE
real-world: remove expected failure from clientssp.fnfis.com test

### DIFF
--- a/test-forms/clientssp_fnfis_com_login.html
+++ b/test-forms/clientssp_fnfis_com_login.html
@@ -181,7 +181,7 @@ form signature in host form: 13057170697064359019
 field frame token: 605E1DE721D4C794AF0CD8962D8FC6C8
 form renderer id: 1
 field renderer id: 14
-autocomplete: off" data-ddg-testresultelementid="558285" data-manual-scoring="username OR emailAddress">
+autocomplete: off" data-ddg-testresultelementid="558285" data-manual-scoring="username">
 
             <span id="ctl00_ContentPlaceHolder1_Label3" class="label pass">Password:</span>
             <input name="ctl00$ContentPlaceHolder1$txtPassword" type="password" id="ctl00_ContentPlaceHolder1_txtPassword" class="tBox pass" autofill-information="overall type: PASSWORD

--- a/test-forms/index.json
+++ b/test-forms/index.json
@@ -335,7 +335,7 @@
   { "html": "www_mcgill_ca_login.html", "generated": true, "title": "User Login", "comment": "rank: 2373" },
   { "html": "www_microfocus_com_signup.html", "generated": true, "title": "Create an Account", "comment": "rank: 2429" },
   { "html": "pacer_login_uscourts_gov_login.html", "generated": true, "title": "PACER: Login", "comment": "rank: 2501" },
-  { "html": "clientssp_fnfis_com_login.html", "generated": true, "title": "Login", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2563" },
+  { "html": "clientssp_fnfis_com_login.html", "generated": true, "title": "Login", "comment": "rank: 2563" },
   { "html": "www_colamanhua_com_login.html", "generated": true, "title": "个人中心 COLAMANHUA", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2670" },
   { "html": "registration_lycos_com_signup.html", "generated": true, "title": "LYCOS Mail: Registration Sign Up", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2693" },
   { "html": "itcdguzman_mindbox_app_login.html", "generated": true, "title": "MindBox®", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2774" },


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/0/1206549572244440/f

## Description
We're able to reliably detect a username input, password input, and submit button on clientssp.fnfis.com/login.aspx. Remove the expected failure for that site.

## Steps to test
`npm run test` should report no failures. For this case specifically, `node_modules/.bin/jest -t fnfis src/Form/input-classifiers.test.js` should show one test case passed.

## Meta
Modifying a single test case in this PR to make sure I'm doing things right 😅 future PRs will have more than one site, I promise.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207319718271466