### PR TITLE
fix scanner performance regression + added test

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -14354,10 +14354,12 @@ class DefaultScanner {
         });
       }
     }
-    for (let [elem, instance] of this.forms) {
-      if (instance.hasOnlyUnknownFields) {
-        instance.destroy();
-        this.forms.delete(elem);
+
+    // Check for forms with too few 'known' inputs
+    // In the case where the only inputs are all 'unknown', we can destroy the form and stop tracking it.
+    for (let formInstance of this.forms.values()) {
+      if (formInstance.hasOnlyUnknownFields) {
+        formInstance.destroy();
       }
     }
     return this;

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -9807,20 +9807,16 @@ class Form {
     this.initFormListeners();
     this.categorizeInputs();
     this.logFormInfo();
-    const numKnownInputs = this.inputs.all.size - this.inputs.unknown.size;
-    if (numKnownInputs === 0) {
-      // This form has too few known inputs and likely doesn't make sense
-      // to track for autofill (e.g. a single-input for search or item quantity).
-      // Self-destruct to stop listening and avoid memory leaks.
-      if ((0, _autofillUtils.shouldLog)()) {
-        console.log(`Form discarded: zero inputs are fillable`);
-      }
-      this.destroy();
-      return;
-    }
     if (shouldAutoprompt) {
       this.promptLoginIfNeeded();
     }
+  }
+  get hasOnlyUnknownFields() {
+    const numKnownInputs = this.inputs.all.size - this.inputs.unknown.size;
+    if (numKnownInputs === 0) {
+      return true;
+    }
+    return false;
   }
 
   /** Whether this form has been destroyed via the `destroy` method or not. */
@@ -14358,6 +14354,12 @@ class DefaultScanner {
         });
       }
     }
+    for (let [elem, instance] of this.forms) {
+      if (instance.hasOnlyUnknownFields) {
+        instance.destroy();
+        this.forms.delete(elem);
+      }
+    }
     return this;
   }
 
@@ -14503,11 +14505,7 @@ class DefaultScanner {
 
       // Only add the form if below the limit of forms per page
       if (this.forms.size < this.options.maxFormsPerPage) {
-        const f = new _Form.Form(parentForm, input, this.device, this.matching, this.shouldAutoprompt);
-        // Also only add the form if it hasn't self-destructed due to having too few fields
-        if (!f.isDestroyed) {
-          this.forms.set(parentForm, f);
-        }
+        this.forms.set(parentForm, new _Form.Form(parentForm, input, this.device, this.matching, this.shouldAutoprompt));
       } else {
         this.stopScanner('The page has too many forms, stop adding them.');
       }

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -10188,10 +10188,12 @@ class DefaultScanner {
         });
       }
     }
-    for (let [elem, instance] of this.forms) {
-      if (instance.hasOnlyUnknownFields) {
-        instance.destroy();
-        this.forms.delete(elem);
+
+    // Check for forms with too few 'known' inputs
+    // In the case where the only inputs are all 'unknown', we can destroy the form and stop tracking it.
+    for (let formInstance of this.forms.values()) {
+      if (formInstance.hasOnlyUnknownFields) {
+        formInstance.destroy();
       }
     }
     return this;

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -1,4 +1,5 @@
 const localPagesPrefix = 'integration-test/pages'
+const testFormsPrefix = 'test-forms'
 const privacyTestPagesPrefix = 'node_modules/@duckduckgo/privacy-test-pages/autofill'
 /**
  * Try to use this a place to store re-used values across the integration tests.
@@ -25,6 +26,9 @@ export const constants = {
         'shadowDom': `${privacyTestPagesPrefix}/shadow-dom.html`,
         'selectInput': `${localPagesPrefix}/select-input.html`,
         'shadowInputsLogin': `${localPagesPrefix}/shadow-inputs-login.html`
+    },
+    forms: {
+        'www_ulisboa_pt_login.html': `${testFormsPrefix}/www_ulisboa_pt_login.html`
     },
     fields: {
         email: {

--- a/integration-test/tests/email-autofill.macos.spec.js
+++ b/integration-test/tests/email-autofill.macos.spec.js
@@ -361,7 +361,7 @@ test.describe('macos', () => {
             await defaultMacosScript(page)
 
             const perfPage = scannerPerf(page)
-            perfPage.navigate('pages/usps_signup.html')
+            await perfPage.navigate('pages/usps_signup.html')
 
             await perfPage.validateInitialScanPerf(200)
         })
@@ -371,7 +371,7 @@ test.describe('macos', () => {
             await defaultMacosScript(page)
 
             const perfPage = scannerPerf(page)
-            perfPage.navigate()
+            await perfPage.navigate()
 
             // In production, we expect autofill to bail on such a page
             await perfPage.validateInitialScanPerf(10)
@@ -390,7 +390,7 @@ test.describe('macos', () => {
                 .applyTo(page)
 
             const perfPage = scannerPerf(page)
-            perfPage.navigate()
+            await perfPage.navigate()
 
             await perfPage.validateInitialScanPerf(300)
         })
@@ -406,8 +406,29 @@ test.describe('macos', () => {
                 .applyTo(page)
 
             const perfPage = scannerPerf(page)
-            perfPage.navigate(constants.pages['perf-huge-regex'])
+            await perfPage.navigate(constants.pages['perf-huge-regex'])
 
+            await perfPage.validateInitialScanPerf(80)
+        })
+
+        /**
+         * See: https://app.asana.com/0/0/1207840563867787/f
+         *
+         * This covered a form with about 60 inputs, but none are deemed 'fillable'.
+         * In that case, we want to ensure we don't do any repeated work.
+         *
+         */
+        test.only('Large form without eligible inputs', async ({page}) => {
+            test.setTimeout(5000)
+            await createWebkitMocks().applyTo(page)
+            await createAutofillScript()
+                .replaceAll(macosContentScopeReplacements())
+                .platform('macos')
+                .applyTo(page)
+
+            const perfPage = scannerPerf(page)
+
+            await perfPage.navigate(constants.forms['www_ulisboa_pt_login.html'])
             await perfPage.validateInitialScanPerf(80)
         })
     })

--- a/integration-test/tests/email-autofill.macos.spec.js
+++ b/integration-test/tests/email-autofill.macos.spec.js
@@ -418,7 +418,7 @@ test.describe('macos', () => {
          * In that case, we want to ensure we don't do any repeated work.
          *
          */
-        test.only('Large form without eligible inputs', async ({page}) => {
+        test('Large form without eligible inputs', async ({page}) => {
             test.setTimeout(5000)
             await createWebkitMocks().applyTo(page)
             await createAutofillScript()

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -118,21 +118,18 @@ class Form {
 
         this.logFormInfo()
 
-        const numKnownInputs = this.inputs.all.size - this.inputs.unknown.size
-        if (numKnownInputs === 0) {
-            // This form has too few known inputs and likely doesn't make sense
-            // to track for autofill (e.g. a single-input for search or item quantity).
-            // Self-destruct to stop listening and avoid memory leaks.
-            if (shouldLog()) {
-                console.log(`Form discarded: zero inputs are fillable`)
-            }
-            this.destroy()
-            return
-        }
-
         if (shouldAutoprompt) {
             this.promptLoginIfNeeded()
         }
+    }
+
+    get hasOnlyUnknownFields () {
+        const numKnownInputs = this.inputs.all.size - this.inputs.unknown.size
+
+        if (numKnownInputs === 0) {
+            return true
+        }
+        return false
     }
 
     /** Whether this form has been destroyed via the `destroy` method or not. */

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -423,10 +423,10 @@ describe('Form bails', () => {
     <!-- A visible field for the number to purchase -->
     <input type="number" name="qty" title="Qty"/>
 </form>
-        `);
-        const int = InterfacePrototype.default();
-        int.scanner = createScanner(int);
-        int.scanner.findEligibleInputs(document);
+        `)
+        const int = InterfacePrototype.default()
+        int.scanner = createScanner(int)
+        int.scanner.findEligibleInputs(document)
         const formClass = int.scanner.forms.get(formEl)
         expect(formClass).not.toBeDefined()
         const decoratedInputs = document.querySelectorAll(`[${constants.ATTR_INPUT_TYPE}]`)

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -423,9 +423,11 @@ describe('Form bails', () => {
     <!-- A visible field for the number to purchase -->
     <input type="number" name="qty" title="Qty"/>
 </form>
-        `)
-        const scanner = createScanner(InterfacePrototype.default()).findEligibleInputs(document)
-        const formClass = scanner.forms.get(formEl)
+        `);
+        const int = InterfacePrototype.default();
+        int.scanner = createScanner(int);
+        int.scanner.findEligibleInputs(document);
+        const formClass = int.scanner.forms.get(formEl)
         expect(formClass).not.toBeDefined()
         const decoratedInputs = document.querySelectorAll(`[${constants.ATTR_INPUT_TYPE}]`)
         expect(decoratedInputs).toHaveLength(0)

--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -170,6 +170,15 @@ class DefaultScanner {
                 })
             }
         }
+
+        // Check for forms with too few 'known' inputs
+        // In the case where the only inputs are all 'unknown', we can destroy the form and stop tracking it.
+        for (let formInstance of this.forms.values()) {
+            if (formInstance.hasOnlyUnknownFields) {
+                formInstance.destroy()
+            }
+        }
+
         return this
     }
 
@@ -322,11 +331,7 @@ class DefaultScanner {
 
             // Only add the form if below the limit of forms per page
             if (this.forms.size < this.options.maxFormsPerPage) {
-                const f = new Form(parentForm, input, this.device, this.matching, this.shouldAutoprompt)
-                // Also only add the form if it hasn't self-destructed due to having too few fields
-                if (!f.isDestroyed) {
-                    this.forms.set(parentForm, f)
-                }
+                this.forms.set(parentForm, new Form(parentForm, input, this.device, this.matching, this.shouldAutoprompt))
             } else {
                 this.stopScanner('The page has too many forms, stop adding them.')
             }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -14354,10 +14354,12 @@ class DefaultScanner {
         });
       }
     }
-    for (let [elem, instance] of this.forms) {
-      if (instance.hasOnlyUnknownFields) {
-        instance.destroy();
-        this.forms.delete(elem);
+
+    // Check for forms with too few 'known' inputs
+    // In the case where the only inputs are all 'unknown', we can destroy the form and stop tracking it.
+    for (let formInstance of this.forms.values()) {
+      if (formInstance.hasOnlyUnknownFields) {
+        formInstance.destroy();
       }
     }
     return this;

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -9807,20 +9807,16 @@ class Form {
     this.initFormListeners();
     this.categorizeInputs();
     this.logFormInfo();
-    const numKnownInputs = this.inputs.all.size - this.inputs.unknown.size;
-    if (numKnownInputs === 0) {
-      // This form has too few known inputs and likely doesn't make sense
-      // to track for autofill (e.g. a single-input for search or item quantity).
-      // Self-destruct to stop listening and avoid memory leaks.
-      if ((0, _autofillUtils.shouldLog)()) {
-        console.log(`Form discarded: zero inputs are fillable`);
-      }
-      this.destroy();
-      return;
-    }
     if (shouldAutoprompt) {
       this.promptLoginIfNeeded();
     }
+  }
+  get hasOnlyUnknownFields() {
+    const numKnownInputs = this.inputs.all.size - this.inputs.unknown.size;
+    if (numKnownInputs === 0) {
+      return true;
+    }
+    return false;
   }
 
   /** Whether this form has been destroyed via the `destroy` method or not. */
@@ -14358,6 +14354,12 @@ class DefaultScanner {
         });
       }
     }
+    for (let [elem, instance] of this.forms) {
+      if (instance.hasOnlyUnknownFields) {
+        instance.destroy();
+        this.forms.delete(elem);
+      }
+    }
     return this;
   }
 
@@ -14503,11 +14505,7 @@ class DefaultScanner {
 
       // Only add the form if below the limit of forms per page
       if (this.forms.size < this.options.maxFormsPerPage) {
-        const f = new _Form.Form(parentForm, input, this.device, this.matching, this.shouldAutoprompt);
-        // Also only add the form if it hasn't self-destructed due to having too few fields
-        if (!f.isDestroyed) {
-          this.forms.set(parentForm, f);
-        }
+        this.forms.set(parentForm, new _Form.Form(parentForm, input, this.device, this.matching, this.shouldAutoprompt));
       } else {
         this.stopScanner('The page has too many forms, stop adding them.');
       }

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -10188,10 +10188,12 @@ class DefaultScanner {
         });
       }
     }
-    for (let [elem, instance] of this.forms) {
-      if (instance.hasOnlyUnknownFields) {
-        instance.destroy();
-        this.forms.delete(elem);
+
+    // Check for forms with too few 'known' inputs
+    // In the case where the only inputs are all 'unknown', we can destroy the form and stop tracking it.
+    for (let formInstance of this.forms.values()) {
+      if (formInstance.hasOnlyUnknownFields) {
+        formInstance.destroy();
       }
     }
     return this;


### PR DESCRIPTION
**Reviewer:** @dbajpeyi 
**Asana:** https://app.asana.com/0/0/1207840563867787/f

## Description

A previous PR caused the Form instance to be created & destroyed for every input found. In the example test case I added, this could be upto 60 times causing a large performance regression.

## Steps to test

An integration test was added. To verify, you can run this branch locally and remove my change in Scanner.js -> then the integration test will fail. 

**NOTE** There are some failing tests for input classifications - I think they'll need updating, but I havn't personally touched that part of the codebase for a long time, so I'd appreciate someone taking a look to see if the failures are valid.

![perf PR](https://github.com/user-attachments/assets/c407180e-2eb3-4876-b7d7-aa10dfce2ca3)
