### PR TITLE
Improve the check-password-resources automation

### DIFF
--- a/.github/workflows/check-password-resources.yml
+++ b/.github/workflows/check-password-resources.yml
@@ -31,14 +31,14 @@ jobs:
               if: ${{ steps.changes.outputs.hasChanged == 'true' }}
               id: existing_pr
               run: |
-                  pr_numbers=$(gh pr list --state open --head automated/update-password-json-files --json number --jq '.[].number')
+                  pr_numbers=$(gh pr list --state open --head automated/update-password-json-files --json number,createdAt --jq 'sort_by(.createdAt) | reverse | .[].number')
                   if [ -n "$pr_numbers" ]; then
                       pr_count=$(echo "$pr_numbers" | wc -l)
                       if [ "$pr_count" -gt 1 ]; then
-                          echo "Warning: Found $pr_count existing PRs. Using the first one."
+                          echo "Warning: Found $pr_count existing PRs. Using the most recent one."
                       fi
-                      first_pr=$(echo "$pr_numbers" | head -n1)
-                      echo "existingPR=$first_pr" >> "$GITHUB_OUTPUT"
+                      most_recent_pr=$(echo "$pr_numbers" | head -n1)
+                      echo "existingPR=$most_recent_pr" >> "$GITHUB_OUTPUT"
                       echo "hasExistingPR=true" >> "$GITHUB_OUTPUT"
                   else
                       echo "hasExistingPR=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
**Reviewer:** @dbajpeyi 
**Asana:** https://app.asana.com/1/137249556945/project/1198964220583541/task/1206533367254914?focus=true

## Description
Stops the password-resources automation from creating duplicate PRs over and over again. There were 83 such branches until this morning 🤯. This update should just update the most recent existing branch if available. The change was mostly AI-generated.

## Steps to test
