### PR TITLE
[Formatters] Make fixes for credentials less restrictive

### DIFF
--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -7825,16 +7825,16 @@ const formatPhoneNumber = phone => phone.replaceAll(/[^0-9|+]/g, '');
 /**
  * Infer credentials from password and identities
  * @param {InternalDataStorageObject['credentials']} credentials
- * @param {InternalDataStorageObject['identities']} identities
- * @param {string|undefined} cardNumber
- * @return {InternalDataStorageObject['credentials'] | undefined}
+ * @param {InternalIdentityObject} identities
+ * @param {InternalCreditCardObject|undefined} creditCards
+ * @return InternalCredentialsObject|undefined
  */
 exports.formatPhoneNumber = formatPhoneNumber;
-const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => {
+const inferCredentialsForPartialSave = (credentials, identities, creditCards) => {
   // Try to infer username from identity or card number
-  if (!credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+  if (!credentials.username) {
     // @ts-ignore - We know that username is not a useful value here
-    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+    credentials.username = (0, _autofillUtils.getUsernameLikeIdentity)(identities, creditCards);
   }
   // Discard empty credentials
   if (Object.keys(credentials ?? {}).length === 0) {
@@ -7846,18 +7846,18 @@ const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => 
 /**
  * Infer credentials from password and identities
  * @param {InternalDataStorageObject['credentials']} credentials
- * @param {InternalDataStorageObject['identities']} identities
- * @param {string|undefined} cardNumber
- * @return {InternalDataStorageObject['credentials'] | undefined}
+ * @param {InternalIdentityObject} identities
+ * @param {InternalCreditCardObject|undefined} creditCards
+ * @return InternalCredentialsObject|undefined
  */
-const inferCredentials = (credentials, identities, cardNumber) => {
+const inferCredentials = (credentials, identities, creditCards) => {
   if (!credentials.password) {
     return undefined;
   }
   // Try to use email as username if password exists but username is missing
-  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+  if (credentials.password && !credentials.username) {
     // @ts-ignore - We know that username is not a useful value here
-    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+    credentials.username = (0, _autofillUtils.getUsernameLikeIdentity)(identities, creditCards);
   }
   return credentials;
 };
@@ -7866,6 +7866,7 @@ const inferCredentials = (credentials, identities, cardNumber) => {
  * Formats form data into an object to send to the device for storage
  * If values are insufficient for a complete entry, they are discarded
  * @param {InternalDataStorageObject} formValues
+ * @param {boolean} canTriggerPartialSave
  * @return {DataStorageObject}
  */
 const prepareFormValuesForStorage = function (formValues) {
@@ -7894,7 +7895,7 @@ const prepareFormValuesForStorage = function (formValues) {
    * but not reproducible with the current tests. Once the feature is stable, we should
    * revisit and remove the older logic.
    */
-  credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
+  credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards) : inferCredentials(credentials, identities, creditCards);
 
   /** Fixes for identities **/
   // Don't store if there isn't enough data
@@ -12892,7 +12893,7 @@ exports.getActiveElement = getActiveElement;
 exports.getDaxBoundingBox = void 0;
 exports.getFormControlElements = getFormControlElements;
 exports.getTextShallow = void 0;
-exports.hasUsernameLikeIdentity = hasUsernameLikeIdentity;
+exports.getUsernameLikeIdentity = getUsernameLikeIdentity;
 exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = void 0;
 exports.isFormLikelyToBeUsedAsPageWrapper = isFormLikelyToBeUsedAsPageWrapper;
 exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedConfig = void 0;
@@ -13569,12 +13570,22 @@ function queryElementsWithShadow(element, selector) {
 }
 
 /**
- * Checks if there is a single username-like identity, i.e. email or phone
+ * Checks if there is a single username-like identity, i.e. email or phone or credit card number
+ * If there is then returns that, otherwise returns undefined
  * @param {InternalIdentityObject} identities
- * @returns {boolean}
+ * @param {InternalCreditCardObject} creditCards
+ * @returns {string | undefined}
  */
-function hasUsernameLikeIdentity(identities) {
-  return Object.keys(identities ?? {}).length === 1 && Boolean(identities?.emailAddress || identities.phone);
+function getUsernameLikeIdentity(identities, creditCards) {
+  if (identities?.emailAddress) {
+    return identities.emailAddress;
+  }
+  if (Object.keys(identities ?? {}).length === 1 && Boolean(identities.phone)) {
+    return identities.phone;
+  }
+  if (Object.keys(creditCards ?? {}).length === 1 && Boolean(creditCards.cardNumber)) {
+    return creditCards.cardNumber;
+  }
 }
 
 },{"./Form/matching.js":34,"./constants.js":57,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],55:[function(require,module,exports){

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -286,6 +286,21 @@ describe('Test the form class reading values correctly', () => {
                 },
             },
         },
+        {
+            testCase: 'signup form with email address and password, with first name and last name in adjacent fields    ',
+            form: `
+<form method="post" id="signupForm">
+    <input type="text" value="Dax" id="firstName" placeholder="First name" />
+    <input type="text" value="McDax" id="lastName" placeholder="Last name" />
+    <input type="email" value="dax@mcdax.com" autocomplete="email" />
+    <input type="password" value="123456" autocomplete="new-password" />
+    <button type="submit">Sign up</button>
+</form>`,
+            expHasValues: true,
+            expValues: {
+                credentials: { username: 'dax@mcdax.com', password: '123456' },
+            },
+        },
     ];
 
     test.each(testCases)('Test $testCase', ({ form, expHasValues, expValues }) => {

--- a/src/Form/formatters.test.js
+++ b/src/Form/formatters.test.js
@@ -107,5 +107,98 @@ describe('prepareFormValuesForStorage()', () => {
             );
             expect(values.credentials).toEqual(inputCredentials);
         });
+
+        it('accepts email address as username when other identity data is present', () => {
+            const inputCredentials = { username: 'dax@example.com', password: '123456' };
+            const values = prepareFormValuesForStorage({
+                // @ts-ignore
+                credentials: { password: inputCredentials.password },
+                // @ts-ignore
+                creditCards: {},
+                // @ts-ignore
+                identities: { emailAddress: 'dax@example.com', firstName: 'Dax', lastName: 'McDax' },
+            });
+            expect(values.credentials).toEqual(inputCredentials);
+        });
+
+        it('accepts email address as username with identity and card data is present', () => {
+            const inputCredentials = { username: 'dax@example.com', password: '123456' };
+            const values = prepareFormValuesForStorage({
+                // @ts-ignore
+                credentials: { password: inputCredentials.password },
+                // @ts-ignore
+                creditCards: { cardNumber: '1234567890123456', cardName: 'Dax McDax' },
+                // @ts-ignore
+                identities: { emailAddress: 'dax@example.com', firstName: 'Dax', lastName: 'McDax', phone: '+133451234563' },
+            });
+            expect(values.credentials).toEqual(inputCredentials);
+        });
+
+        it('accepts phone as username', () => {
+            const inputCredentials = { username: '+133451234563', password: '123456' };
+            const values = prepareFormValuesForStorage({
+                // @ts-ignore
+                credentials: {
+                    password: inputCredentials.password,
+                },
+                // @ts-ignore
+                creditCards: {},
+                // @ts-ignore
+                identities: {
+                    phone: inputCredentials.username,
+                },
+            });
+            expect(values.credentials).toEqual(inputCredentials);
+        });
+
+        it("doesn't accept phone as username if other identity data is present", () => {
+            const inputCredentials = { username: '+133451234563', password: '123456' };
+            const values = prepareFormValuesForStorage({
+                // @ts-ignore
+                credentials: {
+                    password: inputCredentials.password,
+                },
+                // @ts-ignore
+                creditCards: {},
+                // @ts-ignore
+                identities: {
+                    phone: inputCredentials.username,
+                    firstName: 'Dax',
+                    lastName: 'McDax',
+                },
+            });
+            expect(values.credentials).toEqual({ password: inputCredentials.password });
+        });
+
+        it('accepts credit card number as username', () => {
+            const inputCredentials = { username: '1234567890123456', password: '123456' };
+            const values = prepareFormValuesForStorage({
+                // @ts-ignore
+                credentials: { password: inputCredentials.password },
+                // @ts-ignore
+                creditCards: {
+                    cardNumber: inputCredentials.username,
+                },
+                // @ts-ignore
+                identities: {},
+            });
+            expect(values.credentials).toEqual(inputCredentials);
+        });
+
+        it("doesn't accept credit card number as username if other card data is present", () => {
+            const inputCredentials = { username: '1234567890123456', password: '123456' };
+            const values = prepareFormValuesForStorage({
+                // @ts-ignore
+                credentials: { password: inputCredentials.password },
+                // @ts-ignore
+                creditCards: {
+                    cardNumber: inputCredentials.username,
+                    cardName: 'Dax McDax',
+                },
+                // @ts-ignore
+                identities: {},
+            });
+            expect(values.credentials).toEqual({ password: inputCredentials.password });
+        });
     });
 });

--- a/src/autofill-utils.js
+++ b/src/autofill-utils.js
@@ -631,12 +631,22 @@ function queryElementsWithShadow(element, selector, forceScanShadowTree = false)
 }
 
 /**
- * Checks if there is a single username-like identity, i.e. email or phone
+ * Checks if there is a single username-like identity, i.e. email or phone or credit card number
+ * If there is then returns that, otherwise returns undefined
  * @param {InternalIdentityObject} identities
- * @returns {boolean}
+ * @param {InternalCreditCardObject} creditCards
+ * @returns {string | undefined}
  */
-function hasUsernameLikeIdentity(identities) {
-    return Object.keys(identities ?? {}).length === 1 && Boolean(identities?.emailAddress || identities.phone);
+function getUsernameLikeIdentity(identities, creditCards) {
+    if (identities?.emailAddress) {
+        return identities.emailAddress;
+    }
+    if (Object.keys(identities ?? {}).length === 1 && Boolean(identities.phone)) {
+        return identities.phone;
+    }
+    if (Object.keys(creditCards ?? {}).length === 1 && Boolean(creditCards.cardNumber)) {
+        return creditCards.cardNumber;
+    }
 }
 
 export {
@@ -674,5 +684,5 @@ export {
     findElementsInShadowTree,
     queryElementsWithShadow,
     getFormControlElements,
-    hasUsernameLikeIdentity,
+    getUsernameLikeIdentity,
 };

--- a/swift-package/Resources/assets/autofill.js
+++ b/swift-package/Resources/assets/autofill.js
@@ -7825,16 +7825,16 @@ const formatPhoneNumber = phone => phone.replaceAll(/[^0-9|+]/g, '');
 /**
  * Infer credentials from password and identities
  * @param {InternalDataStorageObject['credentials']} credentials
- * @param {InternalDataStorageObject['identities']} identities
- * @param {string|undefined} cardNumber
- * @return {InternalDataStorageObject['credentials'] | undefined}
+ * @param {InternalIdentityObject} identities
+ * @param {InternalCreditCardObject|undefined} creditCards
+ * @return InternalCredentialsObject|undefined
  */
 exports.formatPhoneNumber = formatPhoneNumber;
-const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => {
+const inferCredentialsForPartialSave = (credentials, identities, creditCards) => {
   // Try to infer username from identity or card number
-  if (!credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+  if (!credentials.username) {
     // @ts-ignore - We know that username is not a useful value here
-    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+    credentials.username = (0, _autofillUtils.getUsernameLikeIdentity)(identities, creditCards);
   }
   // Discard empty credentials
   if (Object.keys(credentials ?? {}).length === 0) {
@@ -7846,18 +7846,18 @@ const inferCredentialsForPartialSave = (credentials, identities, cardNumber) => 
 /**
  * Infer credentials from password and identities
  * @param {InternalDataStorageObject['credentials']} credentials
- * @param {InternalDataStorageObject['identities']} identities
- * @param {string|undefined} cardNumber
- * @return {InternalDataStorageObject['credentials'] | undefined}
+ * @param {InternalIdentityObject} identities
+ * @param {InternalCreditCardObject|undefined} creditCards
+ * @return InternalCredentialsObject|undefined
  */
-const inferCredentials = (credentials, identities, cardNumber) => {
+const inferCredentials = (credentials, identities, creditCards) => {
   if (!credentials.password) {
     return undefined;
   }
   // Try to use email as username if password exists but username is missing
-  if (credentials.password && !credentials.username && ((0, _autofillUtils.hasUsernameLikeIdentity)(identities) || cardNumber)) {
+  if (credentials.password && !credentials.username) {
     // @ts-ignore - We know that username is not a useful value here
-    credentials.username = identities.emailAddress || identities.phone || cardNumber;
+    credentials.username = (0, _autofillUtils.getUsernameLikeIdentity)(identities, creditCards);
   }
   return credentials;
 };
@@ -7866,6 +7866,7 @@ const inferCredentials = (credentials, identities, cardNumber) => {
  * Formats form data into an object to send to the device for storage
  * If values are insufficient for a complete entry, they are discarded
  * @param {InternalDataStorageObject} formValues
+ * @param {boolean} canTriggerPartialSave
  * @return {DataStorageObject}
  */
 const prepareFormValuesForStorage = function (formValues) {
@@ -7894,7 +7895,7 @@ const prepareFormValuesForStorage = function (formValues) {
    * but not reproducible with the current tests. Once the feature is stable, we should
    * revisit and remove the older logic.
    */
-  credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards.cardNumber) : inferCredentials(credentials, identities, creditCards.cardNumber);
+  credentials = canTriggerPartialSave ? inferCredentialsForPartialSave(credentials, identities, creditCards) : inferCredentials(credentials, identities, creditCards);
 
   /** Fixes for identities **/
   // Don't store if there isn't enough data
@@ -12892,7 +12893,7 @@ exports.getActiveElement = getActiveElement;
 exports.getDaxBoundingBox = void 0;
 exports.getFormControlElements = getFormControlElements;
 exports.getTextShallow = void 0;
-exports.hasUsernameLikeIdentity = hasUsernameLikeIdentity;
+exports.getUsernameLikeIdentity = getUsernameLikeIdentity;
 exports.isEventWithinDax = exports.isAutofillEnabledFromProcessedConfig = void 0;
 exports.isFormLikelyToBeUsedAsPageWrapper = isFormLikelyToBeUsedAsPageWrapper;
 exports.isLikelyASubmitButton = exports.isIncontextSignupEnabledFromProcessedConfig = void 0;
@@ -13569,12 +13570,22 @@ function queryElementsWithShadow(element, selector) {
 }
 
 /**
- * Checks if there is a single username-like identity, i.e. email or phone
+ * Checks if there is a single username-like identity, i.e. email or phone or credit card number
+ * If there is then returns that, otherwise returns undefined
  * @param {InternalIdentityObject} identities
- * @returns {boolean}
+ * @param {InternalCreditCardObject} creditCards
+ * @returns {string | undefined}
  */
-function hasUsernameLikeIdentity(identities) {
-  return Object.keys(identities ?? {}).length === 1 && Boolean(identities?.emailAddress || identities.phone);
+function getUsernameLikeIdentity(identities, creditCards) {
+  if (identities?.emailAddress) {
+    return identities.emailAddress;
+  }
+  if (Object.keys(identities ?? {}).length === 1 && Boolean(identities.phone)) {
+    return identities.phone;
+  }
+  if (Object.keys(creditCards ?? {}).length === 1 && Boolean(creditCards.cardNumber)) {
+    return creditCards.cardNumber;
+  }
 }
 
 },{"./Form/matching.js":34,"./constants.js":57,"@duckduckgo/content-scope-scripts/src/apple-utils":1}],55:[function(require,module,exports){


### PR DESCRIPTION
**Reviewer:** 
**Asana:** https://app.asana.com/0/1200930669568058/1209414003515479

## Description
In https://github.com/duckduckgo/duckduckgo-autofill/pull/702/files#diff-d6508e689548859e3f4f8cd20227865aa292ae59ddac1d6cb27240a878e220daR206, I ended up adding additional restriction (checking no other identity is present in the form) when attempting to use `identities.emailAddress` as `credentials.username`. 

This restriction was added because now `identities.phone` and `identities.creditCards` are also candidates for username. But the restriction should not apply to `identities.emailAddress`, as that was never a thing before the above mentioned change.

## Steps to test
1. Go to https://www.longhornsteakhouse.com/
2. Click on login on top right, and then create a new account
3. Notice that that the full credentials are saved, before only password was saved.

PS: test cases are covering all the scenarios that we want to fix with this code.
