### PR TITLE
Update password-related json files

### DIFF
--- a/dist/autofill-debug.js
+++ b/dist/autofill-debug.js
@@ -4185,6 +4185,9 @@ Source: "${matchedFrom}"`;
     "hawaiianairlines.com": {
       "password-rules": "maxlength: 16;"
     },
+    "hdfc.bank.in": {
+      "password-rules": "minlength: 8; maxlength: 15; required: digit; required: upper, lower; allowed: [@&:|.^~#_$!)?];"
+    },
     "hertz-japan.com": {
       "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower; required: upper; required: digit; required: [#$%^&!@];"
     },
@@ -4559,6 +4562,9 @@ Source: "${matchedFrom}"`;
     },
     "mysedgwick.com": {
       "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#$%^&+=!];"
+    },
+    "mysmartmove.com": {
+      "password-rules": "minlength: 9; maxlength: 15; allowed: lower; required: upper; required: [!@#$%^&*()];"
     },
     "mysubaru.com": {
       "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/dist/autofill.js
+++ b/dist/autofill.js
@@ -4181,6 +4181,9 @@ Source: "${matchedFrom}"`;
     "hawaiianairlines.com": {
       "password-rules": "maxlength: 16;"
     },
+    "hdfc.bank.in": {
+      "password-rules": "minlength: 8; maxlength: 15; required: digit; required: upper, lower; allowed: [@&:|.^~#_$!)?];"
+    },
     "hertz-japan.com": {
       "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower; required: upper; required: digit; required: [#$%^&!@];"
     },
@@ -4555,6 +4558,9 @@ Source: "${matchedFrom}"`;
     },
     "mysedgwick.com": {
       "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#$%^&+=!];"
+    },
+    "mysmartmove.com": {
+      "password-rules": "minlength: 9; maxlength: 15; allowed: lower; required: upper; required: [!@#$%^&*()];"
     },
     "mysubaru.com": {
       "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"

--- a/packages/password/rules.json
+++ b/packages/password/rules.json
@@ -479,6 +479,9 @@
   "hawaiianairlines.com": {
     "password-rules": "maxlength: 16;"
   },
+  "hdfc.bank.in": {
+    "password-rules": "minlength: 8; maxlength: 15; required: digit; required: upper, lower; allowed: [@&:|.^~#_$!)?];"
+  },
   "hertz-japan.com": {
     "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower; required: upper; required: digit; required: [#$%^&!@];"
   },
@@ -853,6 +856,9 @@
   },
   "mysedgwick.com": {
     "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#$%^&+=!];"
+  },
+  "mysmartmove.com": {
+    "password-rules": "minlength: 9; maxlength: 15; allowed: lower; required: upper; required: [!@#$%^&*()];"
   },
   "mysubaru.com": {
     "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"


### PR DESCRIPTION
Updating password-related json files from remote source, last updated on 2026-07-10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only additions to the domain rules map with no application logic changes; incorrect rules could only affect generated passwords for those two hosts.
> 
> **Overview**
> Syncs the password-rules snapshot with the remote Apple password-manager-resources data by **adding two domain entries** and propagating them into the bundled autofill artifacts.
> 
> **`hdfc.bank.in`** gets rules for 8–15 characters with required digits and mixed case, plus an allowed special-character set. **`mysmartmove.com`** gets 9–15 characters with optional lowercase, required uppercase, and required characters from `!@#$%^&*()`.
> 
> The same additions appear in `packages/password/rules.json`, `dist/autofill.js`, and `dist/autofill-debug.js`; no password-generation logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc7306a17d9ed7f5dca840cef18a32e8e3428df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->