### PR TITLE
[FormAnalyzer] add external link check for submit buttons

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -11201,7 +11201,7 @@ class FormAnalyzer {
     // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
     const isElementLikelyALink = el => {
       if (el == null) return false;
-      return el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
+      return el instanceof HTMLAnchorElement && el.href && !el.getAttribute('href')?.startsWith('#') || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
     };
     return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
   }

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -11188,20 +11188,22 @@ class FormAnalyzer {
   }
 
   /**
-   * Function that checks if the element is an external link or a custom web element that
-   * encapsulates a link.
+   * Function that checks if the element is link like and navigating away from the current page
    * @param {any} el
    * @returns {boolean}
    */
-  isElementExternalLink(el) {
+  isOutboundLink(el) {
     // Checks if the element is present in the cusotm elements registry and ends with a '-link' suffix.
     // If it does, it checks if it contains an anchor element inside.
     const tagName = el.nodeName.toLowerCase();
     const isCustomWebElementLink = customElements?.get(tagName) != null && /-link$/.test(tagName) && (0, _autofillUtils.findElementsInShadowTree)(el, 'a').length > 0;
 
     // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
-    const isElementLink = el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
-    return isCustomWebElementLink || isElementLink;
+    const isElementLikelyALink = el => {
+      if (el == null) return false;
+      return el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
+    };
+    return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
   }
   evaluateElement(el) {
     const string = (0, _autofillUtils.getTextShallow)(el);
@@ -11228,9 +11230,19 @@ class FormAnalyzer {
           }
         });
       } else {
-        // Here we don't think this is a submit, so if there is another submit in the form, flip the score
-        const thereIsASubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
-        shouldFlip = thereIsASubmitButton && this.shouldFlipScoreForButtonText(string);
+        // Here we don't think this is a submit, so determine if we should flip the score
+        const hasAnotherSubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
+        const buttonText = string;
+        if (hasAnotherSubmitButton) {
+          // If there's another submit button, flip based on text content alone
+          shouldFlip = this.shouldFlipScoreForButtonText(buttonText);
+        } else {
+          // With no submit button, only flip if it's an outbound link that navigates away, and also match the text
+          // Here we want to be more conservative, because we don't want to flip for every link given that there was no
+          // submit button detected on the form, hence the extra check for the link.
+          const isOutboundLink = this.isOutboundLink(el);
+          shouldFlip = isOutboundLink && this.shouldFlipScoreForButtonText(buttonText);
+        }
       }
       const strength = likelyASubmit ? 20 : 4;
       this.updateSignal({
@@ -11241,7 +11253,7 @@ class FormAnalyzer {
       });
       return;
     }
-    if (this.isElementExternalLink(el)) {
+    if (this.isOutboundLink(el)) {
       let shouldFlip = true;
       let strength = 1;
       // Don't flip forgotten password links

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6838,7 +6838,7 @@ class FormAnalyzer {
     // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
     const isElementLikelyALink = el => {
       if (el == null) return false;
-      return el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
+      return el instanceof HTMLAnchorElement && el.href && !el.getAttribute('href')?.startsWith('#') || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
     };
     return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
   }

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6825,20 +6825,22 @@ class FormAnalyzer {
   }
 
   /**
-   * Function that checks if the element is an external link or a custom web element that
-   * encapsulates a link.
+   * Function that checks if the element is link like and navigating away from the current page
    * @param {any} el
    * @returns {boolean}
    */
-  isElementExternalLink(el) {
+  isOutboundLink(el) {
     // Checks if the element is present in the cusotm elements registry and ends with a '-link' suffix.
     // If it does, it checks if it contains an anchor element inside.
     const tagName = el.nodeName.toLowerCase();
     const isCustomWebElementLink = customElements?.get(tagName) != null && /-link$/.test(tagName) && (0, _autofillUtils.findElementsInShadowTree)(el, 'a').length > 0;
 
     // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
-    const isElementLink = el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
-    return isCustomWebElementLink || isElementLink;
+    const isElementLikelyALink = el => {
+      if (el == null) return false;
+      return el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
+    };
+    return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
   }
   evaluateElement(el) {
     const string = (0, _autofillUtils.getTextShallow)(el);
@@ -6865,9 +6867,19 @@ class FormAnalyzer {
           }
         });
       } else {
-        // Here we don't think this is a submit, so if there is another submit in the form, flip the score
-        const thereIsASubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
-        shouldFlip = thereIsASubmitButton && this.shouldFlipScoreForButtonText(string);
+        // Here we don't think this is a submit, so determine if we should flip the score
+        const hasAnotherSubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
+        const buttonText = string;
+        if (hasAnotherSubmitButton) {
+          // If there's another submit button, flip based on text content alone
+          shouldFlip = this.shouldFlipScoreForButtonText(buttonText);
+        } else {
+          // With no submit button, only flip if it's an outbound link that navigates away, and also match the text
+          // Here we want to be more conservative, because we don't want to flip for every link given that there was no
+          // submit button detected on the form, hence the extra check for the link.
+          const isOutboundLink = this.isOutboundLink(el);
+          shouldFlip = isOutboundLink && this.shouldFlipScoreForButtonText(buttonText);
+        }
       }
       const strength = likelyASubmit ? 20 : 4;
       this.updateSignal({
@@ -6878,7 +6890,7 @@ class FormAnalyzer {
       });
       return;
     }
-    if (this.isElementExternalLink(el)) {
+    if (this.isOutboundLink(el)) {
       let shouldFlip = true;
       let strength = 1;
       // Don't flip forgotten password links

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -231,12 +231,11 @@ class FormAnalyzer {
     }
 
     /**
-     * Function that checks if the element is an external link or a custom web element that
-     * encapsulates a link.
+     * Function that checks if the element is link like and navigating away from the current page
      * @param {any} el
      * @returns {boolean}
      */
-    isElementExternalLink(el) {
+    isOutboundLink(el) {
         // Checks if the element is present in the cusotm elements registry and ends with a '-link' suffix.
         // If it does, it checks if it contains an anchor element inside.
         const tagName = el.nodeName.toLowerCase();
@@ -244,12 +243,16 @@ class FormAnalyzer {
             customElements?.get(tagName) != null && /-link$/.test(tagName) && findElementsInShadowTree(el, 'a').length > 0;
 
         // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
-        const isElementLink =
-            (el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#') ||
-            (el.getAttribute('role') || '').toUpperCase() === 'LINK' ||
-            el.matches('button[class*=secondary]');
+        const isElementLikelyALink = (el) => {
+            if (el == null) return false;
+            return (
+                (el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#') ||
+                (el.getAttribute('role') || '').toUpperCase() === 'LINK' ||
+                el.matches('button[class*=secondary]')
+            );
+        };
 
-        return isCustomWebElementLink || isElementLink;
+        return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
     }
 
     evaluateElement(el) {
@@ -278,15 +281,26 @@ class FormAnalyzer {
                     }
                 });
             } else {
-                // Here we don't think this is a submit, so if there is another submit in the form, flip the score
-                const thereIsASubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
-                shouldFlip = thereIsASubmitButton && this.shouldFlipScoreForButtonText(string);
+                // Here we don't think this is a submit, so determine if we should flip the score
+                const hasAnotherSubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
+                const buttonText = string;
+
+                if (hasAnotherSubmitButton) {
+                    // If there's another submit button, flip based on text content alone
+                    shouldFlip = this.shouldFlipScoreForButtonText(buttonText);
+                } else {
+                    // With no submit button, only flip if it's an outbound link that navigates away, and also match the text
+                    // Here we want to be more conservative, because we don't want to flip for every link given that there was no
+                    // submit button detected on the form, hence the extra check for the link.
+                    const isOutboundLink = this.isOutboundLink(el);
+                    shouldFlip = isOutboundLink && this.shouldFlipScoreForButtonText(buttonText);
+                }
             }
             const strength = likelyASubmit ? 20 : 4;
             this.updateSignal({ string, strength, signalType: `button: ${string}`, shouldFlip });
             return;
         }
-        if (this.isElementExternalLink(el)) {
+        if (this.isOutboundLink(el)) {
             let shouldFlip = true;
             let strength = 1;
             // Don't flip forgotten password links

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -246,7 +246,7 @@ class FormAnalyzer {
         const isElementLikelyALink = (el) => {
             if (el == null) return false;
             return (
-                (el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#') ||
+                (el instanceof HTMLAnchorElement && el.href && !el.getAttribute('href')?.startsWith('#')) ||
                 (el.getAttribute('role') || '').toUpperCase() === 'LINK' ||
                 el.matches('button[class*=secondary]')
             );

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -11201,7 +11201,7 @@ class FormAnalyzer {
     // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
     const isElementLikelyALink = el => {
       if (el == null) return false;
-      return el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
+      return el instanceof HTMLAnchorElement && el.href && !el.getAttribute('href')?.startsWith('#') || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
     };
     return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
   }

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -11188,20 +11188,22 @@ class FormAnalyzer {
   }
 
   /**
-   * Function that checks if the element is an external link or a custom web element that
-   * encapsulates a link.
+   * Function that checks if the element is link like and navigating away from the current page
    * @param {any} el
    * @returns {boolean}
    */
-  isElementExternalLink(el) {
+  isOutboundLink(el) {
     // Checks if the element is present in the cusotm elements registry and ends with a '-link' suffix.
     // If it does, it checks if it contains an anchor element inside.
     const tagName = el.nodeName.toLowerCase();
     const isCustomWebElementLink = customElements?.get(tagName) != null && /-link$/.test(tagName) && (0, _autofillUtils.findElementsInShadowTree)(el, 'a').length > 0;
 
     // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
-    const isElementLink = el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
-    return isCustomWebElementLink || isElementLink;
+    const isElementLikelyALink = el => {
+      if (el == null) return false;
+      return el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
+    };
+    return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
   }
   evaluateElement(el) {
     const string = (0, _autofillUtils.getTextShallow)(el);
@@ -11228,9 +11230,19 @@ class FormAnalyzer {
           }
         });
       } else {
-        // Here we don't think this is a submit, so if there is another submit in the form, flip the score
-        const thereIsASubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
-        shouldFlip = thereIsASubmitButton && this.shouldFlipScoreForButtonText(string);
+        // Here we don't think this is a submit, so determine if we should flip the score
+        const hasAnotherSubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
+        const buttonText = string;
+        if (hasAnotherSubmitButton) {
+          // If there's another submit button, flip based on text content alone
+          shouldFlip = this.shouldFlipScoreForButtonText(buttonText);
+        } else {
+          // With no submit button, only flip if it's an outbound link that navigates away, and also match the text
+          // Here we want to be more conservative, because we don't want to flip for every link given that there was no
+          // submit button detected on the form, hence the extra check for the link.
+          const isOutboundLink = this.isOutboundLink(el);
+          shouldFlip = isOutboundLink && this.shouldFlipScoreForButtonText(buttonText);
+        }
       }
       const strength = likelyASubmit ? 20 : 4;
       this.updateSignal({
@@ -11241,7 +11253,7 @@ class FormAnalyzer {
       });
       return;
     }
-    if (this.isElementExternalLink(el)) {
+    if (this.isOutboundLink(el)) {
       let shouldFlip = true;
       let strength = 1;
       // Don't flip forgotten password links

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6838,7 +6838,7 @@ class FormAnalyzer {
     // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
     const isElementLikelyALink = el => {
       if (el == null) return false;
-      return el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
+      return el instanceof HTMLAnchorElement && el.href && !el.getAttribute('href')?.startsWith('#') || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
     };
     return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
   }

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6825,20 +6825,22 @@ class FormAnalyzer {
   }
 
   /**
-   * Function that checks if the element is an external link or a custom web element that
-   * encapsulates a link.
+   * Function that checks if the element is link like and navigating away from the current page
    * @param {any} el
    * @returns {boolean}
    */
-  isElementExternalLink(el) {
+  isOutboundLink(el) {
     // Checks if the element is present in the cusotm elements registry and ends with a '-link' suffix.
     // If it does, it checks if it contains an anchor element inside.
     const tagName = el.nodeName.toLowerCase();
     const isCustomWebElementLink = customElements?.get(tagName) != null && /-link$/.test(tagName) && (0, _autofillUtils.findElementsInShadowTree)(el, 'a').length > 0;
 
     // if an external link matches one of the regexes, we assume the match is not pertinent to the current form
-    const isElementLink = el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
-    return isCustomWebElementLink || isElementLink;
+    const isElementLikelyALink = el => {
+      if (el == null) return false;
+      return el instanceof HTMLAnchorElement && el.href && el.getAttribute('href') !== '#' || (el.getAttribute('role') || '').toUpperCase() === 'LINK' || el.matches('button[class*=secondary]');
+    };
+    return isCustomWebElementLink || isElementLikelyALink(el) || isElementLikelyALink(el.closest('a'));
   }
   evaluateElement(el) {
     const string = (0, _autofillUtils.getTextShallow)(el);
@@ -6865,9 +6867,19 @@ class FormAnalyzer {
           }
         });
       } else {
-        // Here we don't think this is a submit, so if there is another submit in the form, flip the score
-        const thereIsASubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
-        shouldFlip = thereIsASubmitButton && this.shouldFlipScoreForButtonText(string);
+        // Here we don't think this is a submit, so determine if we should flip the score
+        const hasAnotherSubmitButton = Boolean(this.form.querySelector('input[type=submit], button[type=submit]'));
+        const buttonText = string;
+        if (hasAnotherSubmitButton) {
+          // If there's another submit button, flip based on text content alone
+          shouldFlip = this.shouldFlipScoreForButtonText(buttonText);
+        } else {
+          // With no submit button, only flip if it's an outbound link that navigates away, and also match the text
+          // Here we want to be more conservative, because we don't want to flip for every link given that there was no
+          // submit button detected on the form, hence the extra check for the link.
+          const isOutboundLink = this.isOutboundLink(el);
+          shouldFlip = isOutboundLink && this.shouldFlipScoreForButtonText(buttonText);
+        }
       }
       const strength = likelyASubmit ? 20 : 4;
       this.updateSignal({
@@ -6878,7 +6890,7 @@ class FormAnalyzer {
       });
       return;
     }
-    if (this.isElementExternalLink(el)) {
+    if (this.isOutboundLink(el)) {
       let shouldFlip = true;
       let strength = 1;
       // Don't flip forgotten password links

--- a/test-forms/fedex_login.html
+++ b/test-forms/fedex_login.html
@@ -1,0 +1,69 @@
+<fdx-grid gutter="extra-large" class="fdx-o-grid fdx-u-pt--8 fdx-o-grid--max-width"
+    _nghost-ng-c636916766=""><fdx-grid-row class="fdx-o-grid__row fdx-o-grid__row--guttered-extra-large"><fdx-grid-item
+            columns="12" id="userIDSubTitle"
+            class="fdx-u-align--center fdx-o-grid__item--12"><wlgn-credentials-create-user-link><a fdxbutton="text"
+                    id="createUserId" _nghost-ng-c2459629155="" href="https://www.fedex.com/register/#/contact"
+                    class="fdx-c-button fdx-c-button--text"><span _ngcontent-ng-c2459629155=""
+                        class="fdx-c-button__loading-container"><!----><span _ngcontent-ng-c2459629155=""
+                            class="fdx-c-button__title ng-star-inserted">CREATE A USER
+                            ID</span><!----><!----><!----></span><!----></a></wlgn-credentials-create-user-link></fdx-grid-item></fdx-grid-row><fdx-grid-row
+        position="center"
+        class="fdx-o-grid__row fdx-o-grid__row--center fdx-o-grid__row--guttered-extra-large"><fdx-grid-item
+            columns="12" class="fdx-o-grid__item--12 fdx-o-grid__item--7@medium"><fdx-form-field
+                _nghost-ng-c4113680412=""
+                class="ng-tns-c4113680412-0 fdx-c-form fdx-c-form--text ng-star-inserted fdx-c-form--is-invalid"><label
+                    _ngcontent-ng-c4113680412="" class="fdx-c-form__label ng-tns-c4113680412-0"
+                    for="username"><fdx-label id="username_label" class="ng-tns-c4113680412-0">User
+                        ID</fdx-label></label><input autocomplete="username" fdxinput="" id="username" maxlength="80"
+                    type="text" class="ng-tns-c4113680412-0 fdx-c-form__input ng-pristine ng-invalid ng-touched"
+                    required="" aria-invalid="true" tabindex="0" data-manual-scoring="username"
+                    data-ddg-autofill="true"
+                    style="background-size: auto 24px !important; background-position: right center !important; background-repeat: no-repeat !important; background-origin: content-box !important; background-image: url(&quot;data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNS4zMzQgNi42NjdhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00Wm0tLjY2NyAyYS42NjcuNjY3IDAgMSAxIDEuMzMzIDAgLjY2Ny42NjcgMCAwIDEtMS4zMzMgMFoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTQuNjY3IDRhNS4zMzMgNS4zMzMgMCAwIDAtNS4xODggNi41NzhsLTUuMjg0IDUuMjg0YS42NjcuNjY3IDAgMCAwLS4xOTUuNDcxdjNjMCAuMzY5LjI5OC42NjcuNjY3LjY2N2gyLjY2NmMuNzM3IDAgMS4zMzQtLjU5NyAxLjMzNC0xLjMzM1YxOGguNjY2Yy43MzcgMCAxLjMzNC0uNTk3IDEuMzM0LTEuMzMzdi0xLjMzNEgxMmMuMTc3IDAgLjM0Ni0uMDcuNDcxLS4xOTVsLjY4OC0uNjg4QTUuMzMzIDUuMzMzIDAgMSAwIDE0LjY2NyA0Wm0tNCA1LjMzM2E0IDQgMCAxIDEgMi41NTUgMy43MzIuNjY3LjY2NyAwIDAgMC0uNzEzLjE1bC0uNzg1Ljc4NUgxMGEuNjY3LjY2NyAwIDAgMC0uNjY3LjY2N3YySDhhLjY2Ny42NjcgMCAwIDAtLjY2Ny42NjZ2MS4zMzRoLTJ2LTIuMDU4bDUuMzY1LTUuMzY0YS42NjcuNjY3IDAgMCAwIC4xNjMtLjY3NyAzLjk5NiAzLjk5NiAwIDAgMS0uMTk0LTEuMjM1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+Cjwvc3ZnPgo=&quot;) !important; transition: background !important;"><!---->
+                <div _ngcontent-ng-c4113680412="" class="fdx-c-form__indicator ng-tns-c4113680412-0"></div>
+                <!----><!----><!----><!----><!---->
+            </fdx-form-field></fdx-grid-item></fdx-grid-row><fdx-grid-row position="center"
+        class="fdx-o-grid__row fdx-o-grid__row--center fdx-o-grid__row--guttered-extra-large"><fdx-grid-item
+            columns="12" class="fdx-o-grid__item--12 fdx-o-grid__item--7@medium"><fdx-form-field
+                _nghost-ng-c4113680412=""
+                class="ng-tns-c4113680412-1 fdx-c-form fdx-c-form--text fdx-c-form--suffix ng-star-inserted"><label
+                    _ngcontent-ng-c4113680412="" class="fdx-c-form__label ng-tns-c4113680412-1"
+                    for="password"><fdx-label id="password_label"
+                        class="ng-tns-c4113680412-1">Password</fdx-label></label><input fdxinput="" id="password"
+                    maxlength="25" class="ng-tns-c4113680412-1 fdx-c-form__input ng-untouched ng-pristine ng-invalid"
+                    type="password" required="" aria-invalid="false" tabindex="0"
+                    data-manual-scoring="password.current" data-ddg-autofill="true"
+                    style="background-size: auto 24px !important; background-position: right center !important; background-repeat: no-repeat !important; background-origin: content-box !important; background-image: url(&quot;data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNS4zMzQgNi42NjdhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00Wm0tLjY2NyAyYS42NjcuNjY3IDAgMSAxIDEuMzMzIDAgLjY2Ny42NjcgMCAwIDEtMS4zMzMgMFoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTQuNjY3IDRhNS4zMzMgNS4zMzMgMCAwIDAtNS4xODggNi41NzhsLTUuMjg0IDUuMjg0YS42NjcuNjY3IDAgMCAwLS4xOTUuNDcxdjNjMCAuMzY5LjI5OC42NjcuNjY3LjY2N2gyLjY2NmMuNzM3IDAgMS4zMzQtLjU5NyAxLjMzNC0xLjMzM1YxOGguNjY2Yy43MzcgMCAxLjMzNC0uNTk3IDEuMzM0LTEuMzMzdi0xLjMzNEgxMmMuMTc3IDAgLjM0Ni0uMDcuNDcxLS4xOTVsLjY4OC0uNjg4QTUuMzMzIDUuMzMzIDAgMSAwIDE0LjY2NyA0Wm0tNCA1LjMzM2E0IDQgMCAxIDEgMi41NTUgMy43MzIuNjY3LjY2NyAwIDAgMC0uNzEzLjE1bC0uNzg1Ljc4NUgxMGEuNjY3LjY2NyAwIDAgMC0uNjY3LjY2N3YySDhhLjY2Ny42NjcgMCAwIDAtLjY2Ny42NjZ2MS4zMzRoLTJ2LTIuMDU4bDUuMzY1LTUuMzY0YS42NjcuNjY3IDAgMCAwIC4xNjMtLjY3NyAzLjk5NiAzLjk5NiAwIDAgMS0uMTk0LTEuMjM1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+Cjwvc3ZnPgo=&quot;) !important; transition: background !important;"><!---->
+                <div _ngcontent-ng-c4113680412="" class="fdx-c-form__indicator ng-tns-c4113680412-1"></div>
+                <!----><fdx-suffix class="ng-tns-c4113680412-1 fdx-c-form__suffix"><button aria-controls="password"
+                        aria-expanded="false"
+                        class="fdx-c-button fdx-c-form__button fdx-c-button--text fdx-c-form__button--outline"><!----><ciam-icon
+                            key="utility_hide" size="2em" color="#007ab7" class="ng-star-inserted"
+                            style="fill: rgb(0, 122, 183);"><svg viewBox="0 0 32 32" id="utility_hide"
+                                xmlns="http://www.w3.org/2000/svg" focusable="false" role="presentation"
+                                aria-hidden="false" style="transition: transform 0.3s; height: 2em; width: 2em;">
+                                <path
+                                    d="M31.9 15.6C31.7 15.2 27.7 7 16 7c-1.4 0-2.6.1-3.7.3l.4 2c.9-.2 2.1-.3 3.3-.3 9.1 0 12.9 5.4 13.9 7-.5.8-1.7 2.7-4.4 4.5l1.1 1.7c4-2.6 5.3-5.6 5.4-5.7 0-.4 0-.7-.1-.9zM1.4 5L6 9.6c-4.2 2.3-5.9 5.8-5.9 6-.1.3-.1.6 0 .8.2.4 4.1 8.6 15.9 8.6 1.3 0 3.8-.2 5-.5l4 3.9 1.4-1.4L2.8 3.6 1.4 5zM16 23c-9.1 0-12.9-5.4-13.9-7 .6-1 2.2-3.3 5.3-4.9l3.3 3.3c-.2.5-.3 1.1-.3 1.7 0 3 2.4 5.5 5.5 5.5.4 0 1 0 1.7-.3l1.6 1.5c-1 .1-2.3.2-3.2.2z">
+                                </path>
+                                <path d="M16 10.5c-.4 0-.9.1-1.3.2l6.6 6.6c.1-.4.2-.9.2-1.3 0-3-2.4-5.5-5.5-5.5z">
+                                </path>
+                            </svg></ciam-icon><!----></button><!----></fdx-suffix><!----><!----><!----><!---->
+            </fdx-form-field></fdx-grid-item></fdx-grid-row><fdx-grid-row
+        class="fdx-o-grid__row fdx-o-grid__row--guttered-extra-large"><fdx-grid-item class="fdx-o-grid__item--12"><input
+                aria-describedby="phoneNumberAPP3537405Labels" autocomplete="off"
+                formcontrolname="phoneNumberAPP3537405" hidden="" id="phoneNumberAPP3537405" maxlength="80"
+                minlength="1" type="text" class="ng-untouched ng-pristine ng-valid"
+                data-manual-scoring="phone" data-ddg-autofill="true"><fdx-label for="username" hidden=""
+                id="phoneNumberAPP3537405Label">phoneNumberAPP3537405</fdx-label></fdx-grid-item></fdx-grid-row><fdx-grid-row
+        position="center"
+        class="fdx-o-grid__row fdx-o-grid__row--center fdx-o-grid__row--guttered-extra-large"><fdx-grid-item
+            columns="12" class="fdx-u-align--center fdx-o-grid__item--12 fdx-o-grid__item--7@medium"><fdx-checkbox
+                _nghost-ng-c521176062=""
+                class="ng-tns-c521176062-2 fdx-c-form fdx-c-form--checkbox ng-untouched ng-pristine ng-valid ng-star-inserted"><label
+                    _ngcontent-ng-c521176062="" class="fdx-c-form__label ng-tns-c521176062-2"
+                    for="fdx-checkbox-0"><fdx-label id="remember_label" class="ng-tns-c521176062-2">Remember my user
+                        ID.</fdx-label></label><input _ngcontent-ng-c521176062="" type="checkbox"
+                    class="fdx-c-form__checkbox ng-tns-c521176062-2" id="fdx-checkbox-0" aria-invalid="false">
+                <div _ngcontent-ng-c521176062="" class="fdx-c-form__indicator ng-tns-c521176062-2"></div>
+                <div _ngcontent-ng-c521176062="" class="fdx-c-form__message ng-tns-c521176062-2 ng-star-inserted"></div>
+                <!---->
+            </fdx-checkbox></fdx-grid-item></fdx-grid-row></fdx-grid>

--- a/test-forms/index.json
+++ b/test-forms/index.json
@@ -551,5 +551,6 @@
   { "html": "deltamath_reset_password.html"},
   { "html": "freshdirect_com_login.html"},
   { "html": "auth_wetransfer_com_login.html"},
-  { "html": "revolut_business_login.html"}
+  { "html": "revolut_business_login.html"},
+  { "html": "fedex_login.html"}
 ]


### PR DESCRIPTION
**Reviewer:** @alistairjcbrown 
**Asana:** https://app.asana.com/0/1200930669568058/1209102571867762

## Description
It seems like the "Create a User ID" text in fedex' login form is wrongly scored, even though it's actually from a "link" that is outbound and the score should be flipped in this case (notice +4)
![image](https://github.com/user-attachments/assets/31c994d6-79f0-4619-b4a7-a3f8c7bad743)

We already have [this](https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/Form/FormAnalyzer.js#L289) logic that is supposed to catch similar links, but sadly the anchor tag in question never reaches it, since it has a "button" like class:

<img width="764" alt="Screenshot 2025-01-14 at 16 16 40" src="https://github.com/user-attachments/assets/6aa5a03a-70e7-47bc-96ba-8a19e4d170c7" />

Which means, we should also check for outbound links when checking submit buttons https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/Form/FormAnalyzer.js#L282

## Score after the changes
<img width="1512" alt="Screenshot 2025-01-14 at 16 24 04" src="https://github.com/user-attachments/assets/73f2d248-570f-4d71-818b-7d49c36f1c18" />

## Other approaches considered
Scanner didn't catch the "Login" submit button, because the form builder bailed out early as the login button is too _far_. We don't want to ideally increase the depth of the builder as it has significant performance impact.

## Steps to test
