### PR TITLE
real-world: remove expected failure for agile.appian.com

### DIFF
--- a/test-forms/agile_appian_com_login.html
+++ b/test-forms/agile_appian_com_login.html
@@ -112,7 +112,7 @@ form signature: 2624432454013304355
 form signature in host form: 2624432454013304355
 field frame token: FA897943B739271F2D1EF2D1B40A9985
 form renderer id: 2
-field renderer id: 16" data-ddg-testresultelementid="559696" data-manual-scoring="username OR emailAddress">
+field renderer id: 16" data-ddg-testresultelementid="559696" data-manual-scoring="username">
                     </div>
 
                     <div class="field-group">

--- a/test-forms/index.json
+++ b/test-forms/index.json
@@ -342,7 +342,7 @@
   { "html": "www_indiapost_gov_in_login.html", "generated": true, "title": "Welcome to Indiapost", "comment": "rank: 2814" },
   { "html": "ssl_tabelog_com_login.html", "generated": true, "title": "食べログ 店舗管理画面ログイン[食べログ]", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2819" },
   { "html": "freelance_habr_com_signup.html", "generated": true, "title": "Регистрация — Хабр Фриланс", "comment": "rank: 2857" },
-  { "html": "agile_appian_com_login.html", "generated": true, "title": "Log in - Appian", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 2936" },
+  { "html": "agile_appian_com_login.html", "generated": true, "title": "Log in - Appian", "comment": "rank: 2936" },
   { "html": "lk_uminet_ru_login.html", "generated": true, "title": "Личный кабинет пользователя", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 3005" },
   { "html": "onehr_ge_com_login.html", "generated": true, "title": "GE Single Sign On", "expectedFailures": ["username OR emailAddress"], "comment": "rank: 3031" },
   { "html": "epaper_zaobao_com_login.html", "generated": true, "expectedFailures": ["username OR emailAddress"], "comment": "rank: 3140" },


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/0/1207309735478042/f

## Description
We can reliably detect the username field on agile.appian.com/login.jsp now, so there's no need for an expected failure.

## Steps to test
`node_modules/.bin/jest src/Form/input-classifiers.test.js -t appian`
