### PR TITLE
[Credentials import] Update copy for dismiss button

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -19451,8 +19451,8 @@ module.exports={
     "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
   },
   "dontShowAgain": {
-    "title": "Don't Show Again",
-    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+    "title": "Don't show again",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt and credentials import prompt from appearing again."
   },
   "credentialsImportHeading": {
     "title": "Import passwords to DuckDuckGo",

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -14923,8 +14923,8 @@ module.exports={
     "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
   },
   "dontShowAgain": {
-    "title": "Don't Show Again",
-    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+    "title": "Don't show again",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt and credentials import prompt from appearing again."
   },
   "credentialsImportHeading": {
     "title": "Import passwords to DuckDuckGo",

--- a/src/locales/en/autofill.json
+++ b/src/locales/en/autofill.json
@@ -86,8 +86,8 @@
     "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
   },
   "dontShowAgain": {
-    "title": "Don't Show Again",
-    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+    "title": "Don't show again",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt and credentials import prompt from appearing again."
   },
   "credentialsImportHeading": {
     "title": "Import passwords to DuckDuckGo",

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -19451,8 +19451,8 @@ module.exports={
     "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
   },
   "dontShowAgain": {
-    "title": "Don't Show Again",
-    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+    "title": "Don't show again",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt and credentials import prompt from appearing again."
   },
   "credentialsImportHeading": {
     "title": "Import passwords to DuckDuckGo",

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -14923,8 +14923,8 @@ module.exports={
     "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
   },
   "dontShowAgain": {
-    "title": "Don't Show Again",
-    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+    "title": "Don't show again",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt and credentials import prompt from appearing again."
   },
   "credentialsImportHeading": {
     "title": "Import passwords to DuckDuckGo",


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/38424471409662/1208548547519457/f

## Description
Updating the copy "Don't Show Again" button -> "Don't show again". Most other languages are already using proper casing. Also originally this button was being used in _email protection prompt,_ , but we don't use that anymore so it should be okay to update.

<img width="796" alt="Screenshot 2024-10-17 at 16 38 59" src="https://github.com/user-attachments/assets/1aeefe4c-47d6-4f0d-a9ed-da333cc8356c">


## Steps to test
1. Build with `graeme/enable-import-prompt-for-all-users` on Mac,
2. Reset autofill data, change activation date to today,
3. Click on login field in https://fill.dev/form/login-simple