### PR TITLE
[GH Action] Reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
     - package-ecosystem: 'npm'
       directory: '/'
       schedule:
-          interval: 'weekly'
+          interval: 'monthly'
       target-branch: 'main'
       labels:
           - 'dependencies'


### PR DESCRIPTION
**Reviewer:** @GioSensation @borgateo 
**Asana:** 

## Description
Use cron for twice a month run, https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cronjob.

https://hyperping.com/cron-expression-generator#0_9_1,15_*_*

## Steps to test
