### PR TITLE
[Matching] Update regex to match for 'confirm password'

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12894,7 +12894,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
-          match: /new|re.?(enter|type)|repeat|update\b/iu
+          match: /new|confirm|re.?(enter|type)|repeat|update\b/iu
         },
         currentPassword: {
           match: /current|old|previous|expired|existing/iu

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8531,7 +8531,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
-          match: /new|re.?(enter|type)|repeat|update\b/iu
+          match: /new|confirm|re.?(enter|type)|repeat|update\b/iu
         },
         currentPassword: {
           match: /current|old|previous|expired|existing/iu

--- a/src/Form/matching-config/__generated__/compiled-matching-config.js
+++ b/src/Form/matching-config/__generated__/compiled-matching-config.js
@@ -249,7 +249,7 @@ const matchingConfiguration = {
           skip: /email|one-time|error|hint|^username$/iu,
           forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
-        newPassword: { match: /new|re.?(enter|type)|repeat|update\b/iu },
+        newPassword: { match: /new|confirm|re.?(enter|type)|repeat|update\b/iu },
         currentPassword: { match: /current|old|previous|expired|existing/iu },
         username: {
           match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,

--- a/src/Form/matching-config/matching-config-source.js
+++ b/src/Form/matching-config/matching-config-source.js
@@ -271,7 +271,7 @@ const matchingConfiguration = {
                     forceUnknown: 'search|captcha|mfa|2fa|two factor|otp|pin',
                 },
                 newPassword: {
-                    match: 'new|re.?(enter|type)|repeat|update\\b',
+                    match: 'new|confirm|re.?(enter|type)|repeat|update\\b',
                 },
                 currentPassword: {
                     match: 'current|old|previous|expired|existing',

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -12894,7 +12894,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
-          match: /new|re.?(enter|type)|repeat|update\b/iu
+          match: /new|confirm|re.?(enter|type)|repeat|update\b/iu
         },
         currentPassword: {
           match: /current|old|previous|expired|existing/iu

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -8531,7 +8531,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           forceUnknown: /search|captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
-          match: /new|re.?(enter|type)|repeat|update\b/iu
+          match: /new|confirm|re.?(enter|type)|repeat|update\b/iu
         },
         currentPassword: {
           match: /current|old|previous|expired|existing/iu

--- a/test-forms/deltamath_reset_password.html
+++ b/test-forms/deltamath_reset_password.html
@@ -1,0 +1,32 @@
+<form class="update-password-form container">
+   <div class="row">
+      <div class="column">
+         <div class="rmd-text-field-container rmd-text-field-container--outline rmd-text-field-container--hoverable rmd-text-field-container--label">
+            <label class="rmd-label rmd-floating-label" for="new-password-text-field">New Password</label>
+            <input id="new-password-text-field" name="newPasswordTextField" type="password" class="rmd-text-field rmd-text-field--floating" data-manual-scoring="password.new">
+         </div>
+      </div>
+   </div>
+   <div class="row">
+      <div class="column">
+         <div class="rmd-text-field-container rmd-text-field-container--outline rmd-text-field-container--hoverable rmd-text-field-container--label">
+            <label class="rmd-label rmd-floating-label" for="confirm-password-text-field">Confirm Password</label>
+            <input id="confirm-password-text-field" name="confirmPasswordTextField" type="password" class="rmd-text-field rmd-text-field--floating" data-manual-scoring="password.new">
+         </div>
+      </div>
+   </div>
+   <div class="error-row">
+      <div class="column"></div>
+   </div>
+   <div class="row submit-row">
+      <div class="column">
+         <button type="submit" class="rmd-button rmd-button--text rmd-button--disabled form-submit-btn" data-manual-submit>
+            Reset Password
+            <span class="rmd-ripple-container"></span>
+         </button>
+      </div>
+   </div>
+   <div class="row">
+      <div class="column"></div>
+   </div>
+</form>

--- a/test-forms/index.json
+++ b/test-forms/index.json
@@ -547,5 +547,6 @@
   { "html": "camelcamelcamel_login.html" },
   { "html": "accounts_oneplus_login.html"},
   { "html": "google_password_manager_search.html"},
-  { "html": "paperlesspost_login.html"}
+  { "html": "paperlesspost_login.html"},
+  { "html": "deltamath_reset_password.html"}
 ]


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/0/1205996472158114/1208965688770983/f

## Description
"Confirm password" doesn't match the `newPassword` regex test, causing the field type to be password.current. This PR updates the regex, no regression is obvious.

## Steps to test
Can be tested on `deltamath.com`'s reset password flow, you need an account (a teacher account is free to create), to trigger the forgot password link.

<img width="830" alt="Screenshot 2024-12-17 at 10 10 18" src="https://github.com/user-attachments/assets/0e21b613-9826-41a9-b0c0-0bd4a3ff770f" />
<img width="739" alt="Screenshot 2024-12-17 at 10 11 03" src="https://github.com/user-attachments/assets/92dfd227-bfde-4c3b-87f4-9ddc9a011b48" />
