### PR TITLE
[GH Actions] upgrade checkout/action to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run test:integration:ci
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-results
           path: test-results


### PR DESCRIPTION
**Reviewer:**  @GioSensation 
**Asana:** 

## Description
It seems like GH actions actions/upload-artifacts are on v3, and [deprecation started in June](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/). Now we're getting exceptions thrown on our PRs, so we should get them up to the latest, https://github.com/duckduckgo/duckduckgo-autofill/actions/runs/10880025511/job/30185927694?pr=652

I couldn't find `download-artifact`, so this seems to be the only one needed.

## Steps to test
