### PR TITLE
[Formatters] re-add partial save logic behind a feature toggle

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12245,7 +12245,18 @@ const prepareFormValuesForStorage = function (formValues) {
     creditCards.cardName = identities?.fullName || formatFullName(identities);
   }
 
-  /** Fixes for credentials **/
+  /** Fixes for credentials
+   * https://app.asana.com/0/1203822806345703/1209282738083555/f
+   * We're splitting the two approaches to infer credentials:
+   * 1. inferCredentialsForPartialSave - This is used when `partialFormSaves` config is enabled,
+   * 2. inferCredentials - This is used when we're triggering a form submission
+   * There's some de-duplication of logic because of it, but it's kept mostly to avoid
+   * having to change the overall older logic. We attempted simplifying this logic
+   * in 16.1.0 (https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0)
+   * but that refactor seem to have caused some regression, which is visible in the metrics
+   * but not reproducible with the current tests. Once the feature is stable, we should
+   * revisit and remove the older logic.
+   */
   credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
 
   /** Fixes for identities **/

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12186,12 +12186,51 @@ const shouldStoreCreditCards = _ref4 => {
 const formatPhoneNumber = phone => phone.replaceAll(/[^0-9|+]/g, '');
 
 /**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+exports.formatPhoneNumber = formatPhoneNumber;
+const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => {
+  // Try to infer username from identity or card number
+  if (!credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+    // @ts-ignore - We know that username is not a useful value here
+    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+  }
+  // Discard empty credentials
+  if (Object.keys(credentials ?? {}).length === 0) {
+    return undefined;
+  }
+  return credentials;
+};
+
+/**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+const inferCredentials = (credentials, identities, cardNumber) => {
+  if (!credentials.password) {
+    return undefined;
+  }
+  // Try to use email as username if password exists but username is missing
+  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+    // @ts-ignore - We know that username is not a useful value here
+    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+  }
+  return credentials;
+};
+
+/**
  * Formats form data into an object to send to the device for storage
  * If values are insufficient for a complete entry, they are discarded
  * @param {InternalDataStorageObject} formValues
  * @return {DataStorageObject}
  */
-exports.formatPhoneNumber = formatPhoneNumber;
 const prepareFormValuesForStorage = function (formValues) {
   let canTriggerPartialSave = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
   /** @type {Partial<InternalDataStorageObject>} */
@@ -12206,17 +12245,8 @@ const prepareFormValuesForStorage = function (formValues) {
     creditCards.cardName = identities?.fullName || formatFullName(identities);
   }
 
-  /** Fixes for credentials */
-  // If we don't have a username to match a password, let's see if email or phone or card number are available
-  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || creditCards.cardNumber)) {
-    // @ts-ignore - username will be likely undefined, but needs to be specifically assigned to a string value
-    credentials.username = identities.emailAddress || identities.phone || creditCards.cardNumber;
-  }
-
-  // If there's no password, and we shouldn't trigger a partial save, let's discard the object
-  if (!credentials.password && !canTriggerPartialSave) {
-    credentials = undefined;
-  }
+  /** Fixes for credentials **/
+  credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
 
   /** Fixes for identities **/
   // Don't store if there isn't enough data

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -7882,7 +7882,18 @@ const prepareFormValuesForStorage = function (formValues) {
     creditCards.cardName = identities?.fullName || formatFullName(identities);
   }
 
-  /** Fixes for credentials **/
+  /** Fixes for credentials
+   * https://app.asana.com/0/1203822806345703/1209282738083555/f
+   * We're splitting the two approaches to infer credentials:
+   * 1. inferCredentialsForPartialSave - This is used when `partialFormSaves` config is enabled,
+   * 2. inferCredentials - This is used when we're triggering a form submission
+   * There's some de-duplication of logic because of it, but it's kept mostly to avoid
+   * having to change the overall older logic. We attempted simplifying this logic
+   * in 16.1.0 (https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0)
+   * but that refactor seem to have caused some regression, which is visible in the metrics
+   * but not reproducible with the current tests. Once the feature is stable, we should
+   * revisit and remove the older logic.
+   */
   credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
 
   /** Fixes for identities **/

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -7823,12 +7823,51 @@ const shouldStoreCreditCards = _ref4 => {
 const formatPhoneNumber = phone => phone.replaceAll(/[^0-9|+]/g, '');
 
 /**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+exports.formatPhoneNumber = formatPhoneNumber;
+const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => {
+  // Try to infer username from identity or card number
+  if (!credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+    // @ts-ignore - We know that username is not a useful value here
+    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+  }
+  // Discard empty credentials
+  if (Object.keys(credentials ?? {}).length === 0) {
+    return undefined;
+  }
+  return credentials;
+};
+
+/**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+const inferCredentials = (credentials, identities, cardNumber) => {
+  if (!credentials.password) {
+    return undefined;
+  }
+  // Try to use email as username if password exists but username is missing
+  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+    // @ts-ignore - We know that username is not a useful value here
+    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+  }
+  return credentials;
+};
+
+/**
  * Formats form data into an object to send to the device for storage
  * If values are insufficient for a complete entry, they are discarded
  * @param {InternalDataStorageObject} formValues
  * @return {DataStorageObject}
  */
-exports.formatPhoneNumber = formatPhoneNumber;
 const prepareFormValuesForStorage = function (formValues) {
   let canTriggerPartialSave = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
   /** @type {Partial<InternalDataStorageObject>} */
@@ -7843,17 +7882,8 @@ const prepareFormValuesForStorage = function (formValues) {
     creditCards.cardName = identities?.fullName || formatFullName(identities);
   }
 
-  /** Fixes for credentials */
-  // If we don't have a username to match a password, let's see if email or phone or card number are available
-  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || creditCards.cardNumber)) {
-    // @ts-ignore - username will be likely undefined, but needs to be specifically assigned to a string value
-    credentials.username = identities.emailAddress || identities.phone || creditCards.cardNumber;
-  }
-
-  // If there's no password, and we shouldn't trigger a partial save, let's discard the object
-  if (!credentials.password && !canTriggerPartialSave) {
-    credentials = undefined;
-  }
+  /** Fixes for credentials **/
+  credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
 
   /** Fixes for identities **/
   // Don't store if there isn't enough data

--- a/src/Form/formatters.js
+++ b/src/Form/formatters.js
@@ -188,6 +188,45 @@ const shouldStoreCreditCards = ({ creditCards }) => {
 const formatPhoneNumber = (phone) => phone.replaceAll(/[^0-9|+]/g, '');
 
 /**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => {
+    // Try to infer username from identity or card number
+    if (!credentials.username && (hasUsernameLikeIdentity(identities) || cardNumber)) {
+        // @ts-ignore - We know that username is not a useful value here
+        credentials.username = identities.emailAddress || identities.phone || cardNumber;
+    }
+    // Discard empty credentials
+    if (Object.keys(credentials ?? {}).length === 0) {
+        return undefined;
+    }
+    return credentials;
+};
+
+/**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+const inferCredentials = (credentials, identities, cardNumber) => {
+    if (!credentials.password) {
+        return undefined;
+    }
+    // Try to use email as username if password exists but username is missing
+    if (credentials.password && !credentials.username && (hasUsernameLikeIdentity(identities) || cardNumber)) {
+        // @ts-ignore - We know that username is not a useful value here
+        credentials.username = identities.emailAddress || identities.phone || cardNumber;
+    }
+    return credentials;
+};
+
+/**
  * Formats form data into an object to send to the device for storage
  * If values are insufficient for a complete entry, they are discarded
  * @param {InternalDataStorageObject} formValues
@@ -202,17 +241,10 @@ const prepareFormValuesForStorage = (formValues, canTriggerPartialSave = false) 
         creditCards.cardName = identities?.fullName || formatFullName(identities);
     }
 
-    /** Fixes for credentials */
-    // If we don't have a username to match a password, let's see if email or phone or card number are available
-    if (credentials.password && !credentials.username && (hasUsernameLikeIdentity(identities) || creditCards.cardNumber)) {
-        // @ts-ignore - username will be likely undefined, but needs to be specifically assigned to a string value
-        credentials.username = identities.emailAddress || identities.phone || creditCards.cardNumber;
-    }
-
-    // If there's no password, and we shouldn't trigger a partial save, let's discard the object
-    if (!credentials.password && !canTriggerPartialSave) {
-        credentials = undefined;
-    }
+    /** Fixes for credentials **/
+    credentials = canTriggerPartialSave
+        ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber)
+        : inferCredentials(credentials, identities, creditCards.cardNumber);
 
     /** Fixes for identities **/
     // Don't store if there isn't enough data

--- a/src/Form/formatters.js
+++ b/src/Form/formatters.js
@@ -241,7 +241,18 @@ const prepareFormValuesForStorage = (formValues, canTriggerPartialSave = false) 
         creditCards.cardName = identities?.fullName || formatFullName(identities);
     }
 
-    /** Fixes for credentials **/
+    /** Fixes for credentials
+     * https://app.asana.com/0/1203822806345703/1209282738083555/f
+     * We're splitting the two approaches to infer credentials:
+     * 1. inferCredentialsForPartialSave - This is used when `partialFormSaves` config is enabled,
+     * 2. inferCredentials - This is used when we're triggering a form submission
+     * There's some de-duplication of logic because of it, but it's kept mostly to avoid
+     * having to change the overall older logic. We attempted simplifying this logic
+     * in 16.1.0 (https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0)
+     * but that refactor seem to have caused some regression, which is visible in the metrics
+     * but not reproducible with the current tests. Once the feature is stable, we should
+     * revisit and remove the older logic.
+     */
     credentials = canTriggerPartialSave
         ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber)
         : inferCredentials(credentials, identities, creditCards.cardNumber);

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -12245,7 +12245,18 @@ const prepareFormValuesForStorage = function (formValues) {
     creditCards.cardName = identities?.fullName || formatFullName(identities);
   }
 
-  /** Fixes for credentials **/
+  /** Fixes for credentials
+   * https://app.asana.com/0/1203822806345703/1209282738083555/f
+   * We're splitting the two approaches to infer credentials:
+   * 1. inferCredentialsForPartialSave - This is used when `partialFormSaves` config is enabled,
+   * 2. inferCredentials - This is used when we're triggering a form submission
+   * There's some de-duplication of logic because of it, but it's kept mostly to avoid
+   * having to change the overall older logic. We attempted simplifying this logic
+   * in 16.1.0 (https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0)
+   * but that refactor seem to have caused some regression, which is visible in the metrics
+   * but not reproducible with the current tests. Once the feature is stable, we should
+   * revisit and remove the older logic.
+   */
   credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
 
   /** Fixes for identities **/

--- a/swift-package/Resources/assets/autofill-debug.js
+++ b/swift-package/Resources/assets/autofill-debug.js
@@ -12186,12 +12186,51 @@ const shouldStoreCreditCards = _ref4 => {
 const formatPhoneNumber = phone => phone.replaceAll(/[^0-9|+]/g, '');
 
 /**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+exports.formatPhoneNumber = formatPhoneNumber;
+const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => {
+  // Try to infer username from identity or card number
+  if (!credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+    // @ts-ignore - We know that username is not a useful value here
+    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+  }
+  // Discard empty credentials
+  if (Object.keys(credentials ?? {}).length === 0) {
+    return undefined;
+  }
+  return credentials;
+};
+
+/**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+const inferCredentials = (credentials, identities, cardNumber) => {
+  if (!credentials.password) {
+    return undefined;
+  }
+  // Try to use email as username if password exists but username is missing
+  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+    // @ts-ignore - We know that username is not a useful value here
+    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+  }
+  return credentials;
+};
+
+/**
  * Formats form data into an object to send to the device for storage
  * If values are insufficient for a complete entry, they are discarded
  * @param {InternalDataStorageObject} formValues
  * @return {DataStorageObject}
  */
-exports.formatPhoneNumber = formatPhoneNumber;
 const prepareFormValuesForStorage = function (formValues) {
   let canTriggerPartialSave = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
   /** @type {Partial<InternalDataStorageObject>} */
@@ -12206,17 +12245,8 @@ const prepareFormValuesForStorage = function (formValues) {
     creditCards.cardName = identities?.fullName || formatFullName(identities);
   }
 
-  /** Fixes for credentials */
-  // If we don't have a username to match a password, let's see if email or phone or card number are available
-  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || creditCards.cardNumber)) {
-    // @ts-ignore - username will be likely undefined, but needs to be specifically assigned to a string value
-    credentials.username = identities.emailAddress || identities.phone || creditCards.cardNumber;
-  }
-
-  // If there's no password, and we shouldn't trigger a partial save, let's discard the object
-  if (!credentials.password && !canTriggerPartialSave) {
-    credentials = undefined;
-  }
+  /** Fixes for credentials **/
+  credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
 
   /** Fixes for identities **/
   // Don't store if there isn't enough data

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -7882,7 +7882,18 @@ const prepareFormValuesForStorage = function (formValues) {
     creditCards.cardName = identities?.fullName || formatFullName(identities);
   }
 
-  /** Fixes for credentials **/
+  /** Fixes for credentials
+   * https://app.asana.com/0/1203822806345703/1209282738083555/f
+   * We're splitting the two approaches to infer credentials:
+   * 1. inferCredentialsForPartialSave - This is used when `partialFormSaves` config is enabled,
+   * 2. inferCredentials - This is used when we're triggering a form submission
+   * There's some de-duplication of logic because of it, but it's kept mostly to avoid
+   * having to change the overall older logic. We attempted simplifying this logic
+   * in 16.1.0 (https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0)
+   * but that refactor seem to have caused some regression, which is visible in the metrics
+   * but not reproducible with the current tests. Once the feature is stable, we should
+   * revisit and remove the older logic.
+   */
   credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
 
   /** Fixes for identities **/

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -7823,12 +7823,51 @@ const shouldStoreCreditCards = _ref4 => {
 const formatPhoneNumber = phone => phone.replaceAll(/[^0-9|+]/g, '');
 
 /**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+exports.formatPhoneNumber = formatPhoneNumber;
+const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => {
+  // Try to infer username from identity or card number
+  if (!credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+    // @ts-ignore - We know that username is not a useful value here
+    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+  }
+  // Discard empty credentials
+  if (Object.keys(credentials ?? {}).length === 0) {
+    return undefined;
+  }
+  return credentials;
+};
+
+/**
+ * Infer credentials from password and identities
+ * @param {InternalDataStorageObject['credentials']} credentials
+ * @param {InternalDataStorageObject['identities']} identities
+ * @param {string|undefined} cardNumber
+ * @return {InternalDataStorageObject['credentials'] | undefined}
+ */
+const inferCredentials = (credentials, identities, cardNumber) => {
+  if (!credentials.password) {
+    return undefined;
+  }
+  // Try to use email as username if password exists but username is missing
+  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+    // @ts-ignore - We know that username is not a useful value here
+    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+  }
+  return credentials;
+};
+
+/**
  * Formats form data into an object to send to the device for storage
  * If values are insufficient for a complete entry, they are discarded
  * @param {InternalDataStorageObject} formValues
  * @return {DataStorageObject}
  */
-exports.formatPhoneNumber = formatPhoneNumber;
 const prepareFormValuesForStorage = function (formValues) {
   let canTriggerPartialSave = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
   /** @type {Partial<InternalDataStorageObject>} */
@@ -7843,17 +7882,8 @@ const prepareFormValuesForStorage = function (formValues) {
     creditCards.cardName = identities?.fullName || formatFullName(identities);
   }
 
-  /** Fixes for credentials */
-  // If we don't have a username to match a password, let's see if email or phone or card number are available
-  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || creditCards.cardNumber)) {
-    // @ts-ignore - username will be likely undefined, but needs to be specifically assigned to a string value
-    credentials.username = identities.emailAddress || identities.phone || creditCards.cardNumber;
-  }
-
-  // If there's no password, and we shouldn't trigger a partial save, let's discard the object
-  if (!credentials.password && !canTriggerPartialSave) {
-    credentials = undefined;
-  }
+  /** Fixes for credentials **/
+  credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
 
   /** Fixes for identities **/
   // Don't store if there isn't enough data


### PR DESCRIPTION
**Reviewer:**  @shakyShane 
**Asana:**  https://app.asana.com/0/1203822806345703/1209282738083555

## Description
Refactoring partial save logic as a result of investigation in https://app.asana.com/0/1203822806345703/1209282738083555.

**Background**
1. Allowing username only saves was introduced first in 16.0.0, as a part of [increase ratio of full credential saves](https://app.asana.com/0/72649045549333/1206048666874230/f) project
2. The project did well in numbers, until a feature toggle for it was introduced in JS in [16.1.0](https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0)
3. This change in logic degraded the autofill accuracy numbers (as first improved by 16.0.0)
4. The reason for why this could've happened is not clear, but the change in [prepareFormValueforStorage](https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0#diff-d6508e689548859e3f4f8cd20227865aa292ae59ddac1d6cb27240a878e220daR206)  is most likely the cause, although hard to reason about because the tests are working as expected and all happy path forms work, as defined in the project.

**Solution**
This change separates the code to two distinct paths based on `partialFormSaves` feature toggle.
1. Turning the feature toggle off, takes the code path in 15.1.0 when there was no partial form saves,
2. Turn on the feature toggle, takes the code to 16.0.0, when partial form saves were giving us good results, effectively ignoring the refactor introduced in  [16.1.0](https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0)

The main reason for doing this (in spite of code repetition) is to clearly narrow down the root cause, based on current strongest hunch. This also allows us to cleanly remove the older code path, once the feature has stabilized over time.

## Steps to test

Note that the existing formatters test is passing https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/Form/formatters.test.js#L96, which covers happy path!

The change can be tested with the various pages defined in this branch https://github.com/duckduckgo/privacy-test-pages/pull/255

1. Load custom config with `partialFormSaves` enabled (or disabled) with https://github.com/duckduckgo/privacy-protections-debugger
2. Go to one of the test pages and try out the flow with the feature enabled/disabled.

Example on reset password flow test page.

https://github.com/user-attachments/assets/2d921048-44bd-4adc-8e4e-be75afaf9974

