### PR TITLE
real-world: remove expected failure from ssl.tabelog.com test

### DIFF
--- a/test-forms/index.json
+++ b/test-forms/index.json
@@ -340,7 +340,7 @@
   { "html": "registration_lycos_com_signup.html", "generated": true, "title": "LYCOS Mail: Registration Sign Up", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2693" },
   { "html": "itcdguzman_mindbox_app_login.html", "generated": true, "title": "MindBox®", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2774" },
   { "html": "www_indiapost_gov_in_login.html", "generated": true, "title": "Welcome to Indiapost", "comment": "rank: 2814" },
-  { "html": "ssl_tabelog_com_login.html", "generated": true, "title": "食べログ 店舗管理画面ログイン[食べログ]", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2819" },
+  { "html": "ssl_tabelog_com_login.html", "generated": true, "title": "食べログ 店舗管理画面ログイン[食べログ]", "comment": "rank: 2819" },
   { "html": "freelance_habr_com_signup.html", "generated": true, "title": "Регистрация — Хабр Фриланс", "comment": "rank: 2857" },
   { "html": "agile_appian_com_login.html", "generated": true, "title": "Log in - Appian", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2936" },
   { "html": "lk_uminet_ru_login.html", "generated": true, "title": "Личный кабинет пользователя", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 3005" },

--- a/test-forms/ssl_tabelog_com_login.html
+++ b/test-forms/ssl_tabelog_com_login.html
@@ -20,7 +20,7 @@ form signature: 18321798703744793289
 form signature in host form: 18321798703744793289
 field frame token: BA49C829712A71652B056D700D8860C7
 form renderer id: 3
-field renderer id: 26" data-ddg-testresultelementid="559156" data-manual-scoring="username OR emailAddress">
+field renderer id: 26" data-ddg-testresultelementid="559156" data-manual-scoring="username">
   </div>
   <div class="owner-login__item">
     <label for="password" class="owner-login__item-name">パスワード</label>


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/0/1207309735478037/f

## Description
We're able to consistently detect the login field, so there's no need to expect a failure for it any more.

## Steps to test
`node_modules/.bin/jest src/Form/input-classifiers.test.js -t tabelog`