### PR TITLE
[Logging] Add debug logs for recategorization

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -10469,6 +10469,7 @@ class Form {
       this.decorateInput(ambiguousInput);
       this.inputs[(0, _matching.getMainTypeFromType)(targetType)].add(ambiguousInput);
       this.inputs[(0, _matching.getMainTypeFromType)(inputType)].delete(ambiguousInput);
+      if ((0, _autofillUtils.shouldLog)()) console.log(`Recategorized input from ${inputType} to ${targetType}`, ambiguousInput);
     }
   }
   categorizeInputs() {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -6106,6 +6106,7 @@ class Form {
       this.decorateInput(ambiguousInput);
       this.inputs[(0, _matching.getMainTypeFromType)(targetType)].add(ambiguousInput);
       this.inputs[(0, _matching.getMainTypeFromType)(inputType)].delete(ambiguousInput);
+      if ((0, _autofillUtils.shouldLog)()) console.log(`Recategorized input from ${inputType} to ${targetType}`, ambiguousInput);
     }
   }
   categorizeInputs() {

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -445,6 +445,7 @@ class Form {
             this.decorateInput(ambiguousInput);
             this.inputs[getMainTypeFromType(targetType)].add(ambiguousInput);
             this.inputs[getMainTypeFromType(inputType)].delete(ambiguousInput);
+            if (shouldLog()) console.log(`Recategorized input from ${inputType} to ${targetType}`, ambiguousInput);
         }
     }
 

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -10469,6 +10469,7 @@ class Form {
       this.decorateInput(ambiguousInput);
       this.inputs[(0, _matching.getMainTypeFromType)(targetType)].add(ambiguousInput);
       this.inputs[(0, _matching.getMainTypeFromType)(inputType)].delete(ambiguousInput);
+      if ((0, _autofillUtils.shouldLog)()) console.log(`Recategorized input from ${inputType} to ${targetType}`, ambiguousInput);
     }
   }
   categorizeInputs() {

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -6106,6 +6106,7 @@ class Form {
       this.decorateInput(ambiguousInput);
       this.inputs[(0, _matching.getMainTypeFromType)(targetType)].add(ambiguousInput);
       this.inputs[(0, _matching.getMainTypeFromType)(inputType)].delete(ambiguousInput);
+      if ((0, _autofillUtils.shouldLog)()) console.log(`Recategorized input from ${inputType} to ${targetType}`, ambiguousInput);
     }
   }
   categorizeInputs() {


### PR DESCRIPTION
**Reviewer:**  @GioSensation 
**Asana:** 

## Description
When an input was re-categorized, log the input and it's target type. This will help debug some of the incoming issues.

## Steps to test
1. Go to https://accounts.oneplus.com/v2/index.html,
2. Set `ddg-autofill-debug` to `true` in session storage for `accounts.oneplus.com`,
3. Looking for "recategorized" in console logs. You should see something like:
<img width="1507" alt="Screenshot 2025-02-07 at 14 23 36" src="https://github.com/user-attachments/assets/fd0acb6b-6a96-4896-bfb0-7d37af38563b" />
