### PR TITLE
Avoid double settings.refresh on all pages

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -8696,8 +8696,7 @@ class InterfacePrototype {
   }
   async startInit() {
     if (this.isInitializationStarted) return;
-    this.alreadyInitialized = true;
-    await this.settings.refresh();
+    this.isInitializationStarted = true;
     this.addDeviceListeners();
     await this.setupAutofill();
     this.uiController = this.createUIController();

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4530,8 +4530,7 @@ class InterfacePrototype {
   }
   async startInit() {
     if (this.isInitializationStarted) return;
-    this.alreadyInitialized = true;
-    await this.settings.refresh();
+    this.isInitializationStarted = true;
     this.addDeviceListeners();
     await this.setupAutofill();
     this.uiController = this.createUIController();

--- a/src/DeviceInterface/InterfacePrototype.js
+++ b/src/DeviceInterface/InterfacePrototype.js
@@ -269,9 +269,7 @@ class InterfacePrototype {
     async startInit () {
         if (this.isInitializationStarted) return
 
-        this.alreadyInitialized = true
-
-        await this.settings.refresh()
+        this.isInitializationStarted = true
 
         this.addDeviceListeners()
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -8696,8 +8696,7 @@ class InterfacePrototype {
   }
   async startInit() {
     if (this.isInitializationStarted) return;
-    this.alreadyInitialized = true;
-    await this.settings.refresh();
+    this.isInitializationStarted = true;
     this.addDeviceListeners();
     await this.setupAutofill();
     this.uiController = this.createUIController();

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -4530,8 +4530,7 @@ class InterfacePrototype {
   }
   async startInit() {
     if (this.isInitializationStarted) return;
-    this.alreadyInitialized = true;
-    await this.settings.refresh();
+    this.isInitializationStarted = true;
     this.addDeviceListeners();
     await this.setupAutofill();
     this.uiController = this.createUIController();


### PR DESCRIPTION
**Reviewer:** @dbajpeyi 
**Asana:** 

## Description
Avoids calling settings.refresh twice in a row, plus makes a safeguard actually work (there was a init check with the wrong name 🤦‍♂️).

## Steps to test
Integration tests should cover everything, but also it'd be good to smoke-test further.