### PR TITLE
vcs: ignore .helix directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 
 # Editor files
 .idea
+.helix
 
 test-results/
 playwright-report/


### PR DESCRIPTION
**Reviewer:** 
**Asana:** 

## Description
The .helix directory is used for directory-specific settings[^1]. Don't track it in git, so I don't accidentally overwrite someone else's settings. No one else at DDG seesm to use helix, but probably easiest to get ahead of it.

[^1]: https://docs.helix-editor.com/configuration.html

## Steps to test
n/a, just a dev quality-of-life improvement
