### PR TITLE
[Form] allow reconciling full credential

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10507,7 +10507,9 @@ class Form {
       // reset this to its initial value
       this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     } else {
-      // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      // otherwise reset shouldPromptToStoreData to to initial value
+      this.resetShouldPromptToStoreData();
+      // and do autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;
     }
     this.device.postAutofill?.(data, dataType, this);

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6341,7 +6341,9 @@ class Form {
       // reset this to its initial value
       this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     } else {
-      // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      // otherwise reset shouldPromptToStoreData to to initial value
+      this.resetShouldPromptToStoreData();
+      // and do autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;
     }
     this.device.postAutofill?.(data, dataType, this);

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -862,7 +862,9 @@ class Form {
             // reset this to its initial value
             this.shouldAutoSubmit = this.device.globalConfig.isMobileApp
         } else {
-            // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
+            // otherwise reset shouldPromptToStoreData to to initial value
+            this.resetShouldPromptToStoreData()
+            // and do autosubmit because the experience is jarring
             this.shouldAutoSubmit = false
         }
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10507,7 +10507,9 @@ class Form {
       // reset this to its initial value
       this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     } else {
-      // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      // otherwise reset shouldPromptToStoreData to to initial value
+      this.resetShouldPromptToStoreData();
+      // and do autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;
     }
     this.device.postAutofill?.(data, dataType, this);

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6341,7 +6341,9 @@ class Form {
       // reset this to its initial value
       this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
     } else {
-      // …otherwise we will prompt and do not want to autosubmit because the experience is jarring
+      // otherwise reset shouldPromptToStoreData to to initial value
+      this.resetShouldPromptToStoreData();
+      // and do autosubmit because the experience is jarring
       this.shouldAutoSubmit = false;
     }
     this.device.postAutofill?.(data, dataType, this);


### PR DESCRIPTION
**Reviewer:**  @GioSensation @shakyShane 
**Asana:**  https://app.asana.com/0/72649045549333/1207436822504728/f

## Description
If there are unknown values at the time of form storing form data, reset the `shouldPromptToStoreData` value to the initial value so that it forces the device to trigger an update.

**PS**: Testing this with an integration seems is not super trivial, as we don't have a way to mock multiple credentials without changing the API. I'd do it, but it feels like out of scope for this problem. I have tested this manually, and rest of our test cases don't break - so confident that it's fine to go without automated tests.

## Steps to test
1. Go to fill.dev (or whatever other site)
2. Save one complete credential (username + password)
3. Save a form with just the password (happens often when updating passwords)
4. Now go to login
5. Fill username from the complete form
6. Fill password from the incomplete form
7. Submit
8. Go back to the login page, and autofill with the full credential
9. The autofill triggers with updated password,
10. The autofill UI also shows updated entry.

### Demo
https://github.com/user-attachments/assets/14724d05-7b76-4443-bde6-9cbb88ab23e2

<img width="602" alt="Screenshot 2024-08-06 at 14 28 00" src="https://github.com/user-attachments/assets/260cbf99-6e7d-4f86-bff8-57eb9753d5f0">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207436822504728