### PR TITLE
[NativeUIController] touch all inputs on none response

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -11754,6 +11754,10 @@ Source: "${matchedFrom}"`;
             form.activeInput?.focus();
             break;
           }
+          case "none": {
+            form.touchAllInputs(mainType);
+            break;
+          }
           case "acceptGeneratedPassword": {
             form.autofillData(
               {

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -7271,6 +7271,10 @@ Source: "${matchedFrom}"`;
             form.activeInput?.focus();
             break;
           }
+          case "none": {
+            form.touchAllInputs(mainType);
+            break;
+          }
           case "acceptGeneratedPassword": {
             form.autofillData(
               {

--- a/src/UI/controllers/NativeUIController.js
+++ b/src/UI/controllers/NativeUIController.js
@@ -75,6 +75,12 @@ export class NativeUIController extends UIController {
                         form.activeInput?.focus();
                         break;
                     }
+
+                    case 'none': {
+                        form.touchAllInputs(mainType);
+                        break;
+                    }
+
                     case 'acceptGeneratedPassword': {
                         form.autofillData(
                             {


### PR DESCRIPTION
**Reviewer:**  @GioSensation 
**Asana:** 

## Description
For mobile, on `none` response touch all inputs to prevent sending `GetAutofillDataCall` on other inputs of the same type.

## Steps to test
[On iOS]
1. Go to https://privacy-test-pages.site/autofill/autoprompt/2-form-in-modal.html
2. Click on "Click here to open dialog", then click on username field,
3. You will see the prompt, dismiss it.
4. Click on password field.
5. No prompt should be shown.
