### PR TITLE
Update password-related json files

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -4120,7 +4120,7 @@ Source: "${matchedFrom}"`;
       "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
     "fc2.com": {
-      "password-rules": "minlength: 8; maxlength: 16;"
+      "password-rules": "minlength: 8; maxlength: 16; allowed: upper, lower, digit;"
     },
     "fccaccessonline.com": {
       "password-rules": "minlength: 8; maxlength: 14; max-consecutive: 3; required: lower; required: upper; required: digit; required: [!#$%*^_];"
@@ -4552,7 +4552,7 @@ Source: "${matchedFrom}"`;
       "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [+_%@!$*~];"
     },
     "mysedgwick.com": {
-      "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#%^&+=!]; allowed: [-~_$.,;]"
+      "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#$%^&+=!];"
     },
     "mysubaru.com": {
       "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4116,7 +4116,7 @@ Source: "${matchedFrom}"`;
       "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
     "fc2.com": {
-      "password-rules": "minlength: 8; maxlength: 16;"
+      "password-rules": "minlength: 8; maxlength: 16; allowed: upper, lower, digit;"
     },
     "fccaccessonline.com": {
       "password-rules": "minlength: 8; maxlength: 14; max-consecutive: 3; required: lower; required: upper; required: digit; required: [!#$%*^_];"
@@ -4548,7 +4548,7 @@ Source: "${matchedFrom}"`;
       "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [+_%@!$*~];"
     },
     "mysedgwick.com": {
-      "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#%^&+=!]; allowed: [-~_$.,;]"
+      "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#$%^&+=!];"
     },
     "mysubaru.com": {
       "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/dist/shared-credentials.json
+++ b/dist/shared-credentials.json
@@ -187,6 +187,14 @@
     ]
   },
   {
+    "from": [
+      "bit.ly"
+    ],
+    "to": [
+      "bitly.com"
+    ]
+  },
+  {
     "shared": [
       "candyrect.com",
       "nekochat.cn"
@@ -375,6 +383,29 @@
       "ebay.ph",
       "ebay.pl",
       "ebay.vn"
+    ]
+  },
+  {
+    "from": [
+      "eo.nl",
+      "gld.nl",
+      "kro-ncrv.nl",
+      "l1.nl",
+      "npo.nl",
+      "npoluister.nl",
+      "nporadio5.nl",
+      "omroepwest.nl",
+      "omroepzeeland.nl",
+      "omropfryslan.nl",
+      "oost.nl",
+      "rijnmond.nl",
+      "rtvdrenthe.nl",
+      "rtvnoord.nl",
+      "rtvutrecht.nl",
+      "wnl.tv"
+    ],
+    "to": [
+      "id.npo.nl"
     ]
   },
   {

--- a/packages/password/rules.json
+++ b/packages/password/rules.json
@@ -414,7 +414,7 @@
     "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
   },
   "fc2.com": {
-    "password-rules": "minlength: 8; maxlength: 16;"
+    "password-rules": "minlength: 8; maxlength: 16; allowed: upper, lower, digit;"
   },
   "fccaccessonline.com": {
     "password-rules": "minlength: 8; maxlength: 14; max-consecutive: 3; required: lower; required: upper; required: digit; required: [!#$%*^_];"
@@ -846,7 +846,7 @@
     "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [+_%@!$*~];"
   },
   "mysedgwick.com": {
-    "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#%^&+=!]; allowed: [-~_$.,;]"
+    "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#$%^&+=!];"
   },
   "mysubaru.com": {
     "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/packages/password/shared-credentials.json
+++ b/packages/password/shared-credentials.json
@@ -187,6 +187,14 @@
     ]
   },
   {
+    "from": [
+      "bit.ly"
+    ],
+    "to": [
+      "bitly.com"
+    ]
+  },
+  {
     "shared": [
       "candyrect.com",
       "nekochat.cn"
@@ -375,6 +383,29 @@
       "ebay.ph",
       "ebay.pl",
       "ebay.vn"
+    ]
+  },
+  {
+    "from": [
+      "eo.nl",
+      "gld.nl",
+      "kro-ncrv.nl",
+      "l1.nl",
+      "npo.nl",
+      "npoluister.nl",
+      "nporadio5.nl",
+      "omroepwest.nl",
+      "omroepzeeland.nl",
+      "omropfryslan.nl",
+      "oost.nl",
+      "rijnmond.nl",
+      "rtvdrenthe.nl",
+      "rtvnoord.nl",
+      "rtvutrecht.nl",
+      "wnl.tv"
+    ],
+    "to": [
+      "id.npo.nl"
     ]
   },
   {


### PR DESCRIPTION
Updating password-related json files from remote source, last updated on 2026-06-18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only JSON updates for autofill password rules and domain aliasing; no application logic changes, with minor site-specific impact on generated passwords and credential matching.
> 
> **Overview**
> Syncs **password rules** and **shared-credentials** from the upstream password-manager-resources snapshot (also reflected in `dist/autofill.js` and `dist/autofill-debug.js`).
> 
> **Password rules** tighten site-specific generation: **fc2.com** now restricts characters to upper, lower, and digit (still 8–16 length). **mysedgwick.com** adds `#` to required specials and drops the separate `allowed: [-~_$.,;]` clause so the rule string matches the updated upstream definition.
> 
> **Shared credentials** add two **from → to** mappings so saved logins can follow the canonical login domain: **bit.ly** → **bitly.com**, and a block of Dutch public-broadcast / regional **\*.nl** and **wnl.tv** hosts → **id.npo.nl**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac15123ed29273434f400595091e05a351e0612e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->