### PR TITLE
Recategorize password variant

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -5719,6 +5719,9 @@ Source: "${matchedFrom}"`;
     canCategorizeAmbiguousInput() {
       return this.device.settings.featureToggles.unknown_username_categorization && this.isLogin && this.ambiguousInputs?.length === 1;
     }
+    canCategorizePasswordVariant() {
+      return this.device.settings.featureToggles.password_variant_categorization;
+    }
     /**
      * Takes an ambiguous input and tries to get a target type that the input should be categorized to.
      * @param {HTMLInputElement} ambiguousInput
@@ -5773,6 +5776,31 @@ Source: "${matchedFrom}"`;
           console.log(`Recategorized input from ${inputType} to ${targetType}`, ambiguousInput);
       }
     }
+    /**
+     * Recategorizes the new/current password field variant
+     */
+    recategorizeInputVariantIfNeeded() {
+      let newPasswordFields = 0;
+      let currentPasswordFields = 0;
+      let firstNewPasswordField = null;
+      for (const credentialElement of this.inputs.credentials) {
+        const variant = getInputVariant(credentialElement);
+        if (variant === "new") {
+          newPasswordFields++;
+          if (!firstNewPasswordField)
+            firstNewPasswordField = credentialElement;
+        }
+        if (variant === "current")
+          currentPasswordFields++;
+        if (newPasswordFields > 3 || currentPasswordFields > 0)
+          return;
+      }
+      if (newPasswordFields === 3 && currentPasswordFields === 0) {
+        if (shouldLog())
+          console.log('Recategorizing password variant to "current"', firstNewPasswordField);
+        firstNewPasswordField.setAttribute(ATTR_INPUT_TYPE2, "credentials.password.current");
+      }
+    }
     categorizeInputs() {
       const selector = this.matching.cssSelector("formInputsSelector");
       if (this.form.matches(selector)) {
@@ -5789,6 +5817,8 @@ Source: "${matchedFrom}"`;
       }
       if (this.canCategorizeAmbiguousInput())
         this.recategorizeInputToTargetType();
+      if (this.canCategorizePasswordVariant())
+        this.recategorizeInputVariantIfNeeded();
       if (this.inputs.all.size === 1 && this.inputs.unknown.size === 1) {
         this.destroy();
         return;
@@ -10499,6 +10529,7 @@ Source: "${matchedFrom}"`;
     inlineIcon_credentials: z.boolean().optional(),
     third_party_credentials_provider: z.boolean().optional(),
     unknown_username_categorization: z.boolean().optional(),
+    password_variant_categorization: z.boolean().optional(),
     partial_form_saves: z.boolean().optional()
   });
   var getIdentityResultSchema = z.object({
@@ -13004,6 +13035,7 @@ Source: "${matchedFrom}"`;
       inputType_creditCards: false,
       inlineIcon_credentials: false,
       unknown_username_categorization: false,
+      password_variant_categorization: false,
       partial_form_saves: false
     },
     /** @type {AvailableInputTypes} */

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -393,6 +393,10 @@ class Form {
         return this.device.settings.featureToggles.unknown_username_categorization && this.isLogin && this.ambiguousInputs?.length === 1;
     }
 
+    canCategorizePasswordVariant() {
+        return this.device.settings.featureToggles.password_variant_categorization;
+    }
+
     /**
      * Takes an ambiguous input and tries to get a target type that the input should be categorized to.
      * @param {HTMLInputElement} ambiguousInput
@@ -450,6 +454,33 @@ class Form {
         }
     }
 
+    /**
+     * Recategorizes the new/current password field variant
+     */
+    recategorizeInputVariantIfNeeded() {
+        let newPasswordFields = 0;
+        let currentPasswordFields = 0;
+        let firstNewPasswordField = null;
+
+        for (const credentialElement of this.inputs.credentials) {
+            const variant = getInputVariant(credentialElement);
+            if (variant === 'new') {
+                newPasswordFields++;
+                if (!firstNewPasswordField) firstNewPasswordField = credentialElement;
+            }
+            if (variant === 'current') currentPasswordFields++;
+
+            // Short circuit if the field counts wouldn't match the requirements
+            if (newPasswordFields > 3 || currentPasswordFields > 0) return;
+        }
+
+        // If a form has 3 new-password fields, but no current, the first is likely a current
+        if (newPasswordFields === 3 && currentPasswordFields === 0) {
+            if (shouldLog()) console.log('Recategorizing password variant to "current"', firstNewPasswordField);
+            firstNewPasswordField.setAttribute(ATTR_INPUT_TYPE, 'credentials.password.current');
+        }
+    }
+
     categorizeInputs() {
         const selector = this.matching.cssSelector('formInputsSelector');
         // If there's no form container and it's just a lonely input field (this.form is an input field)
@@ -474,6 +505,8 @@ class Form {
         }
 
         if (this.canCategorizeAmbiguousInput()) this.recategorizeInputToTargetType();
+
+        if (this.canCategorizePasswordVariant()) this.recategorizeInputVariantIfNeeded();
 
         // If the form has only one input and it's unknown, discard the form
         if (this.inputs.all.size === 1 && this.inputs.unknown.size === 1) {

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -430,6 +430,7 @@ describe('Form re-categorizes inputs', () => {
     const deviceInterface = InterfacePrototype.default();
     deviceInterface.settings.setFeatureToggles({
         unknown_username_categorization: true,
+        password_variant_categorization: true,
     });
     describe('Should recategorize', () => {
         test('when form has unknown input and has username data available', () => {

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -736,3 +736,114 @@ describe('site specific fixes', () => {
         });
     });
 });
+
+describe('Password variant recategorization', () => {
+    test('recategorizes first password field to current-password when there are 3 new-password fields', () => {
+        attachAndReturnGenericForm(`
+            <form>
+                <input id="old-password" type="password" value="oldPassword" />
+                <input id="new-password" type="password" value="newPassword" autocomplete="new-password" />
+                <input id="confirm-password" type="password" value="confirmPassword" autocomplete="new-password" />
+                <button type="submit">Change Password</button>
+            </form>`);
+
+        // Create a device interface with password_variant_categorization enabled
+        const deviceInterface = InterfacePrototype.default();
+        deviceInterface.settings.setFeatureToggles({
+            password_variant_categorization: true,
+        });
+
+        createScanner(deviceInterface).findEligibleInputs(document);
+        
+        // Query password inputs by their IDs
+        const oldPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('old-password'));
+        const newPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('new-password'));
+        const confirmPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('confirm-password'));
+
+        // The first password field should be recategorized to current-password
+        expect(oldPasswordInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.current');
+        // The other password fields should remain as new-password
+        expect(newPasswordInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+        expect(confirmPasswordInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+    });
+
+    test('does not recategorize when there are less than 3 new-password fields', () => {
+        attachAndReturnGenericForm(`
+            <form>
+                <input id="new-password" type="password" value="newPassword" autocomplete="new-password" />
+                <input id="confirm-password" type="password" value="confirmPassword" autocomplete="new-password" />
+                <button type="submit">Create Account</button>
+            </form>`);
+
+        const deviceInterface = InterfacePrototype.default();
+        deviceInterface.settings.setFeatureToggles({
+            password_variant_categorization: true,
+        });
+
+        createScanner(deviceInterface).findEligibleInputs(document);
+        
+        // Query password inputs by their IDs
+        const newPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('new-password'));
+        const confirmPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('confirm-password'));
+
+        // Both password fields should remain as new-password
+        expect(newPasswordInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+        expect(confirmPasswordInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+    });
+
+    test('does not recategorize when there is already a current-password field', () => {
+        attachAndReturnGenericForm(`
+            <form>
+                <input id="current-password" type="password" value="oldPassword" autocomplete="current-password" />
+                <input id="new-password" type="password" value="newPassword" autocomplete="new-password" />
+                <input id="confirm-password" type="password" value="confirmPassword" autocomplete="new-password" />
+                <button type="submit">Change Password</button>
+            </form>`);
+
+        const deviceInterface = InterfacePrototype.default();
+        deviceInterface.settings.setFeatureToggles({
+            password_variant_categorization: true,
+        });
+
+        createScanner(deviceInterface).findEligibleInputs(document);
+        
+        // Query password inputs by their IDs
+        const currentPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('current-password'));
+        const newPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('new-password'));
+        const confirmPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('confirm-password'));
+
+        // The first password should remain as current-password
+        expect(currentPasswordInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.current');
+        // The other password fields should remain as new-password
+        expect(newPasswordInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+        expect(confirmPasswordInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+    });
+
+    test('does not recategorize when feature toggle is disabled', () => {
+        attachAndReturnGenericForm(`
+            <form>
+                <input id="password1" type="password" value="oldPassword" autocomplete="new-password" />
+                <input id="password2" type="password" value="newPassword" autocomplete="new-password" />
+                <input id="password3" type="password" value="confirmPassword" autocomplete="new-password" />
+                <button type="submit">Change Password</button>
+            </form>`);
+
+        // Create a device interface with password_variant_categorization disabled
+        const deviceInterface = InterfacePrototype.default();
+        deviceInterface.settings.setFeatureToggles({
+            password_variant_categorization: false,
+        });
+
+        createScanner(deviceInterface).findEligibleInputs(document);
+        
+        // Query password inputs by their IDs
+        const password1 = /** @type {HTMLInputElement} */ (document.getElementById('password1'));
+        const password2 = /** @type {HTMLInputElement} */ (document.getElementById('password2'));
+        const password3 = /** @type {HTMLInputElement} */ (document.getElementById('password3'));
+
+        // All password fields should remain as new-password
+        expect(password1.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+        expect(password2.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+        expect(password3.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('credentials.password.new');
+    });
+});

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -754,7 +754,7 @@ describe('Password variant recategorization', () => {
         });
 
         createScanner(deviceInterface).findEligibleInputs(document);
-        
+
         // Query password inputs by their IDs
         const oldPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('old-password'));
         const newPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('new-password'));
@@ -781,7 +781,7 @@ describe('Password variant recategorization', () => {
         });
 
         createScanner(deviceInterface).findEligibleInputs(document);
-        
+
         // Query password inputs by their IDs
         const newPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('new-password'));
         const confirmPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('confirm-password'));
@@ -806,7 +806,7 @@ describe('Password variant recategorization', () => {
         });
 
         createScanner(deviceInterface).findEligibleInputs(document);
-        
+
         // Query password inputs by their IDs
         const currentPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('current-password'));
         const newPasswordInput = /** @type {HTMLInputElement} */ (document.getElementById('new-password'));
@@ -835,7 +835,7 @@ describe('Password variant recategorization', () => {
         });
 
         createScanner(deviceInterface).findEligibleInputs(document);
-        
+
         // Query password inputs by their IDs
         const password1 = /** @type {HTMLInputElement} */ (document.getElementById('password1'));
         const password2 = /** @type {HTMLInputElement} */ (document.getElementById('password2'));

--- a/src/Form/input-classifiers.test.js
+++ b/src/Form/input-classifiers.test.js
@@ -214,6 +214,7 @@ describe.each(testCases)('Test $html fields', (testCase) => {
         deviceInterface.settings.setAvailableInputTypes(availableInputTypes);
         deviceInterface.settings.setFeatureToggles({
             unknown_username_categorization: true,
+            password_variant_categorization: true,
         });
         const scanner = createScanner(deviceInterface);
         scanner.findEligibleInputs(document);

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -399,6 +399,7 @@ export class Settings {
             inputType_creditCards: false,
             inlineIcon_credentials: false,
             unknown_username_categorization: false,
+            password_variant_categorization: false,
             partial_form_saves: false,
         },
         /** @type {AvailableInputTypes} */

--- a/src/Settings.test.js
+++ b/src/Settings.test.js
@@ -148,6 +148,7 @@ describe('Settings', () => {
         "inputType_identities": false,
         "partial_form_saves": false,
         "password_generation": false,
+        "password_variant_categorization": false,
         "unknown_username_categorization": false,
       }
     `);

--- a/src/deviceApiCalls/__generated__/validators-ts.ts
+++ b/src/deviceApiCalls/__generated__/validators-ts.ts
@@ -734,9 +734,13 @@ export interface AutofillFeatureToggles {
   inlineIcon_credentials?: boolean;
   third_party_credentials_provider?: boolean;
   /**
-   * If true, we will attempt categorizaing username, based on the rest of the input fields in the form
+   * If true, we will attempt re-categorizing username, based on the rest of the input fields in the form
    */
   unknown_username_categorization?: boolean;
+  /**
+   * If true, we will attempt re-categorizing the password variant, based on other fields in the form
+   */
+  password_variant_categorization?: boolean;
   /**
    * If true, then username only form saves will be allowed
    */

--- a/src/deviceApiCalls/__generated__/validators.zod.js
+++ b/src/deviceApiCalls/__generated__/validators.zod.js
@@ -257,6 +257,7 @@ export const autofillFeatureTogglesSchema = z.object({
     inlineIcon_credentials: z.boolean().optional(),
     third_party_credentials_provider: z.boolean().optional(),
     unknown_username_categorization: z.boolean().optional(),
+    password_variant_categorization: z.boolean().optional(),
     partial_form_saves: z.boolean().optional()
 });
 

--- a/src/deviceApiCalls/schemas/autofill-settings.json
+++ b/src/deviceApiCalls/schemas/autofill-settings.json
@@ -40,7 +40,11 @@
         },
         "unknown_username_categorization": {
           "type": "boolean",
-          "description": "If true, we will attempt categorizaing username, based on the rest of the input fields in the form"
+          "description": "If true, we will attempt re-categorizing username, based on the rest of the input fields in the form"
+        },
+        "password_variant_categorization": {
+          "type": "boolean",
+          "description": "If true, we will attempt re-categorizing the password variant, based on other fields in the form"
         },
         "partial_form_saves": {
           "type": "boolean",

--- a/test-forms/index.json
+++ b/test-forms/index.json
@@ -556,5 +556,6 @@
   { "html": "revolut_business_login.html" },
   { "html": "amazon-mobile-payment-form.html" },
   { "html": "brickit_payment-form.html" },
-  { "html": "fedex_login.html" }
+  { "html": "fedex_login.html" },
+  { "html": "sielte_change-password.html" }
 ]

--- a/test-forms/sielte_change-password.html
+++ b/test-forms/sielte_change-password.html
@@ -1,0 +1,38 @@
+<form action="/profile/changepassword" method="post" enctype="multipart/form-data" class="form-horizontal form-bordered">
+    <input type="hidden" name="csrfmiddlewaretoken" value="">
+
+    <div class="box-body">
+        <div class="form-group">
+            <label class="color_blu font_general col-xs-12 col-sm-3" for="old_password">Vecchia Password<span class="text-danger"> * </span></label>
+            <div class="col-xs-12 col-sm-9">
+                <div class="hideShowPassword-wrapper">
+                    <input type="password" name="old_password" autocomplete="off" required="" placeholder="Inserisci la vecchia password..." id="old_password" class="form-control hideShowPassword-field" data-manual-scoring="password.current">
+                    <button type="button" role="button" aria-label="Show Password" title="Show Password" tabindex="0" class="hideShowPassword-toggle hideShowPassword-toggle-show" aria-pressed="false">Show</button>
+                </div>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="color_blu font_general col-xs-12 col-sm-3" for="new_password1">Nuova Password<span class="text-danger"> * </span></label>
+            <div class="col-xs-12 col-sm-9">
+                <div class="hideShowPassword-wrapper">
+                    <input type="password" name="new_password1" autocomplete="off" required="" placeholder="Inserisci la nuova password..." id="new_password1" class="form-control hideShowPassword-field" data-manual-scoring="password.new">
+                    <button type="button" role="button" aria-label="Show Password" title="Show Password" tabindex="0" class="hideShowPassword-toggle hideShowPassword-toggle-show" aria-pressed="false">Show</button>
+                </div>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="color_blu font_general col-xs-12 col-sm-3" for="new_password2">Conferma Nuova Password<span class="text-danger"> * </span></label>
+            <div class="col-xs-12 col-sm-9">
+                <div class="hideShowPassword-wrapper">
+                    <input type="password" name="new_password2" autocomplete="off" required="" placeholder="...conferma la nuova password!" id="new_password2" class="form-control hideShowPassword-field" data-manual-scoring="password.new">
+                    <button type="button" role="button" aria-label="Show Password" title="Show Password" tabindex="0" class="hideShowPassword-toggle hideShowPassword-toggle-show" aria-pressed="false">Show</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- /.box-body -->
+    <div class="box-footer">
+        <button type="submit" class="btn btn-primary" data-manual-submit><span class="glyphicon glyphicon-ok"></span> Cambia password</button>
+    </div>
+    <!-- /.box-footer -->
+</form>


### PR DESCRIPTION
**Reviewer:** 
**Asana:** 

## Description
Recategorizes password fields when a form has 3 `password.new` and no `password.current`. Kinda like the following:
![CleanShot 2025-05-12 at 17 27 47](https://github.com/user-attachments/assets/8cc6d6fe-4953-4925-b60a-b116ed6f1722)

## Steps to test
Added test case.