### PR TITLE
[SiteSpecificFeature] Support for forced cc form types

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -5302,6 +5302,10 @@ Source: "${matchedFrom}"`;
      * @returns {boolean}
      */
     isCCForm() {
+      const forcedFormType = this.siteSpecificFeature?.getForcedFormType(this.form);
+      if (forcedFormType) {
+        return forcedFormType === "cc";
+      }
       if (this._isCCForm !== void 0) return this._isCCForm;
       const formEl = this.form;
       const ccFieldSelector = this.matching.joinCssSelectors("cc");

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -5298,6 +5298,10 @@ Source: "${matchedFrom}"`;
      * @returns {boolean}
      */
     isCCForm() {
+      const forcedFormType = this.siteSpecificFeature?.getForcedFormType(this.form);
+      if (forcedFormType) {
+        return forcedFormType === "cc";
+      }
       if (this._isCCForm !== void 0) return this._isCCForm;
       const formEl = this.form;
       const ccFieldSelector = this.matching.joinCssSelectors("cc");

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -731,6 +731,35 @@ describe('site specific fixes', () => {
             expect(form?.isLogin).toBeFalsy();
             expect(form?.isSignup).toBeTruthy();
         });
+        test('when a forced form (cc) type is present in the config', () => {
+            // Given a form whose card fields have no identifying attributes (labels are
+            // only associated by proximity), so it would not be detected as a CC form
+            const formEl = attachAndReturnGenericForm(`
+            <form id="checkout">
+                <div class="field">
+                    <label>Card Number</label>
+                    <div class="control"><input id="cc-number-input" type="text" /></div>
+                </div>
+                <div class="field">
+                    <label>Expiration (MM/YY)</label>
+                    <div class="control"><input id="cc-exp-input" type="text" /></div>
+                </div>
+                <button type="submit">Add</button>
+            </form>`);
+
+            const deviceInterface = InterfacePrototype.default();
+            // And a config that forces the form to be a credit card form
+            setMockSiteSpecificFixes(deviceInterface, 'force-cc');
+            const scanner = createScanner(deviceInterface).findEligibleInputs(document);
+            const form = scanner.forms.get(formEl);
+            // Then the form is treated as a credit card form, and not as login/signup
+            expect(form?.isCCForm).toBeTruthy();
+            expect(form?.isLogin).toBeFalsy();
+            expect(form?.isSignup).toBeFalsy();
+            // And the fields are categorized as credit card inputs
+            const cardNumberInput = /** @type {HTMLInputElement} */ (document.getElementById('cc-number-input'));
+            expect(cardNumberInput.getAttribute(constants.ATTR_INPUT_TYPE)).toBe('creditCards.cardNumber');
+        });
     });
 
     describe('Force input type', () => {

--- a/src/Form/FormAnalyzer.js
+++ b/src/Form/FormAnalyzer.js
@@ -408,6 +408,13 @@ class FormAnalyzer {
      * @returns {boolean}
      */
     isCCForm() {
+        // A site-specific config can force the form type. When present it takes
+        // precedence over inference, mirroring isLogin/isSignup/isHybrid.
+        const forcedFormType = this.siteSpecificFeature?.getForcedFormType(this.form);
+        if (forcedFormType) {
+            return forcedFormType === 'cc';
+        }
+
         if (this._isCCForm !== undefined) return this._isCCForm;
 
         const formEl = this.form;

--- a/src/testConfig/siteSpecificFixes/force-cc.json
+++ b/src/testConfig/siteSpecificFixes/force-cc.json
@@ -1,0 +1,29 @@
+{
+    "siteSpecificFixes": {
+        "state": "enabled",
+        "anyOtherSettingForNative": "anyValue",
+        "settings": {
+            "domains": [
+                {
+                    "domain": [
+                        "localhost"
+                    ],
+                    "patchSettings": [
+                        {
+                            "path": "",
+                            "op": "add",
+                            "value": {
+                                "formTypeSettings": [
+                                    {
+                                        "selector": "form[id*=\"checkout\"]",
+                                        "type": "cc"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
**Reviewer:** @GioSensation 
**Asana:**  https://app.asana.com/1/137249556945/project/1200930669568058/task/1214787241405867?focus=true

## Description
Add support for forcing `cc` fields in site-specific-feature, currently it only supports `login` and `signup`.

## Steps to test


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how forms are classified for credit card autofill on configured sites; scope is small and follows an existing override pattern, but misconfigured selectors could misclassify forms.
> 
> **Overview**
> Site-specific **`formTypeSettings`** can now force a form to be treated as a **credit card** form (`type: "cc"`), not only login, signup, or hybrid.
> 
> **`FormAnalyzer.isCCForm()`** checks **`getForcedFormType`** first and returns true when the forced type is `cc`, skipping heuristic CC detection—the same precedence pattern as **`isLogin`** / **`isSignup`**. That lets checkout UIs with weak field markup still get CC autofill and field typing.
> 
> A **`force-cc`** test fixture and a **`Form.test.js`** case cover a checkout form that would not infer as CC without the override. Built **`autofill.js`** / **`autofill-debug.js`** bundles include the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533e83fb8b19a395e35e8a863c6ad7780831d90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->