### PR TITLE
[SiteSpecificFixes] Add support for input types

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12529,7 +12529,7 @@ Source: "${matchedFrom}"`;
       super(FEATURE_NAME, args);
     }
     /**
-     * @returns {InputTypeSettings}
+     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['inputTypeSettings']}
      */
     get inputTypeSettings() {
       return this.getFeatureSetting("inputTypeSettings") || [];
@@ -12539,7 +12539,10 @@ Source: "${matchedFrom}"`;
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-      return this.inputTypeSettings.find((config) => input.matches(config.selector))?.type || null;
+      return (
+        /** @type {import('./Form/matching').SupportedTypes} */
+        this.inputTypeSettings?.find((config) => input.matches(config.selector))?.type || null
+      );
     }
     /**
      * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formTypeSettings']}

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -897,11 +897,12 @@ Source: "${matchedFrom}"`;
      * Sets the input type as a data attribute to the element and returns it
      * @param {HTMLInputElement} input
      * @param {HTMLElement} formEl
+     * @param {SupportedTypes | null} forcedInputType
      * @param {SetInputTypeOpts} [opts]
      * @returns {SupportedSubTypes | string}
      */
-    setInputType(input, formEl, opts = {}) {
-      const type = this.inferInputType(input, formEl, opts);
+    setInputType(input, formEl, forcedInputType, opts = {}) {
+      const type = forcedInputType || this.inferInputType(input, formEl, opts);
       input.setAttribute(ATTR_INPUT_TYPE, type);
       return type;
     }
@@ -5857,7 +5858,8 @@ Source: "${matchedFrom}"`;
         hasCredentials: Boolean(this.device.settings.availableInputTypes.credentials?.username),
         supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
       };
-      this.matching.setInputType(input, this.form, opts);
+      const forcedInputType = this.device.settings.siteSpecificFeature?.getForcedInputType(input) || null;
+      this.matching.setInputType(input, this.form, forcedInputType, opts);
       const mainInputType = getInputMainType(input);
       this.inputs[mainInputType].add(input);
       this.decorateInput(input);
@@ -12525,6 +12527,22 @@ Source: "${matchedFrom}"`;
   var SiteSpecificFeature = class extends ConfigFeature {
     constructor(args) {
       super(FEATURE_NAME, args);
+    }
+    /**
+     * @returns {ForcedInputTypes}
+     */
+    get forcedInputTypes() {
+      return this.getFeatureSetting("forcedInputTypes") || [];
+    }
+    /**
+     * @param {HTMLInputElement} input
+     * @returns {import('./Form/matching').SupportedTypes | null}
+     */
+    getForcedInputType(input) {
+      return (
+        /** @type {import('./Form/matching').SupportedTypes} */
+        this.forcedInputTypes.find((config) => input.matches(config.selector))?.type || null
+      );
     }
     /**
      * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formTypeSettings']}

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12529,7 +12529,7 @@ Source: "${matchedFrom}"`;
       super(FEATURE_NAME, args);
     }
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['inputTypeSettings']}
+     * @returns {InputTypeSetting[]}
      */
     get inputTypeSettings() {
       return this.getFeatureSetting("inputTypeSettings") || [];
@@ -12539,19 +12539,19 @@ Source: "${matchedFrom}"`;
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-      return (
-        /** @type {import('./Form/matching').SupportedTypes} */
-        this.inputTypeSettings?.find((config) => input.matches(config.selector))?.type || null
-      );
+      const setting = this.inputTypeSettings.find((config) => input.matches(config.selector));
+      if (!isValidSupportedType(setting?.type))
+        return null;
+      return setting?.type;
     }
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formTypeSettings']}
+     * @returns {FormTypeSetting[]}
      */
     get formTypeSettings() {
       return this.getFeatureSetting("formTypeSettings") || [];
     }
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formBoundarySelector'] | null}
+     * @returns {FormBoundarySelector|null}
      */
     get formBoundarySelector() {
       return this.getFeatureSetting("formBoundarySelector");
@@ -12562,7 +12562,7 @@ Source: "${matchedFrom}"`;
      * @returns {string|null|undefined}
      */
     getForcedFormType(form) {
-      return this.formTypeSettings?.find((config) => form.matches(config.selector))?.type;
+      return this.formTypeSettings.find((config) => form.matches(config.selector))?.type;
     }
     /**
      * @returns {HTMLElement|null}

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -12529,20 +12529,17 @@ Source: "${matchedFrom}"`;
       super(FEATURE_NAME, args);
     }
     /**
-     * @returns {ForcedInputTypes}
+     * @returns {InputTypeSettings}
      */
-    get forcedInputTypes() {
-      return this.getFeatureSetting("forcedInputTypes") || [];
+    get inputTypeSettings() {
+      return this.getFeatureSetting("inputTypeSettings") || [];
     }
     /**
      * @param {HTMLInputElement} input
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-      return (
-        /** @type {import('./Form/matching').SupportedTypes} */
-        this.forcedInputTypes.find((config) => input.matches(config.selector))?.type || null
-      );
+      return this.inputTypeSettings.find((config) => input.matches(config.selector))?.type || null;
     }
     /**
      * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formTypeSettings']}

--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -897,11 +897,12 @@ Source: "${matchedFrom}"`;
      * Sets the input type as a data attribute to the element and returns it
      * @param {HTMLInputElement} input
      * @param {HTMLElement} formEl
-     * @param {SupportedTypes | null} forcedInputType
+     * @param {import('../site-specific-feature.js').default | null} siteSpecificFeature
      * @param {SetInputTypeOpts} [opts]
      * @returns {SupportedSubTypes | string}
      */
-    setInputType(input, formEl, forcedInputType, opts = {}) {
+    setInputType(input, formEl, siteSpecificFeature, opts = {}) {
+      const forcedInputType = siteSpecificFeature?.getForcedInputType(input);
       const type = forcedInputType || this.inferInputType(input, formEl, opts);
       input.setAttribute(ATTR_INPUT_TYPE, type);
       return type;
@@ -5858,8 +5859,7 @@ Source: "${matchedFrom}"`;
         hasCredentials: Boolean(this.device.settings.availableInputTypes.credentials?.username),
         supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
       };
-      const forcedInputType = this.device.settings.siteSpecificFeature?.getForcedInputType(input) || null;
-      this.matching.setInputType(input, this.form, forcedInputType, opts);
+      this.matching.setInputType(input, this.form, this.device.settings.siteSpecificFeature, opts);
       const mainInputType = getInputMainType(input);
       this.inputs[mainInputType].add(input);
       this.decorateInput(input);

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8100,7 +8100,7 @@ Source: "${matchedFrom}"`;
       super(FEATURE_NAME, args);
     }
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['inputTypeSettings']}
+     * @returns {InputTypeSetting[]}
      */
     get inputTypeSettings() {
       return this.getFeatureSetting("inputTypeSettings") || [];
@@ -8110,19 +8110,19 @@ Source: "${matchedFrom}"`;
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-      return (
-        /** @type {import('./Form/matching').SupportedTypes} */
-        this.inputTypeSettings?.find((config) => input.matches(config.selector))?.type || null
-      );
+      const setting = this.inputTypeSettings.find((config) => input.matches(config.selector));
+      if (!isValidSupportedType(setting?.type))
+        return null;
+      return setting?.type;
     }
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formTypeSettings']}
+     * @returns {FormTypeSetting[]}
      */
     get formTypeSettings() {
       return this.getFeatureSetting("formTypeSettings") || [];
     }
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formBoundarySelector'] | null}
+     * @returns {FormBoundarySelector|null}
      */
     get formBoundarySelector() {
       return this.getFeatureSetting("formBoundarySelector");
@@ -8133,7 +8133,7 @@ Source: "${matchedFrom}"`;
      * @returns {string|null|undefined}
      */
     getForcedFormType(form) {
-      return this.formTypeSettings?.find((config) => form.matches(config.selector))?.type;
+      return this.formTypeSettings.find((config) => form.matches(config.selector))?.type;
     }
     /**
      * @returns {HTMLElement|null}

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8100,20 +8100,17 @@ Source: "${matchedFrom}"`;
       super(FEATURE_NAME, args);
     }
     /**
-     * @returns {ForcedInputTypes}
+     * @returns {InputTypeSettings}
      */
-    get forcedInputTypes() {
-      return this.getFeatureSetting("forcedInputTypes") || [];
+    get inputTypeSettings() {
+      return this.getFeatureSetting("inputTypeSettings") || [];
     }
     /**
      * @param {HTMLInputElement} input
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-      return (
-        /** @type {import('./Form/matching').SupportedTypes} */
-        this.forcedInputTypes.find((config) => input.matches(config.selector))?.type || null
-      );
+      return this.inputTypeSettings.find((config) => input.matches(config.selector))?.type || null;
     }
     /**
      * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formTypeSettings']}

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -8100,7 +8100,7 @@ Source: "${matchedFrom}"`;
       super(FEATURE_NAME, args);
     }
     /**
-     * @returns {InputTypeSettings}
+     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['inputTypeSettings']}
      */
     get inputTypeSettings() {
       return this.getFeatureSetting("inputTypeSettings") || [];
@@ -8110,7 +8110,10 @@ Source: "${matchedFrom}"`;
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-      return this.inputTypeSettings.find((config) => input.matches(config.selector))?.type || null;
+      return (
+        /** @type {import('./Form/matching').SupportedTypes} */
+        this.inputTypeSettings?.find((config) => input.matches(config.selector))?.type || null
+      );
     }
     /**
      * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formTypeSettings']}

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -897,11 +897,12 @@ Source: "${matchedFrom}"`;
      * Sets the input type as a data attribute to the element and returns it
      * @param {HTMLInputElement} input
      * @param {HTMLElement} formEl
-     * @param {SupportedTypes | null} forcedInputType
+     * @param {import('../site-specific-feature.js').default | null} siteSpecificFeature
      * @param {SetInputTypeOpts} [opts]
      * @returns {SupportedSubTypes | string}
      */
-    setInputType(input, formEl, forcedInputType, opts = {}) {
+    setInputType(input, formEl, siteSpecificFeature, opts = {}) {
+      const forcedInputType = siteSpecificFeature?.getForcedInputType(input);
       const type = forcedInputType || this.inferInputType(input, formEl, opts);
       input.setAttribute(ATTR_INPUT_TYPE, type);
       return type;
@@ -5858,8 +5859,7 @@ Source: "${matchedFrom}"`;
         hasCredentials: Boolean(this.device.settings.availableInputTypes.credentials?.username),
         supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities
       };
-      const forcedInputType = this.device.settings.siteSpecificFeature?.getForcedInputType(input) || null;
-      this.matching.setInputType(input, this.form, forcedInputType, opts);
+      this.matching.setInputType(input, this.form, this.device.settings.siteSpecificFeature, opts);
       const mainInputType = getInputMainType(input);
       this.inputs[mainInputType].add(input);
       this.decorateInput(input);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-env": "^7.22.20",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.1.0",
         "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#main",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#dbajpeyi/feat/autofill-update-privacy-config",
         "@duckduckgo/privacy-test-pages": "github:duckduckgo/privacy-test-pages#1.3.1",
         "@playwright/test": "^1.50.0",
         "@types/jest": "^29.5.11",
@@ -1777,7 +1777,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#15dad087783ce5b4389e25d63e84c646cf5eb025",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#2502c03c66171b16c0a9b691f2c3bf3b0324b6d0",
       "dev": true,
       "dependencies": {
         "eslint-plugin-json": "^4.0.1",
@@ -2168,9 +2168,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.0.tgz",
+      "integrity": "sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==",
       "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -4833,9 +4833,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.135",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.135.tgz",
-      "integrity": "sha512-8gXUdEmvb+WCaYUhA0Svr08uSeRjM2w3x5uHOc1QbaEVzJXB8rgm5eptieXzyKoVEtinLvW6MtTcurA65PeS1Q==",
+      "version": "1.5.136",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz",
+      "integrity": "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -10728,21 +10728,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.85",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.85.tgz",
-      "integrity": "sha512-gBdZ1RjCSevRPFix/hpaUWeak2/RNUZB4/8frF1r5uYMHjFptkiT0JXIebWvgI/0ZHXvxaUDDJshiA0j6GdL3w==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "dependencies": {
-        "tldts-core": "^6.1.85"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.85",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.85.tgz",
-      "integrity": "sha512-DTjUVvxckL1fIoPSb3KE7ISNtkWSawZdpfxGxwiIrZoO6EbHVDXXUIlIuWympPaeS+BLGyggozX/HTMsRAdsoA==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true
     },
     "node_modules/tmp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,7 +1777,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#2502c03c66171b16c0a9b691f2c3bf3b0324b6d0",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#e1f069625ac37f34471f68575983fa6e35fe694b",
       "dev": true,
       "dependencies": {
         "eslint-plugin-json": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-env": "^7.22.20",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.1.0",
         "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#dbajpeyi/feat/autofill-update-privacy-config",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#main",
         "@duckduckgo/privacy-test-pages": "github:duckduckgo/privacy-test-pages#1.3.1",
         "@playwright/test": "^1.50.0",
         "@types/jest": "^29.5.11",
@@ -1777,7 +1777,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#e1f069625ac37f34471f68575983fa6e35fe694b",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#f94e1afa41d97d65e5d809f7fb3dde4bfef8561f",
       "dev": true,
       "dependencies": {
         "eslint-plugin-json": "^4.0.1",
@@ -4833,9 +4833,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.136",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz",
-      "integrity": "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==",
+      "version": "1.5.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.137.tgz",
+      "integrity": "sha512-/QSJaU2JyIuTbbABAo/crOs+SuAZLS+fVVS10PVrIT9hrRkmZl8Hb0xPSkKRUUWHQtYzXHpQUW3Dy5hwMzGZkA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -9472,9 +9472,9 @@
       }
     },
     "node_modules/portfinder": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.35.tgz",
-      "integrity": "sha512-73JaFg4NwYNAufDtS5FsFu/PdM49ahJrO1i44aCRsDWju1z5wuGDaqyFUQWR6aJoK2JPDWlaYYAGFNIGTSUHSw==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.36.tgz",
+      "integrity": "sha512-gMKUzCoP+feA7t45moaSx7UniU7PgGN3hA8acAB+3Qn7/js0/lJ07fYZlxt9riE9S3myyxDCyAFzSrLlta0c9g==",
       "dev": true,
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.1.0",
     "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
     "@duckduckgo/privacy-test-pages": "github:duckduckgo/privacy-test-pages#1.3.1",
-    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#main",
+    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#dbajpeyi/feat/autofill-update-privacy-config",
     "@playwright/test": "^1.50.0",
     "@types/jest": "^29.5.11",
     "@types/node": "^18.17.19",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.1.0",
     "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
     "@duckduckgo/privacy-test-pages": "github:duckduckgo/privacy-test-pages#1.3.1",
-    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#dbajpeyi/feat/autofill-update-privacy-config",
+    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#main",
     "@playwright/test": "^1.50.0",
     "@types/jest": "^29.5.11",
     "@types/node": "^18.17.19",

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -570,10 +570,8 @@ class Form {
             hasCredentials: Boolean(this.device.settings.availableInputTypes.credentials?.username),
             supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities,
         };
-        // The type is inferred as undefined when using the forcedInputType, seems like some TSC limitation.
-        // Hence we force it to null.
-        const forcedInputType = this.device.settings.siteSpecificFeature?.getForcedInputType(input) || null;
-        this.matching.setInputType(input, this.form, forcedInputType, opts);
+
+        this.matching.setInputType(input, this.form, this.device.settings.siteSpecificFeature, opts);
 
         const mainInputType = getInputMainType(input);
         this.inputs[mainInputType].add(input);

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -570,7 +570,10 @@ class Form {
             hasCredentials: Boolean(this.device.settings.availableInputTypes.credentials?.username),
             supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities,
         };
-        this.matching.setInputType(input, this.form, opts);
+        // Seems like the the type is inferred as undefined when using the forcedInputType, seems like some TSC limitation.
+        // Hence we force it to null.
+        const forcedInputType = this.device.settings.siteSpecificFeature?.getForcedInputType(input) || null;
+        this.matching.setInputType(input, this.form, forcedInputType, opts);
 
         const mainInputType = getInputMainType(input);
         this.inputs[mainInputType].add(input);

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -570,7 +570,7 @@ class Form {
             hasCredentials: Boolean(this.device.settings.availableInputTypes.credentials?.username),
             supportsIdentitiesAutofill: this.device.settings.featureToggles.inputType_identities,
         };
-        // Seems like the the type is inferred as undefined when using the forcedInputType, seems like some TSC limitation.
+        // The type is inferred as undefined when using the forcedInputType, seems like some TSC limitation.
         // Hence we force it to null.
         const forcedInputType = this.device.settings.siteSpecificFeature?.getForcedInputType(input) || null;
         this.matching.setInputType(input, this.form, forcedInputType, opts);

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -707,4 +707,31 @@ describe('site specific fixes', () => {
             expect(form?.isSignup).toBeTruthy();
         });
     });
+
+    describe('Force input type', () => {
+        beforeEach(() => {
+            document.body.innerHTML = '';
+            attachAndReturnGenericForm(`
+                <form id="login">
+                    <input id="username-input" type="text" value="username" autocomplete="username" />
+                </form>`);
+        });
+
+        test('when a forced input type is not present in the config', () => {
+            const deviceInterface = InterfacePrototype.default();
+            // Setting a forced form type, but no forced input type
+            setMockSiteSpecificFixes(deviceInterface, 'form-boundary');
+            createScanner(deviceInterface).findEligibleInputs(document);
+            const input = /** @type {HTMLInputElement} */ (document.getElementById('username-input'));
+            expect(input.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.username');
+        });
+
+        test('when a forced input type is present in the config', () => {
+            const deviceInterface = InterfacePrototype.default();
+            setMockSiteSpecificFixes(deviceInterface, 'input-type');
+            createScanner(deviceInterface).findEligibleInputs(document);
+            const input = /** @type {HTMLInputElement} */ (document.getElementById('username-input'));
+            expect(input.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('identities.emailAddress');
+        });
+    });
 });

--- a/src/Form/matching.js
+++ b/src/Form/matching.js
@@ -323,11 +323,12 @@ class Matching {
      * Sets the input type as a data attribute to the element and returns it
      * @param {HTMLInputElement} input
      * @param {HTMLElement} formEl
+     * @param {SupportedTypes | null} forcedInputType
      * @param {SetInputTypeOpts} [opts]
      * @returns {SupportedSubTypes | string}
      */
-    setInputType(input, formEl, opts = {}) {
-        const type = this.inferInputType(input, formEl, opts);
+    setInputType(input, formEl, forcedInputType, opts = {}) {
+        const type = forcedInputType || this.inferInputType(input, formEl, opts);
         input.setAttribute(ATTR_INPUT_TYPE, type);
         return type;
     }

--- a/src/Form/matching.js
+++ b/src/Form/matching.js
@@ -1023,4 +1023,5 @@ export {
     checkPlaceholderAndLabels,
     Matching,
     createMatching,
+    isValidSupportedType,
 };

--- a/src/Form/matching.js
+++ b/src/Form/matching.js
@@ -323,11 +323,12 @@ class Matching {
      * Sets the input type as a data attribute to the element and returns it
      * @param {HTMLInputElement} input
      * @param {HTMLElement} formEl
-     * @param {SupportedTypes | null} forcedInputType
+     * @param {import('../site-specific-feature.js').default | null} siteSpecificFeature
      * @param {SetInputTypeOpts} [opts]
      * @returns {SupportedSubTypes | string}
      */
-    setInputType(input, formEl, forcedInputType, opts = {}) {
+    setInputType(input, formEl, siteSpecificFeature, opts = {}) {
+        const forcedInputType = siteSpecificFeature?.getForcedInputType(input);
         const type = forcedInputType || this.inferInputType(input, formEl, opts);
         input.setAttribute(ATTR_INPUT_TYPE, type);
         return type;

--- a/src/site-specific-feature.js
+++ b/src/site-specific-feature.js
@@ -2,9 +2,31 @@ import ConfigFeature from '@duckduckgo/content-scope-scripts/injected/src/config
 
 const FEATURE_NAME = 'siteSpecificFixes';
 
+// TMP: will come from privacy-configuration
+/** @typedef {Array<{selector: string, type: string}>} ForcedInputTypes */
+
 export default class SiteSpecificFeature extends ConfigFeature {
     constructor(args) {
         super(FEATURE_NAME, args);
+    }
+
+    /**
+     * @returns {ForcedInputTypes}
+     */
+    get forcedInputTypes() {
+        return this.getFeatureSetting('forcedInputTypes') || [];
+    }
+
+    /**
+     * @param {HTMLInputElement} input
+     * @returns {import('./Form/matching').SupportedTypes | null}
+     */
+    getForcedInputType(input) {
+        return (
+            /** @type {import('./Form/matching').SupportedTypes} */ (
+                this.forcedInputTypes.find((config) => input.matches(config.selector))?.type
+            ) || null
+        );
     }
 
     /**

--- a/src/site-specific-feature.js
+++ b/src/site-specific-feature.js
@@ -3,7 +3,7 @@ import ConfigFeature from '@duckduckgo/content-scope-scripts/injected/src/config
 const FEATURE_NAME = 'siteSpecificFixes';
 
 // TMP: will come from privacy-configuration
-/** @typedef {Array<{selector: string, type: string}>} ForcedInputTypes */
+/** @typedef {Array<{selector: string, type: import('./Form/matching').SupportedTypes}>} InputTypeSettings */
 
 export default class SiteSpecificFeature extends ConfigFeature {
     constructor(args) {
@@ -11,10 +11,10 @@ export default class SiteSpecificFeature extends ConfigFeature {
     }
 
     /**
-     * @returns {ForcedInputTypes}
+     * @returns {InputTypeSettings}
      */
-    get forcedInputTypes() {
-        return this.getFeatureSetting('forcedInputTypes') || [];
+    get inputTypeSettings() {
+        return this.getFeatureSetting('inputTypeSettings') || [];
     }
 
     /**
@@ -22,11 +22,7 @@ export default class SiteSpecificFeature extends ConfigFeature {
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-        return (
-            /** @type {import('./Form/matching').SupportedTypes} */ (
-                this.forcedInputTypes.find((config) => input.matches(config.selector))?.type
-            ) || null
-        );
+        return this.inputTypeSettings.find((config) => input.matches(config.selector))?.type || null;
     }
 
     /**

--- a/src/site-specific-feature.js
+++ b/src/site-specific-feature.js
@@ -2,16 +2,13 @@ import ConfigFeature from '@duckduckgo/content-scope-scripts/injected/src/config
 
 const FEATURE_NAME = 'siteSpecificFixes';
 
-// TMP: will come from privacy-configuration
-/** @typedef {Array<{selector: string, type: import('./Form/matching').SupportedTypes}>} InputTypeSettings */
-
 export default class SiteSpecificFeature extends ConfigFeature {
     constructor(args) {
         super(FEATURE_NAME, args);
     }
 
     /**
-     * @returns {InputTypeSettings}
+     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['inputTypeSettings']}
      */
     get inputTypeSettings() {
         return this.getFeatureSetting('inputTypeSettings') || [];
@@ -22,7 +19,11 @@ export default class SiteSpecificFeature extends ConfigFeature {
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-        return this.inputTypeSettings.find((config) => input.matches(config.selector))?.type || null;
+        return (
+            /** @type {import('./Form/matching').SupportedTypes} */ (
+                this.inputTypeSettings?.find((config) => input.matches(config.selector))?.type
+            ) || null
+        );
     }
 
     /**

--- a/src/site-specific-feature.js
+++ b/src/site-specific-feature.js
@@ -1,6 +1,13 @@
 import ConfigFeature from '@duckduckgo/content-scope-scripts/injected/src/config-feature';
+import { isValidSupportedType } from './Form/matching.js';
 
 const FEATURE_NAME = 'siteSpecificFixes';
+
+/**
+ * @typedef {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').InputTypeSetting} InputTypeSetting
+ * @typedef {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').FormTypeSetting} FormTypeSetting
+ * @typedef {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').FormBoundarySelector} FormBoundarySelector
+ */
 
 export default class SiteSpecificFeature extends ConfigFeature {
     constructor(args) {
@@ -8,7 +15,7 @@ export default class SiteSpecificFeature extends ConfigFeature {
     }
 
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['inputTypeSettings']}
+     * @returns {InputTypeSetting[]}
      */
     get inputTypeSettings() {
         return this.getFeatureSetting('inputTypeSettings') || [];
@@ -19,22 +26,20 @@ export default class SiteSpecificFeature extends ConfigFeature {
      * @returns {import('./Form/matching').SupportedTypes | null}
      */
     getForcedInputType(input) {
-        return (
-            /** @type {import('./Form/matching').SupportedTypes} */ (
-                this.inputTypeSettings?.find((config) => input.matches(config.selector))?.type
-            ) || null
-        );
+        const setting = this.inputTypeSettings.find((config) => input.matches(config.selector));
+        if (!isValidSupportedType(setting?.type)) return null;
+        return setting?.type;
     }
 
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formTypeSettings']}
+     * @returns {FormTypeSetting[]}
      */
     get formTypeSettings() {
         return this.getFeatureSetting('formTypeSettings') || [];
     }
 
     /**
-     * @returns {import('@duckduckgo/privacy-configuration/schema/features/autofill.js').SiteSpecificFixes['formBoundarySelector'] | null}
+     * @returns {FormBoundarySelector|null}
      */
     get formBoundarySelector() {
         return this.getFeatureSetting('formBoundarySelector');
@@ -46,7 +51,7 @@ export default class SiteSpecificFeature extends ConfigFeature {
      * @returns {string|null|undefined}
      */
     getForcedFormType(form) {
-        return this.formTypeSettings?.find((config) => form.matches(config.selector))?.type;
+        return this.formTypeSettings.find((config) => form.matches(config.selector))?.type;
     }
 
     /**

--- a/src/testConfig/siteSpecificFixes/input-type.json
+++ b/src/testConfig/siteSpecificFixes/input-type.json
@@ -1,0 +1,28 @@
+{
+    "siteSpecificFixes": {
+        "state": "enabled",
+        "settings": {
+            "domains": [
+                {
+                    "domain": [
+                        "localhost"
+                    ],
+                    "patchSettings": [
+                        {
+                            "path": "",
+                            "op": "add",
+                            "value": {
+                                "inputTypeSettings": [
+                                    {
+                                        "selector": "input[id=\"username-input\"]",
+                                        "type": "identities.emailAddress"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** https://app.asana.com/1/137249556945/project/72649045549333/task/1209945606697018?focus=true

## Description

- [x] Add `inputtypeSettings` support in autofill.js
- [x] Include this in [autofill.ts](https://github.com/duckduckgo/privacy-configuration/blob/main/schema/features/autofill.ts), in the privacy config repo https://github.com/duckduckgo/privacy-configuration/pull/2983
- [x] Add Form tests for this setting, with example JSON 

## Steps to test
We can test this for the `zendesk` [login page](https://www.zendesk.com/login/).
1. Create a remote config with the following settings (you can play around with the `type` property to be anything:
<img width="592" alt="Screenshot 2025-04-14 at 11 56 53" src="https://github.com/user-attachments/assets/8f8bc7f6-833c-44b0-b88e-a97aeb51dd29" />

2. Go to the login page, and inspect the input type.
3. Without the settings, you should see `unknown` in `data-ddg-inputtype='unknown'` but after you should see it as `identities.emailAddress` or `credentials.username` depending on the `type` set in your config (ideally for zendesk we want `credentials.username`, but you won't see a prompt because there's no password. However if you have an account, and you can get to the password field - it should all just work normally).



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209975580708260
  - https://app.asana.com/0/0/1209945606697018