### PR TITLE
[Credentials] Add a test case to reproduce chase.com issue with custom form

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10753,9 +10753,14 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = window.location.href;
-    const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
-    const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
+    const {
+      pathname,
+      search,
+      hash
+    } = window.location;
+    const pathToMatch = pathname + search + hash.slice(0, 100);
+    const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), pathToMatch);
+    const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), pathToMatch);
 
     // If the url matches both, do nothing: the signal is probably confounding
     if (matchesLogin && matchesSignup) return;

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10753,7 +10753,7 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = `${window.location.pathname}${window.location.hash}`;
+    const path = window.location.href;
     const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
     const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
 

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10753,7 +10753,7 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = window.location.pathname;
+    const path = `${window.location.pathname}${window.location.hash}`;
     const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
     const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6587,7 +6587,7 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = `${window.location.pathname}${window.location.hash}`;
+    const path = window.location.href;
     const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
     const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6587,7 +6587,7 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = window.location.pathname;
+    const path = `${window.location.pathname}${window.location.hash}`;
     const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
     const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
 

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6587,9 +6587,14 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = window.location.href;
-    const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
-    const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
+    const {
+      pathname,
+      search,
+      hash
+    } = window.location;
+    const pathToMatch = pathname + search + hash.slice(0, 100);
+    const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), pathToMatch);
+    const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), pathToMatch);
 
     // If the url matches both, do nothing: the signal is probably confounding
     if (matchesLogin && matchesSignup) return;

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -23,7 +23,8 @@ export const constants = {
         'loginCovered': `${localPagesPrefix}/login-covered.html`,
         'loginMultistep': `${privacyTestPagesPrefix}/autoprompt/3-multistep-form.html`,
         'shadowDom': `${privacyTestPagesPrefix}/shadow-dom.html`,
-        'selectInput': `${localPagesPrefix}/select-input.html`
+        'selectInput': `${localPagesPrefix}/select-input.html`,
+        'shadowInputsLogin': `${localPagesPrefix}/shadow-inputs-login.html`
     },
     fields: {
         email: {

--- a/integration-test/helpers/pages/shadowInputsLoginPage.js
+++ b/integration-test/helpers/pages/shadowInputsLoginPage.js
@@ -1,0 +1,49 @@
+import {constants} from '../mocks.js'
+import {expect} from '@playwright/test'
+
+/**
+ * @param {import("@playwright/test").Page} page
+ */
+export function shadowInputsLoginPage (page) {
+    class ShadowInputsLoginPage {
+        async navigate () {
+            await page.goto(constants.pages['shadowInputsLogin'])
+        }
+
+        async clickTheUsernameField (text) {
+            const input = page.locator('#username')
+            await input.click()
+            const button = await page.waitForSelector(`button:has-text("${text}")`)
+            await button.click({force: true})
+        }
+
+        /**
+         * @param {string} value
+         * @return {Promise<void>}
+         */
+        async assertUsernameFilled (value) {
+            const username = page.locator('#username')
+            await expect(username).toHaveValue(value)
+        }
+        /**
+         * @param {string} value
+         * @return {Promise<void>}
+         */
+        async assertPasswordFilled (value) {
+            const passwordField = page.locator('#password')
+            await expect(passwordField).toHaveValue(value)
+        }
+
+        /**
+         * @param {string} username
+         * @param {string} password
+         * @return {Promise<void>}
+         */
+        async assertCredentialsFilled (username, password) {
+            await this.assertUsernameFilled(username)
+            await this.assertPasswordFilled((password))
+        }
+    }
+
+    return new ShadowInputsLoginPage()
+}

--- a/integration-test/pages/index.html
+++ b/integration-test/pages/index.html
@@ -20,6 +20,7 @@
     <li><a href="login-poor-form.html">login-poor-form.html</a></li>
     <li><a href="signup.html">signup.html</a></li>
     <li><a href="select-input.html">select-input.html</a></li>
+    <li><a href="shadow-inputs-login.html">shadow-inputs-login.html</a></li>
 </ul>
 </body>
 </html>

--- a/integration-test/pages/shadow-inputs-login.html
+++ b/integration-test/pages/shadow-inputs-login.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Shadow DOM Form</title>
+</head>
+<body>
+    <p>Replicating secure.chase.com: each of the following form elements are within a shadow root that is open. 
+        The form element itself is not in a shadow root
+    </p>
+    <form>
+        <div id="usernameRoot"></div>
+        <div id="passwordRoot"></div>
+        <div id="submitRoot" type="submit">Login</div>
+    </form>
+
+    <script>
+        // Create shadow roots for username and password inputs
+        const usernameRoot = document.getElementById('usernameRoot').attachShadow({ mode: 'open' });
+        const passwordRoot = document.getElementById('passwordRoot').attachShadow({ mode: 'open' });
+        const submitRoot = document.getElementById('submitRoot').attachShadow({ mode: 'open' });
+
+        // Create username input element
+        const usernameInput = document.createElement('input');
+        usernameInput.type = 'text';
+        usernameInput.placeholder = 'Username';
+        usernameInput.id = 'username';
+        usernameInput.name = 'userId';
+        usernameRoot.appendChild(usernameInput);
+
+        // Create password input element
+        const passwordInput = document.createElement('input');
+        passwordInput.type = 'password';
+        passwordInput.placeholder = 'Password';
+        passwordInput.id = 'password';
+        passwordInput.name = 'password-input';
+        passwordRoot.appendChild(passwordInput);
+
+       // Create a submit button
+        const submitButton = document.createElement('button');
+        submitButton.textContent = 'Login';
+        submitButton.name = 'login';
+        submitButton.id = 'login';
+        submitRoot.appendChild(submitButton);
+
+        // Add event listener to submit button
+        submitButton.addEventListener('click', function(event) {
+            event.preventDefault();
+            alert('Username: ' + usernameInput.value + '\nPassword: ' + passwordInput.value);
+        }); 
+
+    </script>
+
+</body>
+</html>

--- a/integration-test/tests/login-form.macos.spec.js
+++ b/integration-test/tests/login-form.macos.spec.js
@@ -6,6 +6,7 @@ import {createAvailableInputTypes} from '../helpers/utils.js'
 import {loginPage} from '../helpers/pages/loginPage.js'
 import {overlayPage} from '../helpers/pages/overlayPage.js'
 import {genericPage} from '../helpers/pages/genericPage.js'
+import { shadowInputsLoginPage } from '../helpers/pages/shadowInputsLoginPage.js'
 
 /**
  *  Tests for various auto-fill scenarios on macos
@@ -81,10 +82,27 @@ async function createLoginFormInModalPage (page) {
 }
 
 test.describe('Auto-fill a login form on macOS', () => {
+    test.describe('when elements are within (open) shadow roots', () => {
+        test.skip('clicking on username should fill the username and password field', async ({page}) => {
+            await forwardConsoleMessages(page)
+            await mocks(page)
+            await createAutofillScript()
+                .replaceAll(macosContentScopeReplacements({}))
+                .platform('macos')
+                .applyTo(page)
+            const login = shadowInputsLoginPage(page)
+            await login.navigate()
+            await login.clickTheUsernameField(personalAddress)
+            await page.pause()
+            await login.assertCredentialsFilled(personalAddress, password)
+        })
+    })
+
     test.describe('without getAvailableInputTypes API', () => {
         test('with in-page HTMLTooltip', async ({page}) => {
             await testLoginPage(page)
         })
+
         test.describe('with overlay', () => {
             test('with click', async ({page}) => {
                 const login = await testLoginPage(page, { overlay: true, pageType: 'loginWithText' })

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -90,6 +90,7 @@ class ExtensionInterface extends InterfacePrototype {
                     notifyWebApp({ deviceSignedIn: {value: false} })
                 }
             })
+
             if (this.activeForm?.activeInput) {
                 this.attachTooltip({
                     form: this.activeForm,

--- a/src/DeviceInterface/ExtensionInterface.js
+++ b/src/DeviceInterface/ExtensionInterface.js
@@ -90,7 +90,6 @@ class ExtensionInterface extends InterfacePrototype {
                     notifyWebApp({ deviceSignedIn: {value: false} })
                 }
             })
-
             if (this.activeForm?.activeInput) {
                 this.attachTooltip({
                     form: this.activeForm,

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -175,10 +175,11 @@ class FormAnalyzer {
     }
 
     evaluateUrl () {
-        const path = window.location.href
+        const {pathname, search, hash} = window.location
+        const pathToMatch = pathname + search + hash.slice(0, 100)
 
-        const matchesLogin = safeRegexTest(this.matching.getDDGMatcherRegex('loginRegex'), path)
-        const matchesSignup = safeRegexTest(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path)
+        const matchesLogin = safeRegexTest(this.matching.getDDGMatcherRegex('loginRegex'), pathToMatch)
+        const matchesSignup = safeRegexTest(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), pathToMatch)
 
         // If the url matches both, do nothing: the signal is probably confounding
         if (matchesLogin && matchesSignup) return

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -175,7 +175,7 @@ class FormAnalyzer {
     }
 
     evaluateUrl () {
-        const path = `${window.location.pathname}${window.location.hash}`
+        const path = window.location.href
 
         const matchesLogin = safeRegexTest(this.matching.getDDGMatcherRegex('loginRegex'), path)
         const matchesSignup = safeRegexTest(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path)

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -175,7 +175,7 @@ class FormAnalyzer {
     }
 
     evaluateUrl () {
-        const path = window.location.pathname
+        const path = `${window.location.pathname}${window.location.hash}`
 
         const matchesLogin = safeRegexTest(this.matching.getDDGMatcherRegex('loginRegex'), path)
         const matchesSignup = safeRegexTest(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path)

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10753,9 +10753,14 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = window.location.href;
-    const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
-    const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
+    const {
+      pathname,
+      search,
+      hash
+    } = window.location;
+    const pathToMatch = pathname + search + hash.slice(0, 100);
+    const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), pathToMatch);
+    const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), pathToMatch);
 
     // If the url matches both, do nothing: the signal is probably confounding
     if (matchesLogin && matchesSignup) return;

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10753,7 +10753,7 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = `${window.location.pathname}${window.location.hash}`;
+    const path = window.location.href;
     const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
     const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10753,7 +10753,7 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = window.location.pathname;
+    const path = `${window.location.pathname}${window.location.hash}`;
     const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
     const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6587,7 +6587,7 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = `${window.location.pathname}${window.location.hash}`;
+    const path = window.location.href;
     const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
     const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6587,7 +6587,7 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = window.location.pathname;
+    const path = `${window.location.pathname}${window.location.hash}`;
     const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
     const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
 

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6587,9 +6587,14 @@ class FormAnalyzer {
     });
   }
   evaluateUrl() {
-    const path = window.location.href;
-    const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), path);
-    const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), path);
+    const {
+      pathname,
+      search,
+      hash
+    } = window.location;
+    const pathToMatch = pathname + search + hash.slice(0, 100);
+    const matchesLogin = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('loginRegex'), pathToMatch);
+    const matchesSignup = (0, _autofillUtils.safeRegexTest)(this.matching.getDDGMatcherRegex('conservativeSignupRegex'), pathToMatch);
 
     // If the url matches both, do nothing: the signal is probably confounding
     if (matchesLogin && matchesSignup) return;


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:**  https://app.asana.com/0/1205996472158114/1207793442006227/f

## Description
The chase.com logon form is currently not autofilling. This PR does two things:
1. Fixes the `FormAnalyser` to include `window.location.hash` part of the URL so that the form is correctly recognized as login. That fixes one problem that at least the input fields on focus are autofilling on their own
2. Adds a form and test case to reproduce the actual issue on chase.com. The form contains two `input` elements, and a submit button that are in shadow root, with the `form` element that is outside shadow root. (The test currently breaks, but we want to aim to fix it. Skipping it with a `@skip` annotation).

## Steps to test
