### PR TITLE
[Form] Cursor/autofill state dropdown conflict 58f9

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -5343,6 +5343,12 @@ Source: "${matchedFrom}"`;
     return "";
   };
   var canBeInteractedWith = (input) => !input.readOnly && !input.disabled;
+  var hasDropdownIndicators = (input) => {
+    if (input.getAttribute("role") === "combobox") return true;
+    if (input.hasAttribute("aria-haspopup")) return true;
+    if (input.list) return true;
+    return false;
+  };
   var canBeAutofilled = async (input, device) => {
     const mainType = getInputMainType(input);
     if (mainType === "unknown") return false;
@@ -5417,6 +5423,12 @@ Source: "${matchedFrom}"`;
       getIconFilled: getIdentitiesIcon,
       getIconAlternate: getIdentitiesAlternateIcon,
       shouldDecorate: async (input, { device }) => {
+        if (input instanceof HTMLInputElement) {
+          const subtype = getInputSubtype(input);
+          if ((subtype === "addressProvince" || subtype === "addressCountryCode") && hasDropdownIndicators(input)) {
+            return false;
+          }
+        }
         return canBeAutofilled(input, device);
       },
       dataType: "Identities",

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -5339,6 +5339,12 @@ Source: "${matchedFrom}"`;
     return "";
   };
   var canBeInteractedWith = (input) => !input.readOnly && !input.disabled;
+  var hasDropdownIndicators = (input) => {
+    if (input.getAttribute("role") === "combobox") return true;
+    if (input.hasAttribute("aria-haspopup")) return true;
+    if (input.list) return true;
+    return false;
+  };
   var canBeAutofilled = async (input, device) => {
     const mainType = getInputMainType(input);
     if (mainType === "unknown") return false;
@@ -5413,6 +5419,12 @@ Source: "${matchedFrom}"`;
       getIconFilled: getIdentitiesIcon,
       getIconAlternate: getIdentitiesAlternateIcon,
       shouldDecorate: async (input, { device }) => {
+        if (input instanceof HTMLInputElement) {
+          const subtype = getInputSubtype(input);
+          if ((subtype === "addressProvince" || subtype === "addressCountryCode") && hasDropdownIndicators(input)) {
+            return false;
+          }
+        }
         return canBeAutofilled(input, device);
       },
       dataType: "Identities",

--- a/integration-test/helpers/mocks.js
+++ b/integration-test/helpers/mocks.js
@@ -26,6 +26,7 @@ export const constants = {
         loginMultistep: `${privacyTestPagesPrefix}/autoprompt/3-multistep-form.html`,
         shadowDom: `${privacyTestPagesPrefix}/shadow-dom.html`,
         selectInput: `${localPagesPrefix}/select-input.html`,
+        stateDropdown: `${localPagesPrefix}/state-dropdown.html`,
         shadowInputsLogin: `${localPagesPrefix}/shadow-inputs-login.html`,
         unknownUsernameLogin: `${localPagesPrefix}/unknown-username-login.html`,
         creditCardVariousInputs: `${privacyTestPagesPrefix}/credit-card-various-inputs.html`,
@@ -60,6 +61,7 @@ export const constants = {
             lastName: 'Last',
             phone: '+1234567890',
             addressCity: 'city1',
+            addressProvince: 'PA',
         },
         creditCard: {
             id: '01',

--- a/integration-test/helpers/pages/stateDropdownPage.js
+++ b/integration-test/helpers/pages/stateDropdownPage.js
@@ -1,0 +1,78 @@
+import { constants } from '../mocks.js';
+import { expect } from '@playwright/test';
+
+/**
+ * A wrapper around interactions for `integration-test/pages/state-dropdown.html`
+ *
+ * @param {import("@playwright/test").Page} page
+ */
+export function stateDropdownPage(page) {
+    class StateDropdownPage {
+        /**
+         * @param {'combobox' | 'plain-text'} [formType]
+         * @return {Promise<void>}
+         */
+        async navigate(formType = 'combobox') {
+            const url =
+                formType === 'plain-text'
+                    ? `${constants.pages.stateDropdown}?form-type=plain-text`
+                    : constants.pages.stateDropdown;
+            await page.goto(url);
+        }
+
+        /**
+         * Clicks on the first name field and selects the identity from the tooltip
+         * @param {string} name
+         * @param {'combobox' | 'plain-text'} [formType]
+         * @return {Promise<void>}
+         */
+        async selectFirstName(name, formType = 'combobox') {
+            const selector = formType === 'plain-text' ? '#pt-firstname' : '#cb-firstname';
+            const input = page.locator(selector);
+            await input.click();
+            const button = await page.waitForSelector(`button:has-text("${name}")`);
+            await button.click({ force: true });
+        }
+
+        /**
+         * Asserts that the state input does NOT have the autofill decoration attribute
+         * @return {Promise<void>}
+         */
+        async assertComboboxStateNotDecorated() {
+            const stateInput = page.locator('#cb-state');
+            await expect(stateInput).not.toHaveAttribute('data-ddg-autofill');
+        }
+
+        /**
+         * Asserts that the state input DOES have the autofill decoration attribute
+         * @return {Promise<void>}
+         */
+        async assertPlainTextStateDecorated() {
+            const stateInput = page.locator('#pt-state');
+            await expect(stateInput).toHaveAttribute('data-ddg-autofill');
+        }
+
+        /**
+         * Asserts the value of the state input
+         * @param {string} value
+         * @param {'combobox' | 'plain-text'} [formType]
+         * @return {Promise<void>}
+         */
+        async assertStateValue(value, formType = 'combobox') {
+            const selector = formType === 'plain-text' ? '#pt-state' : '#cb-state';
+            const stateInput = page.locator(selector);
+            await expect(stateInput).toHaveValue(value);
+        }
+
+        /**
+         * Asserts the state input still has the input type attribute (classified but not decorated)
+         * @return {Promise<void>}
+         */
+        async assertComboboxStateClassified() {
+            const stateInput = page.locator('#cb-state');
+            await expect(stateInput).toHaveAttribute('data-ddg-inputType', 'identities.addressProvince');
+        }
+    }
+
+    return new StateDropdownPage();
+}

--- a/integration-test/helpers/pages/stateDropdownPage.js
+++ b/integration-test/helpers/pages/stateDropdownPage.js
@@ -13,10 +13,7 @@ export function stateDropdownPage(page) {
          * @return {Promise<void>}
          */
         async navigate(formType = 'combobox') {
-            const url =
-                formType === 'plain-text'
-                    ? `${constants.pages.stateDropdown}?form-type=plain-text`
-                    : constants.pages.stateDropdown;
+            const url = formType === 'plain-text' ? `${constants.pages.stateDropdown}?form-type=plain-text` : constants.pages.stateDropdown;
             await page.goto(url);
         }
 

--- a/integration-test/pages/state-dropdown.html
+++ b/integration-test/pages/state-dropdown.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title>State dropdown autofill conflict</title>
+        <link rel="stylesheet" href="./style.css">
+    </head>
+
+    <body>
+
+        <!-- Form with combobox state input (tooltip should NOT show) -->
+        <form id="combobox-form">
+            <h2>Form: state as combobox</h2>
+            <fieldset>
+                <label for="cb-firstname">First Name</label>
+                <input id="cb-firstname" type="text" name="firstName" autocomplete="given-name">
+                <label for="cb-lastname">Last Name</label>
+                <input id="cb-lastname" type="text" name="lastName" autocomplete="family-name">
+                <label for="cb-city">City</label>
+                <input id="cb-city" type="text" name="city" autocomplete="address-level2">
+                <label for="cb-state">State</label>
+                <input
+                    id="cb-state"
+                    type="text"
+                    name="state"
+                    autocomplete="address-level1"
+                    role="combobox"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-controls="cb-state-listbox"
+                >
+                <label for="cb-zip">Postal Code</label>
+                <input id="cb-zip" type="text" name="zip" autocomplete="postal-code">
+            </fieldset>
+        </form>
+
+        <!-- Form with plain text state input (tooltip SHOULD show) -->
+        <form id="plain-text-form" style="display: none;">
+            <h2>Form: state as plain text</h2>
+            <fieldset>
+                <label for="pt-firstname">First Name</label>
+                <input id="pt-firstname" type="text" name="firstName" autocomplete="given-name">
+                <label for="pt-lastname">Last Name</label>
+                <input id="pt-lastname" type="text" name="lastName" autocomplete="family-name">
+                <label for="pt-city">City</label>
+                <input id="pt-city" type="text" name="city" autocomplete="address-level2">
+                <label for="pt-state">State</label>
+                <input id="pt-state" type="text" name="state" autocomplete="address-level1">
+                <label for="pt-zip">Postal Code</label>
+                <input id="pt-zip" type="text" name="zip" autocomplete="postal-code">
+            </fieldset>
+        </form>
+
+        <script>
+            const urlParams = new URLSearchParams(window.location.search);
+            const formType = urlParams.get('form-type');
+
+            if (formType === 'plain-text') {
+                document.getElementById('combobox-form').style.display = 'none';
+                document.getElementById('plain-text-form').style.display = 'block';
+            }
+        </script>
+
+    </body>
+
+</html>

--- a/integration-test/tests/email-autofill.macos.spec.js
+++ b/integration-test/tests/email-autofill.macos.spec.js
@@ -8,6 +8,7 @@ import { signupPage } from '../helpers/pages/signupPage.js';
 import { scannerPerf } from '../helpers/pages/scannerPerf.js';
 import { emailAutofillPage } from '../helpers/pages/emailAutofillPage.js';
 import { selectInputPage } from '../helpers/pages/selectInputPage.js';
+import { stateDropdownPage } from '../helpers/pages/stateDropdownPage.js';
 
 /**
  *  Tests for various auto-fill scenarios on macos
@@ -238,6 +239,49 @@ test.describe('macos', () => {
             await selectInput.selectFirstName(identity.firstName, formWithLabel);
             await page.waitForTimeout(100);
             await selectInput.assertSelectedValue(identity.addressCity, formWithLabel);
+        });
+
+        test('with an identity only - should not decorate state input with combobox role', async ({ page }) => {
+            await forwardConsoleMessages(page);
+            const statePage = stateDropdownPage(page);
+
+            await createWebkitMocks().withAvailableInputTypes(createAvailableInputTypes()).withIdentity(identity).applyTo(page);
+
+            await applyScript(page);
+
+            await statePage.navigate('combobox');
+            await page.waitForTimeout(100);
+            // The combobox state input should be classified but NOT decorated
+            await statePage.assertComboboxStateClassified();
+            await statePage.assertComboboxStateNotDecorated();
+        });
+
+        test('with an identity only - should still autofill combobox state input when filling from another field', async ({ page }) => {
+            await forwardConsoleMessages(page);
+            const statePage = stateDropdownPage(page);
+
+            await createWebkitMocks().withAvailableInputTypes(createAvailableInputTypes()).withIdentity(identity).applyTo(page);
+
+            await applyScript(page);
+
+            await statePage.navigate('combobox');
+            await statePage.selectFirstName(identity.firstName);
+            await page.waitForTimeout(100);
+            await statePage.assertStateValue(identity.addressProvince, 'combobox');
+        });
+
+        test('with an identity only - should decorate plain text state input', async ({ page }) => {
+            await forwardConsoleMessages(page);
+            const statePage = stateDropdownPage(page);
+
+            await createWebkitMocks().withAvailableInputTypes(createAvailableInputTypes()).withIdentity(identity).applyTo(page);
+
+            await applyScript(page);
+
+            await statePage.navigate('plain-text');
+            await page.waitForTimeout(100);
+            // The plain text state input should be both classified AND decorated
+            await statePage.assertPlainTextStateDecorated();
         });
 
         test('with an identity + Email Protection, autofill using duck address in identity', async ({ page }) => {

--- a/src/Form/inputTypeConfig.js
+++ b/src/Form/inputTypeConfig.js
@@ -72,6 +72,20 @@ const getIdentitiesAlternateIcon = (input, { device }) => {
 const canBeInteractedWith = (input) => !input.readOnly && !input.disabled;
 
 /**
+ * Checks whether an input element has DOM indicators that it functions as a custom dropdown.
+ * This includes ARIA combobox roles, popup indicators, and native datalist associations.
+ * Used to avoid showing the autofill tooltip on fields that already have their own picker UI.
+ * @param {HTMLInputElement} input
+ * @returns {boolean}
+ */
+const hasDropdownIndicators = (input) => {
+    if (input.getAttribute('role') === 'combobox') return true;
+    if (input.hasAttribute('aria-haspopup')) return true;
+    if (input.list) return true;
+    return false;
+};
+
+/**
  * Checks if the input can be decorated and we have the needed data
  * @param {HTMLInputElement} input
  * @param {import("../DeviceInterface/InterfacePrototype").default} device
@@ -171,6 +185,17 @@ const inputTypeConfig = {
         getIconFilled: getIdentitiesIcon,
         getIconAlternate: getIdentitiesAlternateIcon,
         shouldDecorate: async (input, { device }) => {
+            // Don't show tooltip for state/country inputs that have custom dropdown indicators
+            // (e.g., role="combobox", aria-haspopup, or an associated <datalist>).
+            // These fields have their own picker UI, and our tooltip would cover it.
+            // They will still be autofilled when triggered from another identity field,
+            // because isFieldDecorated checks ATTR_INPUT_TYPE (set regardless of decoration).
+            if (input instanceof HTMLInputElement) {
+                const subtype = getInputSubtype(input);
+                if ((subtype === 'addressProvince' || subtype === 'addressCountryCode') && hasDropdownIndicators(input)) {
+                    return false;
+                }
+            }
             return canBeAutofilled(input, device);
         },
         dataType: 'Identities',


### PR DESCRIPTION
**Reviewer:**  
**Asana:**  https://app.asana.com/1/137249556945/project/1200930669568058/task/1213329977550787?focus=true

## Description

Fixes an issue where the autofill identity tooltip appears on state/province and country input fields that already have their own custom dropdown UI (e.g., Material UI Select, React Select, or other `role="combobox"` components). The tooltip covers the site's own dropdown options, making it difficult for users to select a state.

### Changes

- **`src/Form/inputTypeConfig.js`**: Added a `hasDropdownIndicators()` helper that checks for DOM signals indicating a custom dropdown: `role="combobox"`, `aria-haspopup` attribute, or an associated `<datalist>` via `input.list`. Modified `identities.shouldDecorate` to skip decoration (tooltip + icon) for `addressProvince` and `addressCountryCode` inputs **only when dropdown indicators are detected**.
- **Integration tests**: Added 3 new tests validating the behavior:
  1. Combobox state input is classified but NOT decorated (no tooltip)
  2. Combobox state input IS still autofilled when triggered from another field
  3. Plain text state input IS decorated (tooltip shows normally)

### How it works

- Native `<select>` elements were already handled correctly (no tooltip shown).
- The fix targets `<input>` elements used as custom dropdowns — these are detected via ARIA/DOM attributes.
- Undecorated fields are still autofilled when triggered from another identity field, because `isFieldDecorated` checks `ATTR_INPUT_TYPE` (set by `addInput`), not `ATTR_AUTOFILL` (set during decoration).
- The approach is conservative: plain text state/country inputs without dropdown indicators continue to show the tooltip as before.

## Steps to test

1. Load the test page at `integration-test/pages/state-dropdown.html`
2. Ensure identity autofill data is available (with an address including a state/province)
3. **Form 2 (combobox)**: Click the state field — the autofill tooltip should NOT appear; the custom dropdown should work unobstructed
4. **Form 3 (plain text)**: Click the state field — the autofill tooltip SHOULD appear as normal
5. **Form 2 (combobox)**: Click the first name field, select an identity — verify the state field IS autofilled with the correct value (e.g., "PA")
6. Run integration tests: `npx playwright test --project=macos --grep "state"`

### Submodule branches

| Submodule | Branch |
|-----------|--------|
| `test-pages` | [`cursor/autofill-state-dropdown-conflict-58f9`](https://github.com/duckduckgo/privacy-test-pages/pull/414) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when identity fields are decorated, specifically suppressing the autofill tooltip/icon on state/province and country inputs that look like dropdowns; mis-detection could hide helpful UI on some sites. Added integration tests reduce regression risk and confirm autofill still fills these fields when triggered from other inputs.
> 
> **Overview**
> Prevents the identity autofill tooltip/icon from appearing on `addressProvince` and `addressCountryCode` inputs that already behave like dropdowns (detected via `role="combobox"`, `aria-haspopup`, or an associated `<datalist>`), avoiding conflicts where the tooltip covers the site’s picker UI.
> 
> Adds a new integration test page and Playwright coverage to assert combobox-style state fields are *classified but not decorated*, still get autofilled when another identity field triggers a fill, and plain text state fields continue to be decorated as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1925a2608c370bed9725a205640ec8f955cbc79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->