### PR TITLE
[CredentialsImport] Call credentials flow call first, and then close parent

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -7769,8 +7769,8 @@ class CredentialsImport {
     activeInput?.focus();
   }
   async started() {
-    this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
     this.device.deviceApi.notify(new _deviceApiCalls.StartCredentialsImportFlowCall({}));
+    this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
   }
   async dismissed() {
     this.device.deviceApi.notify(new _deviceApiCalls.CredentialsImportFlowPermanentlyDismissedCall(null));

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -3406,8 +3406,8 @@ class CredentialsImport {
     activeInput?.focus();
   }
   async started() {
-    this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
     this.device.deviceApi.notify(new _deviceApiCalls.StartCredentialsImportFlowCall({}));
+    this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
   }
   async dismissed() {
     this.device.deviceApi.notify(new _deviceApiCalls.CredentialsImportFlowPermanentlyDismissedCall(null));

--- a/src/CredentialsImport.js
+++ b/src/CredentialsImport.js
@@ -59,8 +59,8 @@ class CredentialsImport {
     }
 
     async started() {
-        this.device.deviceApi.notify(new CloseAutofillParentCall(null));
         this.device.deviceApi.notify(new StartCredentialsImportFlowCall({}));
+        this.device.deviceApi.notify(new CloseAutofillParentCall(null));
     }
 
     async dismissed() {

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -7769,8 +7769,8 @@ class CredentialsImport {
     activeInput?.focus();
   }
   async started() {
-    this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
     this.device.deviceApi.notify(new _deviceApiCalls.StartCredentialsImportFlowCall({}));
+    this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
   }
   async dismissed() {
     this.device.deviceApi.notify(new _deviceApiCalls.CredentialsImportFlowPermanentlyDismissedCall(null));

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -3406,8 +3406,8 @@ class CredentialsImport {
     activeInput?.focus();
   }
   async started() {
-    this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
     this.device.deviceApi.notify(new _deviceApiCalls.StartCredentialsImportFlowCall({}));
+    this.device.deviceApi.notify(new _deviceApiCalls.CloseAutofillParentCall(null));
   }
   async dismissed() {
     this.device.deviceApi.notify(new _deviceApiCalls.CredentialsImportFlowPermanentlyDismissedCall(null));


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:**  https://app.asana.com/0/1203822806345703/1208958786488368/f

## Description
On windows `IWebView` disposes after `closeAutofillParent` more efficiently (since https://github.com/duckduckgo/windows-browser/pull/2658/files#diff-e9708afe1dc71c217b0379bc7531fd02309a7ce40e69ce7e60e3bed7edde1160) now causing `startCredentialsImportFlow` call to be late. This causes the native import flow UI to not open anymore.

This PR changes the sequence of `closeAutofillParent` and `startCredentialsImportFlow` calls. Note that this will also affect MacOS, it does affect MAC a little bit as the parent closes a bit later than the import prompt. I think it's not bad enough, and doesn't call for multiple implementations

**Tests**

- [x] Tested on Mac

(Before)

https://github.com/user-attachments/assets/c90ba225-4ab7-41c4-8523-aac2ae5d6005

(After, regression in UX?)

https://github.com/user-attachments/assets/1ecf3ed6-7376-4f8b-9d94-a3bf275c05b0


- [x] Tested on Windows

https://github.com/user-attachments/assets/f7501308-b27b-4693-836d-7d421c4262b0

