### PR TITLE
generation: ensure password gen feature flag is respected

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -14751,15 +14751,22 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {boolean}
    */
   isTypeUnavailable(_ref) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref;
     if (mainType === 'unknown') return true;
+
+    // Ensure password generation feature flag is respected
+    if (subtype === 'password' && variant === 'new') {
+      return !this.featureToggles.password_generation;
+    }
     if (!this.featureToggles[`inputType_${mainType}`] && subtype !== 'emailAddress') {
       return true;
     }
@@ -14780,17 +14787,20 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {Promise<boolean>}
    */
   async populateDataIfNeeded(_ref2) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref2;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
     if (this.availableInputTypes?.[mainType] === undefined) {
       await this.populateData();
@@ -14818,7 +14828,8 @@ class Settings {
     } = _ref3;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
 
     // If it's an email field and Email Protection is enabled, return true regardless of other options

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -10585,15 +10585,22 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {boolean}
    */
   isTypeUnavailable(_ref) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref;
     if (mainType === 'unknown') return true;
+
+    // Ensure password generation feature flag is respected
+    if (subtype === 'password' && variant === 'new') {
+      return !this.featureToggles.password_generation;
+    }
     if (!this.featureToggles[`inputType_${mainType}`] && subtype !== 'emailAddress') {
       return true;
     }
@@ -10614,17 +10621,20 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {Promise<boolean>}
    */
   async populateDataIfNeeded(_ref2) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref2;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
     if (this.availableInputTypes?.[mainType] === undefined) {
       await this.populateData();
@@ -10652,7 +10662,8 @@ class Settings {
     } = _ref3;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
 
     // If it's an email field and Email Protection is enabled, return true regardless of other options

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -198,11 +198,18 @@ export class Settings {
      * @param {{
      *   mainType: SupportedMainTypes
      *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+     *   variant?: import('./Form/matching.js').SupportedVariants | ""
      * }} types
      * @returns {boolean}
      */
-    isTypeUnavailable ({mainType, subtype}) {
+    isTypeUnavailable ({mainType, subtype, variant}) {
         if (mainType === 'unknown') return true
+
+        // Ensure password generation feature flag is respected
+        if (subtype === 'password' && variant === 'new') {
+            return !this.featureToggles.password_generation
+        }
+
         if (!this.featureToggles[`inputType_${mainType}`] && subtype !== 'emailAddress') {
             return true
         }
@@ -223,11 +230,12 @@ export class Settings {
      * @param {{
      *   mainType: SupportedMainTypes
      *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+     *   variant?: import('./Form/matching.js').SupportedVariants | ""
      * }} types
      * @returns {Promise<boolean>}
      */
-    async populateDataIfNeeded ({mainType, subtype}) {
-        if (this.isTypeUnavailable({mainType, subtype})) return false
+    async populateDataIfNeeded ({mainType, subtype, variant}) {
+        if (this.isTypeUnavailable({mainType, subtype, variant})) return false
         if (this.availableInputTypes?.[mainType] === undefined) {
             await this.populateData()
             return true
@@ -247,7 +255,7 @@ export class Settings {
      * @returns {boolean}
      */
     canAutofillType ({mainType, subtype, variant}, inContextSignup) {
-        if (this.isTypeUnavailable({ mainType, subtype })) return false
+        if (this.isTypeUnavailable({ mainType, subtype, variant })) return false
 
         // If it's an email field and Email Protection is enabled, return true regardless of other options
         const isEmailProtectionEnabled = this.featureToggles.emailProtection && this.availableInputTypes.email

--- a/src/Settings.test.js
+++ b/src/Settings.test.js
@@ -51,6 +51,17 @@ describe('Settings', () => {
                 }
             ],
             [
+                { password_generation: false },
+                {
+                    ...createAvailableInputTypes({
+                        credentials: {username: true, password: true}
+                    })
+                },
+                (settings) => {
+                    expect(settings.canAutofillType({ mainType: 'credentials', subtype: 'password', variant: 'new' }, null)).toBe(false)
+                }
+            ],
+            [
                 {},
                 {
                     ...createAvailableInputTypes({

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -14751,15 +14751,22 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {boolean}
    */
   isTypeUnavailable(_ref) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref;
     if (mainType === 'unknown') return true;
+
+    // Ensure password generation feature flag is respected
+    if (subtype === 'password' && variant === 'new') {
+      return !this.featureToggles.password_generation;
+    }
     if (!this.featureToggles[`inputType_${mainType}`] && subtype !== 'emailAddress') {
       return true;
     }
@@ -14780,17 +14787,20 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {Promise<boolean>}
    */
   async populateDataIfNeeded(_ref2) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref2;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
     if (this.availableInputTypes?.[mainType] === undefined) {
       await this.populateData();
@@ -14818,7 +14828,8 @@ class Settings {
     } = _ref3;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
 
     // If it's an email field and Email Protection is enabled, return true regardless of other options

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -10585,15 +10585,22 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {boolean}
    */
   isTypeUnavailable(_ref) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref;
     if (mainType === 'unknown') return true;
+
+    // Ensure password generation feature flag is respected
+    if (subtype === 'password' && variant === 'new') {
+      return !this.featureToggles.password_generation;
+    }
     if (!this.featureToggles[`inputType_${mainType}`] && subtype !== 'emailAddress') {
       return true;
     }
@@ -10614,17 +10621,20 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {Promise<boolean>}
    */
   async populateDataIfNeeded(_ref2) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref2;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
     if (this.availableInputTypes?.[mainType] === undefined) {
       await this.populateData();
@@ -10652,7 +10662,8 @@ class Settings {
     } = _ref3;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
 
     // If it's an email field and Email Protection is enabled, return true regardless of other options


### PR DESCRIPTION
**Reviewer:** @GioSensation
**Asana:** https://app.asana.com/0/0/1207632297018372/f

## Description
This was originally introduced as a commit squashed into 8b046b1 (Android: enable iframe support (#536), 2024-04-09), but was accidentally removed via 18dd599 (android: revert "Android: enable iframe support (#536)" (#582), 2024-06-20). Reintroduce that commit, to ensure the `password_generation` runtime config flag is again respected and prevent password prompts after a user clicks "Never save for site".

(cherry picked from commit 4c16e5290066f3237dab14beded53fee148ff402)

## Steps to test
1. Use this autofill build
1. Ensure at least 1 credential is already saved for fill.dev
1. Visit https://fill.dev/form/registration-username
1. Enter a username and a manual password (do not select the suggested generated password)
1. When prompted to save, choose “Never Ask for this Site" 
1. Open a new tab and open https://fill.dev/form/registration-username again
1. Ensure you're not prompted to fill with your saved credentials
