### PR TITLE
Disable automatic Asana sync workflow

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -1,14 +1,18 @@
 name: 'asana sync'
+# NOTE: Automatic Asana sync is disabled. The workflow only runs when triggered
+# manually via the Actions tab. To re-enable, restore the commented triggers below
+# and remove `workflow_dispatch`.
 on:
-    pull_request_review:
-    pull_request_target:
-        types:
-            - opened
-            - edited
-            - closed
-            - reopened
-            - synchronize
-            - review_requested
+    workflow_dispatch:
+    # pull_request_review:
+    # pull_request_target:
+    #     types:
+    #         - opened
+    #         - edited
+    #         - closed
+    #         - reopened
+    #         - synchronize
+    #         - review_requested
 
 jobs:
     sync:


### PR DESCRIPTION
Neutralizes the PR-triggered Asana sync so it no longer runs on pull_request_target / pull_request_review events (which have been failing with an Asana API 'Invalid Request'). The workflow is kept in place and can still be run manually via workflow_dispatch; the original triggers are preserved as comments for easy re-enable.

**Reviewer:** 
**Asana:** 

## Description


## Steps to test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger-only change; no app code or secret handling changes beyond stopping noisy failed runs.
> 
> **Overview**
> Stops the **asana sync** workflow from running on every pull request and review, which had been failing with Asana API invalid-request errors.
> 
> The `on` block now only includes **`workflow_dispatch`**, so sync can still be run manually from the Actions tab. The previous **`pull_request_target`** and **`pull_request_review`** triggers are left commented in the file, with a short note at the top on how to turn automatic sync back on. The sync job steps and secrets are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c1c19a4c608a7fcb576511dbf484ce1c4ee739f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->