### PR TITLE
[DeviceInterface] Call closeautofillparent only after openManage calls

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -16581,25 +16581,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
   /**
    * Called when clicking on the Manage… button in the html tooltip
-   *
    * @param {SupportedMainTypes} type
    * @returns {*}
    * @private
    */
   _onManage(type) {
-    this.removeTooltip();
     switch (type) {
       case 'credentials':
-        return this._options.device.openManagePasswords();
+        this._options.device.openManagePasswords();
+        break;
       case 'creditCards':
-        return this._options.device.openManageCreditCards();
+        this._options.device.openManageCreditCards();
+        break;
       case 'identities':
-        return this._options.device.openManageIdentities();
+        this._options.device.openManageIdentities();
+        break;
       default:
       // noop
     }
-  }
 
+    this.removeTooltip();
+  }
   _onIncontextSignupDismissed(_ref) {
     let {
       hasOtherOptions

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -12218,25 +12218,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
   /**
    * Called when clicking on the Manage… button in the html tooltip
-   *
    * @param {SupportedMainTypes} type
    * @returns {*}
    * @private
    */
   _onManage(type) {
-    this.removeTooltip();
     switch (type) {
       case 'credentials':
-        return this._options.device.openManagePasswords();
+        this._options.device.openManagePasswords();
+        break;
       case 'creditCards':
-        return this._options.device.openManageCreditCards();
+        this._options.device.openManageCreditCards();
+        break;
       case 'identities':
-        return this._options.device.openManageIdentities();
+        this._options.device.openManageIdentities();
+        break;
       default:
       // noop
     }
-  }
 
+    this.removeTooltip();
+  }
   _onIncontextSignupDismissed(_ref) {
     let {
       hasOtherOptions

--- a/src/UI/controllers/HTMLTooltipUIController.js
+++ b/src/UI/controllers/HTMLTooltipUIController.js
@@ -328,23 +328,25 @@ export class HTMLTooltipUIController extends UIController {
 
     /**
      * Called when clicking on the Manage… button in the html tooltip
-     *
      * @param {SupportedMainTypes} type
      * @returns {*}
      * @private
      */
     _onManage(type) {
-        this.removeTooltip();
         switch (type) {
             case 'credentials':
-                return this._options.device.openManagePasswords();
+                this._options.device.openManagePasswords();
+                break;
             case 'creditCards':
-                return this._options.device.openManageCreditCards();
+                this._options.device.openManageCreditCards();
+                break;
             case 'identities':
-                return this._options.device.openManageIdentities();
+                this._options.device.openManageIdentities();
+                break;
             default:
             // noop
         }
+        this.removeTooltip();
     }
 
     _onIncontextSignupDismissed({ hasOtherOptions }) {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -16581,25 +16581,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
   /**
    * Called when clicking on the Manage… button in the html tooltip
-   *
    * @param {SupportedMainTypes} type
    * @returns {*}
    * @private
    */
   _onManage(type) {
-    this.removeTooltip();
     switch (type) {
       case 'credentials':
-        return this._options.device.openManagePasswords();
+        this._options.device.openManagePasswords();
+        break;
       case 'creditCards':
-        return this._options.device.openManageCreditCards();
+        this._options.device.openManageCreditCards();
+        break;
       case 'identities':
-        return this._options.device.openManageIdentities();
+        this._options.device.openManageIdentities();
+        break;
       default:
       // noop
     }
-  }
 
+    this.removeTooltip();
+  }
   _onIncontextSignupDismissed(_ref) {
     let {
       hasOtherOptions

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -12218,25 +12218,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
   /**
    * Called when clicking on the Manage… button in the html tooltip
-   *
    * @param {SupportedMainTypes} type
    * @returns {*}
    * @private
    */
   _onManage(type) {
-    this.removeTooltip();
     switch (type) {
       case 'credentials':
-        return this._options.device.openManagePasswords();
+        this._options.device.openManagePasswords();
+        break;
       case 'creditCards':
-        return this._options.device.openManageCreditCards();
+        this._options.device.openManageCreditCards();
+        break;
       case 'identities':
-        return this._options.device.openManageIdentities();
+        this._options.device.openManageIdentities();
+        break;
       default:
       // noop
     }
-  }
 
+    this.removeTooltip();
+  }
   _onIncontextSignupDismissed(_ref) {
     let {
       hasOtherOptions


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:**  https://app.asana.com/0/1203822806345703/1208958786488368/f

## Description
On windows `IWebView` disposes after `closeAutofillParent` more efficiently (since https://github.com/duckduckgo/windows-browser/pull/2658/files#diff-e9708afe1dc71c217b0379bc7531fd02309a7ce40e69ce7e60e3bed7edde1160) now causing `openManagePasswords` call to be late. This causes native password manager UI to not open.

This PR changes the sequence of `closeAutofillParent` and `openPasswordManager` calls. Note that this will also affect MacOS, but so far there doesn't seem to be any regression with manual testing.

## Steps to test
1. Go to `windows-browser` repo,
2. Update duckduckgo-autofill submodule to use `dbajpeyi/fix/manage-password-race-condition`
3. Build the browser,
4. Go to https://autofill.me/form/registration-email and try to open password manager from the autofill prompt.
5. The manage prompt should open! 
