### PR TITLE
build: add missing precompile-regexes step

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "postinstall": "cd packages/password && npm install",
     "start": "chokidar 'src' 'debug' -i 'src/deviceApiCalls/__generated__' -i 'debug/dist' -c 'npm run build' --initial",
-    "build": "npm run schema:generate && node scripts/bundle.mjs && npm run copy-assets",
+    "build": "npm run precompile-regexes && npm run schema:generate && node scripts/bundle.mjs && npm run copy-assets",
     "build:translations": "node scripts/bundle-locales.mjs",
     "lint": "eslint . && prettier . --check",
     "lint:fix": "eslint . --fix && prettier . --write",


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:** 

## Description

- in the esbuild migration, we missed a line from the Gruntfile that ran the regex generation step, this brings it back


## Steps to test

- make a change in `selectors-css.js`
- run `npm run build` 
- check git, there should be changes in the `dist` folder
