### PR TITLE
[Matching] Add 'search' for forceUnknown

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12692,7 +12692,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
         password: {
           match: /password|passwort|kennwort|wachtwoord|mot de passe|clave|contraseña|lösenord/iu,
           skip: /email|one-time|error|hint|^username$/iu,
-          forceUnknown: /captcha|mfa|2fa|two factor|otp|pin/iu
+          forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
           match: /new|re.?(enter|type)|repeat|update\b/iu

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8526,7 +8526,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
         password: {
           match: /password|passwort|kennwort|wachtwoord|mot de passe|clave|contraseña|lösenord/iu,
           skip: /email|one-time|error|hint|^username$/iu,
-          forceUnknown: /captcha|mfa|2fa|two factor|otp|pin/iu
+          forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
           match: /new|re.?(enter|type)|repeat|update\b/iu

--- a/src/Form/matching-config/__generated__/compiled-matching-config.js
+++ b/src/Form/matching-config/__generated__/compiled-matching-config.js
@@ -247,7 +247,7 @@ const matchingConfiguration = {
         password: {
           match: /password|passwort|kennwort|wachtwoord|mot de passe|clave|contraseña|lösenord/iu,
           skip: /email|one-time|error|hint|^username$/iu,
-          forceUnknown: /captcha|mfa|2fa|two factor|otp|pin/iu
+          forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: { match: /new|re.?(enter|type)|repeat|update\b/iu },
         currentPassword: { match: /current|old|previous|expired|existing/iu },

--- a/src/Form/matching-config/matching-config-source.js
+++ b/src/Form/matching-config/matching-config-source.js
@@ -265,7 +265,7 @@ const matchingConfiguration = {
                         // Swedish
                         '|lösenord',
                     skip: 'email|one-time|error|hint|^username$',
-                    forceUnknown: 'captcha|mfa|2fa|two factor|otp|pin'
+                    forceUnknown: 'search|captcha|mfa|2fa|two factor|otp|pin'
                 },
                 newPassword: {
                     match: 'new|re.?(enter|type)|repeat|update\\b'

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -12692,7 +12692,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
         password: {
           match: /password|passwort|kennwort|wachtwoord|mot de passe|clave|contraseña|lösenord/iu,
           skip: /email|one-time|error|hint|^username$/iu,
-          forceUnknown: /captcha|mfa|2fa|two factor|otp|pin/iu
+          forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
           match: /new|re.?(enter|type)|repeat|update\b/iu

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -8526,7 +8526,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
         password: {
           match: /password|passwort|kennwort|wachtwoord|mot de passe|clave|contraseña|lösenord/iu,
           skip: /email|one-time|error|hint|^username$/iu,
-          forceUnknown: /captcha|mfa|2fa|two factor|otp|pin/iu
+          forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
           match: /new|re.?(enter|type)|repeat|update\b/iu

--- a/test-forms/google_password_manager_search.html
+++ b/test-forms/google_password_manager_search.html
@@ -1,0 +1,31 @@
+<div class="QJfW3">
+    <div class="rFrNMe L9di L3JtQc zKHdkd u3bW4e" jscontroller="pxq3x" jsaction="clickonly:KjsqPd; focus:Jt1EX; blur:fpfTEe; input:Lg5SV" jsshadow="" jsname="btrqz">
+       <div class="aCsJod oJeWuf">
+          <div class="aXBtI I0VJ4d Wic03c">
+             <span jsslot="" class="A37UZe qgcB3c iHd5yb">
+                <div class="VfPpkd-Bz112c-LgbsSe yHy1rc eT1oJ QDwDD mN1ivc BeY8ie" jscontroller="nKuFpb" jsaction="click:cOuCgd; mousedown:UX7yZ; mouseup:lbsD7e; mouseenter:tfO1Yc; mouseleave:JywGue; touchstart:p6p2H; touchmove:FwuNnf; touchend:yfqBxc; touchcancel:JMtRjd; focus:AHmuwe; blur:O22p3e; contextmenu:mg9Pef;mlnRJb:fLiPzd;" data-idom-class="yHy1rc eT1oJ QDwDD mN1ivc BeY8ie" style="--mdc-ripple-fg-size: 28px; --mdc-ripple-fg-scale: 1.7142857142857142; --mdc-ripple-left: 10px; --mdc-ripple-top: 10px;">
+                   <div jsname="s3Eaab" class="VfPpkd-Bz112c-Jh9lGc"></div>
+                   <i class="google-material-icons" aria-hidden="true">arrow_back</i><a class="WpHeLc VfPpkd-mRLv6" href="?ep=1&amp;f.sid=5221294659451512461" aria-label="Back" jsname="hSRGPd" data-focusid="6"></a>
+                   <div class="VfPpkd-Bz112c-J1Ukfc-LhBDec"></div>
+                </div>
+             </span>
+             <div class="Xb9hP">
+                <input type="text" class="whsOnd zHQkBf" jsname="YPqjbf" autocomplete="off" tabindex="0" aria-label="Search passwords" aria-disabled="false" autofocus="" data-initial-value="" data-ddg-inputtype="unknown">
+                <div jsname="LwH6nd" class="ndJi5d snByac" aria-hidden="true" data-manual-scoring="unknown">Search passwords</div>
+             </div>
+             <span jsslot="" class="A37UZe sxyYjd MQL3Ob">
+                <button class="VfPpkd-Bz112c-LgbsSe yHy1rc eT1oJ mN1ivc T7G6Pe FwqFJb" jscontroller="soHxf" jsaction="click:cOuCgd; mousedown:UX7yZ; mouseup:lbsD7e; mouseenter:tfO1Yc; mouseleave:JywGue; touchstart:p6p2H; touchmove:FwuNnf; touchend:yfqBxc; touchcancel:JMtRjd; focus:AHmuwe; blur:O22p3e; contextmenu:mg9Pef;mlnRJb:fLiPzd;" data-idom-class="yHy1rc eT1oJ mN1ivc T7G6Pe FwqFJb" jsname="pZn8Oc" aria-label="Clear search keyword.">
+                   <div jsname="s3Eaab" class="VfPpkd-Bz112c-Jh9lGc"></div>
+                   <div class="VfPpkd-Bz112c-J1Ukfc-LhBDec"></div>
+                   <i class="google-material-icons" aria-hidden="true">close</i>
+                </button>
+             </span>
+             <div class="i9lrp mIZh1c"></div>
+             <div jsname="XmnwAc" class="OabDMe cXrdqd Y2Zypf" style="transform-origin: 146px center;"></div>
+          </div>
+       </div>
+       <div class="LXRPh">
+          <div jsname="ty6ygf" class="ovnfwe Is7Fhb"></div>
+       </div>
+    </div>
+ </div>

--- a/test-forms/google_password_manager_search.html
+++ b/test-forms/google_password_manager_search.html
@@ -10,8 +10,8 @@
                 </div>
              </span>
              <div class="Xb9hP">
-                <input type="text" class="whsOnd zHQkBf" jsname="YPqjbf" autocomplete="off" tabindex="0" aria-label="Search passwords" aria-disabled="false" autofocus="" data-initial-value="" data-ddg-inputtype="unknown">
-                <div jsname="LwH6nd" class="ndJi5d snByac" aria-hidden="true" data-manual-scoring="unknown">Search passwords</div>
+                <input type="text" class="whsOnd zHQkBf" jsname="YPqjbf" autocomplete="off" tabindex="0" aria-label="Search passwords" aria-disabled="false" autofocus="" data-initial-value="" data-manual-scoring="unknown">
+                <div jsname="LwH6nd" class="ndJi5d snByac" aria-hidden="true">Search passwords</div>
              </div>
              <span jsslot="" class="A37UZe sxyYjd MQL3Ob">
                 <button class="VfPpkd-Bz112c-LgbsSe yHy1rc eT1oJ mN1ivc T7G6Pe FwqFJb" jscontroller="soHxf" jsaction="click:cOuCgd; mousedown:UX7yZ; mouseup:lbsD7e; mouseenter:tfO1Yc; mouseleave:JywGue; touchstart:p6p2H; touchmove:FwuNnf; touchend:yfqBxc; touchcancel:JMtRjd; focus:AHmuwe; blur:O22p3e; contextmenu:mg9Pef;mlnRJb:fLiPzd;" data-idom-class="yHy1rc eT1oJ mN1ivc T7G6Pe FwqFJb" jsname="pZn8Oc" aria-label="Clear search keyword.">

--- a/test-forms/index.json
+++ b/test-forms/index.json
@@ -545,5 +545,7 @@
   { "html": "malta-taxes-payment-form.html", "expectedFailures": ["expirationMonth", "expirationYear", "cardSecurityCode"] },
   { "html": "single-select-form.html" },
   { "html": "camelcamelcamel_login.html" },
-  { "html": "accounts_oneplus_login.html"}
+  { "html": "accounts_oneplus_login.html"},
+  { "html": "google_password_manager_search.html"}
+
 ]


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/1205996472158114/1208334053998373/f

## Description
Google password manager's search gets matched as password:
![image](https://github.com/user-attachments/assets/1ee10eb5-5e12-4f91-be5f-8c37eea9fa9c)

Adding it to `forceUnknown` to negate the matcher.

## Steps to test
1. Build with mac,
2. Go to https://passwords.google.com
3. Sign-in if you haven't,
4. On the landing page after sign in - you will not see the key icon.
