### PR TITLE
matchers: detect username inputs with placeholders containing '账号'

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12583,7 +12583,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           match: /current|old|previous|expired|existing/iu
         },
         username: {
-          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
+          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id|账号/iu,
           skip: /phone/iu,
           forceUnknown: /search|policy|choose a user\b/iu
         },

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8417,7 +8417,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           match: /current|old|previous|expired|existing/iu
         },
         username: {
-          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
+          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id|账号/iu,
           skip: /phone/iu,
           forceUnknown: /search|policy|choose a user\b/iu
         },

--- a/src/Form/matching-config/__generated__/compiled-matching-config.js
+++ b/src/Form/matching-config/__generated__/compiled-matching-config.js
@@ -252,7 +252,7 @@ const matchingConfiguration = {
         newPassword: { match: /new|re.?(enter|type)|repeat|update|reset\b/iu },
         currentPassword: { match: /current|old|previous|expired|existing/iu },
         username: {
-          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
+          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id|账号/iu,
           skip: /phone/iu,
           forceUnknown: /search|policy|choose a user\b/iu
         },

--- a/src/Form/matching-config/matching-config-source.js
+++ b/src/Form/matching-config/matching-config-source.js
@@ -288,7 +288,10 @@ const matchingConfiguration = {
                             // in Spanish dni and nie stand for id number, often used as username
                             '|\\bdni\\b|\\bnie\\b| del? documento|documento de identidad' +
                         // Swedish
-                        '|användarnamn|kontonamn|användar-id',
+                        '|användarnamn|kontonamn|användar-id' +
+                        // Simplified Chinese
+                        // * 账号 translates to "account number"
+                        '|账号',
                     skip: 'phone',
                     forceUnknown: 'search|policy' +
                         // Github assignee picker

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -12583,7 +12583,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           match: /current|old|previous|expired|existing/iu
         },
         username: {
-          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
+          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id|账号/iu,
           skip: /phone/iu,
           forceUnknown: /search|policy|choose a user\b/iu
         },

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -8417,7 +8417,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           match: /current|old|previous|expired|existing/iu
         },
         username: {
-          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
+          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id|账号/iu,
           skip: /phone/iu,
           forceUnknown: /search|policy|choose a user\b/iu
         },

--- a/test-forms/index.json
+++ b/test-forms/index.json
@@ -336,7 +336,7 @@
   { "html": "www_microfocus_com_signup.html", "generated": true, "title": "Create an Account", "comment": "rank: 2429" },
   { "html": "pacer_login_uscourts_gov_login.html", "generated": true, "title": "PACER: Login", "comment": "rank: 2501" },
   { "html": "clientssp_fnfis_com_login.html", "generated": true, "title": "Login", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2563" },
-  { "html": "www_colamanhua_com_login.html", "generated": true, "title": "个人中心 COLAMANHUA", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2670" },
+  { "html": "www_colamanhua_com_login.html", "generated": true, "title": "个人中心 COLAMANHUA", "comment": "rank: 2670" },
   { "html": "registration_lycos_com_signup.html", "generated": true, "title": "LYCOS Mail: Registration Sign Up", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2693" },
   { "html": "itcdguzman_mindbox_app_login.html", "generated": true, "title": "MindBox®", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2774" },
   { "html": "www_indiapost_gov_in_login.html", "generated": true, "title": "Welcome to Indiapost", "comment": "rank: 2814" },

--- a/test-forms/www_colamanhua_com_login.html
+++ b/test-forms/www_colamanhua_com_login.html
@@ -199,7 +199,7 @@ form signature: 1359617811454836994
 form signature in host form: 1359617811454836994
 field frame token: CC277ADA01A985F2623C5542E35214AC
 form renderer id: 4
-field renderer id: 25" data-ddg-testresultelementid="558584" data-manual-scoring="username OR emailAddress">
+field renderer id: 25" data-ddg-testresultelementid="558584">
             <input class="fed-user-text fed-col-xs12" type="password" name="user_pwd" placeholder="请输入密码" maxlength="20" autofill-information="overall type: PASSWORD
 server type: PASSWORD
 heuristic type: UNKNOWN_TYPE
@@ -211,7 +211,7 @@ form signature: 1359617811454836994
 form signature in host form: 1359617811454836994
 field frame token: CC277ADA01A985F2623C5542E35214AC
 form renderer id: 4
-field renderer id: 26" data-ddg-testresultelementid="558586" data-manual-scoring="password">
+field renderer id: 26" data-ddg-testresultelementid="558586">
             <input class="fed-user-text fed-col-xs8" type="tel" name="verifyCode" placeholder="请输入验证码" maxlength="8" autofill-information="overall type: UNKNOWN_TYPE
 server type: NO_SERVER_DATA
 heuristic type: UNKNOWN_TYPE


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/1206682621538333/1207319718271458/f

## Description
In Simplified Chinese, '账号' translates to "account number". Add that as a possible arm of the username-matching regex.

## Steps to test
`node_modules/.bin/jest src/Form/input-classifiers.test.js -t colamanhua` reports no failures