### PR TITLE
Update Apple project file references in the release workflow

### DIFF
--- a/.github/workflows/asana-release.yml
+++ b/.github/workflows/asana-release.yml
@@ -181,7 +181,7 @@ jobs:
               id: create-pr
               with:
                   path: ios/
-                  add-paths: DuckDuckGo.xcodeproj/project.pbxproj
+                  add-paths: DuckDuckGo-iOS.xcodeproj/project.pbxproj
                   commit-message: Update BSK with autofill ${{ github.event.release.tag_name }}
                   branch: update-bsk-with-autofill-${{ github.event.release.tag_name }}
                   title: Update BSK with autofill ${{ github.event.release.tag_name }}
@@ -232,7 +232,7 @@ jobs:
               id: create-pr
               with:
                   path: macos/
-                  add-paths: DuckDuckGo.xcodeproj/project.pbxproj
+                  add-paths: DuckDuckGo-macOS.xcodeproj/project.pbxproj
                   commit-message: Update BSK with autofill ${{ github.event.release.tag_name }}
                   branch: update-bsk-with-autofill-${{ github.event.release.tag_name }}
                   title: Update BSK with autofill ${{ github.event.release.tag_name }}

--- a/scripts/release/update-apple-device-repo.js
+++ b/scripts/release/update-apple-device-repo.js
@@ -16,14 +16,24 @@ function updateAppleDeviceRepo(platform = 'ios', commit) {
 
     if (!commit) throw new Error('Commit not provided');
 
-    const projectFilePath = filepath(`../../${platform}/DuckDuckGo.xcodeproj/project.pbxproj`);
+    let projectFileName;
+
+    if (platform === 'ios') {
+        projectFileName = 'DuckDuckGo-iOS.xcodeproj';
+    } else if (platform === 'macos') {
+        projectFileName = 'DuckDuckGo-macOS.xcodeproj';
+    } else {
+        throw new Error(`Unsupported platform: ${platform}`);
+    }
+
+    const projectFilePath = filepath(`../../${platform}/${projectFileName}/project.pbxproj`);
 
     const projectFile = readFileSync(projectFilePath, 'utf8');
     const updatedProjectFile = updateProjectPbxproj(projectFile, commit);
     writeFileSync(projectFilePath, updatedProjectFile);
 
     if (platform === 'macos') {
-        const packageResolvedPath = filepath('../../macos/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved');
+        const packageResolvedPath = filepath(`../../macos/${projectFileName}/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`);
 
         const substitutions = {
             autofill: {


### PR DESCRIPTION
**Reviewer:** @dbajpeyi 
**Asana:** https://app.asana.com/0/1199333091098016/1209379286138008

## Description

This PR fixes a path issue with the Apple project file references. These were renamed a couple weeks prior, but the release workflow wasn't updated.

## Steps to test
1. Verify that there are no lingering path references to `DuckDuckGo.xcodeproj` anywhere in the release workflows & scripts