### PR TITLE
Add Asana PR sync workflow

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                   ASANA_ACCESS_TOKEN: ${{ secrets.NATIVE_APPS_WORKFLOW }}
                   ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}
-                  ASANA_PROJECT_ID: ${{ vars.ASANA_PROJECT_ID }}
+                  ASANA_PROJECT_ID: '1198964220583541'
                   GITHUB_PAT: ${{ secrets.GH_RO_PAT }}
                   USER_MAP: ${{ vars.USER_MAP }}
                   ASSIGN_PR_AUTHOR: 'true'

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -1,0 +1,25 @@
+name: 'asana sync'
+on:
+    pull_request_review:
+    pull_request_target:
+        types:
+            - opened
+            - edited
+            - closed
+            - reopened
+            - synchronize
+            - review_requested
+
+jobs:
+    sync:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: duckduckgo/action-asana-sync@v11
+              with:
+                  ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+                  ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}
+                  ASANA_PROJECT_ID: ${{ vars.ASANA_PROJECT_ID }}
+                  GITHUB_PAT: ${{ secrets.GH_RO_PAT }}
+                  USER_MAP: ${{ vars.USER_MAP }}
+                  ASSIGN_PR_AUTHOR: 'true'

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -17,7 +17,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: duckduckgo/action-asana-sync@v11
               with:
-                  ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+                  ASANA_ACCESS_TOKEN: ${{ secrets.NATIVE_APPS_WORKFLOW }}
                   ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}
                   ASANA_PROJECT_ID: ${{ vars.ASANA_PROJECT_ID }}
                   GITHUB_PAT: ${{ secrets.GH_RO_PAT }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that syncs PR lifecycle events to Asana using duckduckgo/action-asana-sync@v11. This creates Asana tasks when reviewers are assigned, and updates tasks on PR open/close/merge events.

Mirrors the existing workflow in content-scope-scripts and other repos.

Note: Repository variables ASANA_PROJECT_ID and USER_MAP must be configured by repo admins for this workflow to function.

**Reviewer:** 
**Asana:** 

## Description


## Steps to test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `pull_request_target`-triggered workflow that runs with repository secrets, so misconfiguration or unsafe action behavior could expose sensitive tokens. Otherwise it's an isolated CI automation change.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/asana.yml`) that syncs PR lifecycle and review events to Asana via `duckduckgo/action-asana-sync@v11`.
> 
> The workflow triggers on `pull_request_target` PR events and `pull_request_review`, checks out the repo, and uses repository secrets/vars (Asana tokens, workspace/project IDs, `GH_RO_PAT`, `USER_MAP`) to create/update Asana tasks and optionally assign the PR author.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8c1e22d1c99244023d345385a15d41e800c0f55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->