### PR TITLE
[Autofill] Remove caching from getAvailableInputTypes

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -15081,9 +15081,6 @@ class Settings {
       if (this.globalConfig.isTopFrame) {
         return Settings.defaults.availableInputTypes;
       }
-      if (this._availableInputTypes) {
-        return this.availableInputTypes;
-      }
       return await this.deviceApi.request(new _deviceApiCalls.GetAvailableInputTypesCall(null));
     } catch (e) {
       if (this.globalConfig.isDDGTestMode) {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -10915,9 +10915,6 @@ class Settings {
       if (this.globalConfig.isTopFrame) {
         return Settings.defaults.availableInputTypes;
       }
-      if (this._availableInputTypes) {
-        return this.availableInputTypes;
-      }
       return await this.deviceApi.request(new _deviceApiCalls.GetAvailableInputTypesCall(null));
     } catch (e) {
       if (this.globalConfig.isDDGTestMode) {

--- a/integration-test/helpers/mocks.android.js
+++ b/integration-test/helpers/mocks.android.js
@@ -80,6 +80,7 @@ export function createAndroidMocks () {
         getAutofillData: null,
         showInContextEmailProtectionSignupPrompt: { isSignedIn: true },
         incontextSignupDismissedAt: {},
+        getAvailableInputTypes: {},
         /** @type {{alias: string}|null} */
         address: null,
         isSignedIn: ''
@@ -213,6 +214,10 @@ export function createAndroidMocks () {
                         response: mocks.getAutofillData
                     },
                     {callName: 'storeFormData'},
+                    {
+                        callName: 'getAvailableInputTypes',
+                        response: mocks.getAvailableInputTypes
+                    },
                     {
                         callName: 'getIncontextSignupDismissedAt',
                         response: mocks.incontextSignupDismissedAt

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -160,10 +160,6 @@ export class Settings {
                 return Settings.defaults.availableInputTypes
             }
 
-            if (this._availableInputTypes) {
-                return this.availableInputTypes
-            }
-
             return await this.deviceApi.request(new GetAvailableInputTypesCall(null))
         } catch (e) {
             if (this.globalConfig.isDDGTestMode) {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -15081,9 +15081,6 @@ class Settings {
       if (this.globalConfig.isTopFrame) {
         return Settings.defaults.availableInputTypes;
       }
-      if (this._availableInputTypes) {
-        return this.availableInputTypes;
-      }
       return await this.deviceApi.request(new _deviceApiCalls.GetAvailableInputTypesCall(null));
     } catch (e) {
       if (this.globalConfig.isDDGTestMode) {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -10915,9 +10915,6 @@ class Settings {
       if (this.globalConfig.isTopFrame) {
         return Settings.defaults.availableInputTypes;
       }
-      if (this._availableInputTypes) {
-        return this.availableInputTypes;
-      }
       return await this.deviceApi.request(new _deviceApiCalls.GetAvailableInputTypesCall(null));
     } catch (e) {
       if (this.globalConfig.isDDGTestMode) {


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:**  https://app.asana.com/0/0/1208539108786973/f

## Description
There are occasions where we want to be able to refresh availableInput types, when we know that new available types are available from the native side. E.g when `refreshAvailableInputTypes` is sent back for `getAutofillData` call. This is needed for credentials import prompt, when after finishing the import or after clicking on "Don't show again" button, we want to permanently dismiss the prompt (even before user has refreshed the page).
 
## Steps to test
1. Build mac on branch `graeme/enable-import-prompt-for-all-users`,
2. Refresh autofill data and set activation date to today from debug menu,
3. You will see the import prompt, click on dismiss,
4. Prompt should be permanently dismissed.
