### PR TITLE
Update Apple BSK path

### DIFF
--- a/.github/workflows/asana-release.yml
+++ b/.github/workflows/asana-release.yml
@@ -141,7 +141,7 @@ jobs:
               id: create-pr
               with:
                   path: apple-monorepo/
-                  add-paths: BrowserServicesKit/Package.swift,BrowserServicesKit/Package.resolved
+                  add-paths: SharedPackages/BrowserServicesKit/Package.swift,SharedPackages/BrowserServicesKit/Package.resolved
                   commit-message: Update autofill to ${{ env.VERSION }}
                   branch: update-autofill-${{ env.VERSION }}
                   title: Update autofill to ${{ env.VERSION }}

--- a/docs/runtime.ios.md
+++ b/docs/runtime.ios.md
@@ -2,7 +2,7 @@
 
 on Apple devices, this data is retrieved from the following string-replacements
 
-- [BrowserServices Kit String replacements](https://github.com/duckduckgo/apple-browsers/blob/main/BrowserServicesKit/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SourceProvider.swift#L54-L56)
+- [BrowserServices Kit String replacements](https://github.com/duckduckgo/apple-browsers/blob/main/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SourceProvider.swift#L54-L56)
 
 Internally, we force it into the following shape in order to conform to the following schema definition:
 - [Runtime Configuration Schema](https://github.com/duckduckgo/content-scope-scripts/blob/shane/unify-config/src/schema/runtime-configuration.schema.json)

--- a/scripts/release/update-bsk-repo.js
+++ b/scripts/release/update-bsk-repo.js
@@ -7,8 +7,8 @@ const { updatePackageResolved, updatePackageSwift } = require('./release-utils.j
 const autofillCommit = process.env.GITHUB_SHA;
 const autofillVersion = process.env.VERSION;
 
-const packageSwiftPath = filepath('../../apple-monorepo/BrowserServicesKit/Package.swift');
-const packageResolvedPath = filepath('../../apple-monorepo/BrowserServicesKit/Package.resolved');
+const packageSwiftPath = filepath('../../apple-monorepo/SharedPackages/BrowserServicesKit/Package.swift');
+const packageResolvedPath = filepath('../../apple-monorepo/SharedPackages/BrowserServicesKit/Package.resolved');
 
 function updateBSKRepo(version, commit) {
     console.log('running updateBSKrepo');


### PR DESCRIPTION
**Reviewer:** @dbajpeyi 
**Asana:** https://app.asana.com/0/414235014887631/1209745503606409/f

## Description
This PR updates the BSK paths to account for upcoming changes in https://github.com/duckduckgo/apple-browsers/pull/304.

This PR will be merged as soon as the upstream changes are complete.

## Steps to test
1. Check that CI is green
2. Check that no other references to BSK need updating - this is hard to test otherwise, since the upstream changes aren't yet merged